### PR TITLE
Markdown bug fix, linkbox activate shortcut

### DIFF
--- a/client/components/calendar/classic/indicator/CalendarTileIndicator.svelte
+++ b/client/components/calendar/classic/indicator/CalendarTileIndicator.svelte
@@ -120,7 +120,7 @@
 {#if type === CalendarTileIndicatorDisplayType.METRICS}
   <div
     class={cn(
-      "flex flex-col items-start justify-center text-b3 2k:text-b2 w-full h-full",
+      "flex flex-col items-start justify-center text-b3 w-full h-full",
       {
         "text-fgs3": !isActive,
         "gap-1": isActive

--- a/client/components/calendar/classic/indicator/MonthTileIndicator.svelte
+++ b/client/components/calendar/classic/indicator/MonthTileIndicator.svelte
@@ -18,13 +18,10 @@
 </script>
 
 <div
-  class={cn(
-    "grid grid-rows-[1fr_auto] text-b3 2k:text-b2 gap-1 w-full h-full",
-    {
-      "text-aps1": isActive,
-      "text-fgs3 group-hover:text-fgs2": !isActive
-    }
-  )}
+  class={cn("grid grid-rows-[1fr_auto] text-b3 gap-1 w-full h-full", {
+    "text-aps1": isActive,
+    "text-fgs3 group-hover:text-fgs2": !isActive
+  })}
 >
   {#if data.tasks.length > 0 || data.focusSummary.focus > 0}
     <div class="flex flex-col items-start">

--- a/client/components/commandBar/CommandBar.svelte
+++ b/client/components/commandBar/CommandBar.svelte
@@ -155,7 +155,11 @@
               key: "Space",
               os: $context.os
             })} -->
-            <ShortcutText shortcut={Action.CMD} parentBgIndex={1} />
+            <ShortcutText
+              shortcut={Action.CMD}
+              parentBgIndex={1}
+              isAlwaysShown={true}
+            />
           {:else if isFullPageContext && isFocusing}
             Press <b>Esc</b> to close
           {:else}
@@ -198,7 +202,11 @@
       )}
     >
       <span> Press <b>Esc</b> to close </span>
-      <ShortcutText shortcut={Action.CMD} parentBgIndex={1} />
+      <ShortcutText
+        shortcut={Action.CMD}
+        parentBgIndex={1}
+        isAlwaysShown={true}
+      />
     </div>
   {/if}
 </div>

--- a/client/components/commandBar/CommandModePage.svelte
+++ b/client/components/commandBar/CommandModePage.svelte
@@ -112,7 +112,11 @@
       <div class="flex flex-col items-center gap-4">
         <span class="flex flex-row text-fgs3 gap-1">
           Press
-          <ShortcutText shortcut={Action.GLOBAL_SEARCH} parentBgIndex={2} />
+          <ShortcutText
+            shortcut={Action.GLOBAL_SEARCH}
+            parentBgIndex={2}
+            isAlwaysShown={true}
+          />
           to search
         </span>
         <Button

--- a/client/components/flux/flux.ts
+++ b/client/components/flux/flux.ts
@@ -155,7 +155,7 @@ class Flux {
     kvRecords?: string[];
     resources?: Resource[];
   }) {
-    logger.info({ at: "flux.loadInMemoryStores", params });
+    logger.log({ at: "flux.loadInMemoryStores", params });
     try {
       let kvStores = this.stores.filter(
         (x) => x.dataType === StoreDataType.KVO
@@ -240,7 +240,7 @@ class Flux {
    * @returns
    */
   async seed() {
-    logger.info({ at: "flux.seed" });
+    logger.log({ at: "flux.seed" });
     try {
     } catch (e) {
       logger.error({ at: "flux.seed", error: e });
@@ -257,7 +257,7 @@ class Flux {
     additionalParams: IMutationAdditionalParams = {}
   ) {
     let response;
-    logger.info({
+    logger.log({
       at: "flux.mutation",
       resource,
       params: {
@@ -312,7 +312,7 @@ class Flux {
       });
       throw e;
     }
-    logger.info({
+    logger.log({
       at: "flux.mutation - result",
       resource,
       action: params.action,
@@ -515,7 +515,7 @@ class Flux {
       ...data,
       id: `kv:${storeId}`
     };
-    logger.info({ at: "kvMerge", storeId, record });
+    logger.log({ at: "kvMerge", storeId, record });
     const result = await this.persistence.mutation(Resource.kv, {
       record,
       action: PersistenceActionType.MERGE
@@ -857,7 +857,7 @@ class Flux {
     response: any,
     params?: { isInitialSyncdown?: boolean; src?: string }
   ) {
-    logger.info({ at: "flux.processSyncDown", ...params });
+    logger.log({ at: "flux.processSyncDown", ...params });
     if (!response) {
       return;
     }

--- a/client/components/library/LibrarySearchBox.svelte
+++ b/client/components/library/LibrarySearchBox.svelte
@@ -14,7 +14,6 @@
   import type { IEvent } from "$lib/client/types/event.type";
   import { appEvents } from "$lib/client/stores/notification.store";
   import { GlobalEvent } from "$lib/client/types/event.enum";
-  import { uiStateDerived } from "$lib/client/stores/uiState/uiState.store";
   import ShortcutText from "$lib/client/elements/text/ShortcutText.svelte";
   const dispatch = createEventDispatcher();
   export let resource: Resource;
@@ -62,14 +61,12 @@
       placeholder={"Search " + resource + "s"}
     />
     <div class="flex items-center gap-2">
-      {#if $uiStateDerived.isShowHotKeyHints}
-        <span>
-          <ShortcutText
-            shortcut={GlobalEvent.ACTIVATE_SEARCH_BOX}
-            parentBgIndex={0}
-          />
-        </span>
-      {/if}
+      <span>
+        <ShortcutText
+          shortcut={GlobalEvent.ACTIVATE_SEARCH_BOX}
+          parentBgIndex={0}
+        />
+      </span>
       {#if dev_enableSemanticSearch && $userPreferences.localAI.semanticSearch && (selectedSubType === "nodular_markdown" || selectedSubType === "all")}
         <SwitchInput
           label={{ label: "Semantic", orientation: Orientation.Horizontal }}

--- a/client/components/markdown/Markdown.svelte
+++ b/client/components/markdown/Markdown.svelte
@@ -320,9 +320,12 @@
   }
 </script>
 
-<button
+<div
   id="markDown-{mdId}"
   class="relative flex flex-col justify-start items-start text-start w-full h-full"
+  aria-label="Markdown editor"
+  role="textbox"
+  tabindex="-1"
   on:keydown={onKeyDown}
   use:resizeListener={(e) => {
     containerWidth = e.width;
@@ -462,7 +465,7 @@
       />
     {/if}
   </div>
-</button>
+</div>
 {#if $multiSelectStore.length > 0}
   <BottomFloat zIndex="z-30" {containerId}>
     <BulkEditBar

--- a/client/components/markdown/contextMenu/LeftControls.svelte
+++ b/client/components/markdown/contextMenu/LeftControls.svelte
@@ -426,6 +426,7 @@
       direction: Placement.Bottom,
       delay: 500
     }}
+    tabindex="-1"
   >
     {#if isNodularizable && (isBlockHovering || isDebugLeftControls || isPopoverVisible || isHovering || isFocusing)}
       <FocusRing on:click={onNodularize} />

--- a/client/components/shortcuts/ComponentShortcutListener.svelte
+++ b/client/components/shortcuts/ComponentShortcutListener.svelte
@@ -2,6 +2,7 @@
   import { isTextElement } from "$lib/client/utils/browser.utils";
   import type { IKeyboardShortcut } from "./shortcut.type";
   import { keyboardShortcuts } from "./shortcuts.store";
+  export let isAllowFromTextInput: boolean = false;
   export let shortcuts: {
     shortcut: string | IKeyboardShortcut;
     callback: () => void;
@@ -9,7 +10,7 @@
 
   function shortcutListener(event: KeyboardEvent) {
     const isTextInputSource = isTextElement(event.target);
-    if (isTextInputSource) return;
+    if (isTextInputSource && !isAllowFromTextInput) return;
     const result = shortcuts.find((s) =>
       keyboardShortcuts.checkShortcut(event, s.shortcut)
     );

--- a/client/components/shortcuts/ShortcutRunner.svelte
+++ b/client/components/shortcuts/ShortcutRunner.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { appStore } from "$lib/client/stores/app.store";
-  import { isTextElement } from "$lib/client/utils/browser.utils";
+  import {
+    hasActivePopovers,
+    isTextElement
+  } from "$lib/client/utils/browser.utils";
   import { keyboardShortcuts } from "./shortcuts.store";
   import { appEvents } from "$lib/client/stores/notification.store";
   import { GlobalEvent } from "$lib/client/types/event.enum";
@@ -33,9 +36,11 @@
   const shortcutListener = (event: KeyboardEvent) => {
     if ($context.embed === Embed.HANDSET) return;
     const target = event.target || event.srcElement;
+    const isPopoverActive = hasActivePopovers();
     const isTextInputSource = isTextElement(target);
     const isSystemShortcut = checkIfSystemShortcut(event);
     if (isSystemShortcut) {
+      if (isPopoverActive && event.key === KeyboardKey.ESCAPE) return;
       appEvents.publish(event.key.toString() as GlobalEvent, event);
       return;
     }

--- a/client/components/shortcuts/shortcuts.config.ts
+++ b/client/components/shortcuts/shortcuts.config.ts
@@ -42,6 +42,10 @@ export const shortcutsConfig: Record<string, IKeyboardShortcut> = {
     key: "Space",
     code: "Space"
   },
+  ACTIVATE_LINK_BOX: {
+    key: "l",
+    modifiers: [ModifierKey.META]
+  },
   TOGGLE_FOCUS_SESSION: {
     key: "Space",
     code: "Space",

--- a/client/components/tasks/CreateTask.svelte
+++ b/client/components/tasks/CreateTask.svelte
@@ -150,6 +150,7 @@
         <span>Press</span>
         <ShortcutText
           parentBgIndex={1}
+          isAlwaysShown={true}
           shortcut={{
             key: "Enter",
             modifiers: [ModifierKey.SHIFT]

--- a/client/elements/InlineSearchBar.svelte
+++ b/client/elements/InlineSearchBar.svelte
@@ -3,7 +3,6 @@
   import TextInput from "./input/TextInput.svelte";
   import { Size } from "$lib/client/types/size.enum";
   import { createEventDispatcher, onMount, tick } from "svelte";
-  import { uiStateDerived } from "../stores/uiState/uiState.store";
   import ShortcutText from "./text/ShortcutText.svelte";
   import { GlobalEvent } from "../types/event.enum";
   import { appEvents } from "../stores/notification.store";
@@ -85,14 +84,12 @@
     on:enter
   >
     <slot>
-      {#if $uiStateDerived.isShowHotKeyHints}
-        <span>
-          <ShortcutText
-            shortcut={GlobalEvent.ACTIVATE_SEARCH_BOX}
-            {parentBgIndex}
-          />
-        </span>
-      {/if}
+      <span>
+        <ShortcutText
+          shortcut={GlobalEvent.ACTIVATE_SEARCH_BOX}
+          {parentBgIndex}
+        />
+      </span>
     </slot>
   </TextInput>
 </div>

--- a/client/elements/button/Button.svelte
+++ b/client/elements/button/Button.svelte
@@ -6,12 +6,9 @@
   import { Placement } from "$lib/client/types/direction.enum";
   import { bg, cn } from "$lib/client/utils/ui.utils";
   import type { IPopoverRenderBaseParams } from "$lib/client/types/popover.type";
-  import context from "$lib/client/stores/context.store";
-  import { Embed } from "$lib/client/types/context.type";
   import Badge from "../text/Badge.svelte";
   import { hoverable } from "$lib/client/actions/hover.action";
   import { popover } from "$lib/client/actions/popover.action";
-  import { uiStateDerived } from "$lib/client/stores/uiState/uiState.store";
   import ShortcutText from "../text/ShortcutText.svelte";
   import type { IKeyboardShortcut } from "$lib/client/components/shortcuts/shortcut.type";
   import { PopoverTriggerMethod } from "$lib/client/types/popover.type";
@@ -176,19 +173,17 @@
       <div class="min-w-fit whitespace-nowrap">
         {label}
       </div>
-      {#if $uiStateDerived?.isShowHotKeyHints && shortcut && $context.embed !== Embed.HANDSET}
-        <ShortcutText
-          {shortcut}
-          {size}
-          parentBgIndex={style === ButtonStyle.PLAIN
-            ? parentBgIndex
-            : style === ButtonStyle.OUTLINED && type !== ButtonVariant.PRIMARY
-              ? parentBgIndex + 1
-              : undefined}
-          isAccentOutlined={style === ButtonStyle.OUTLINED &&
-            type === ButtonVariant.PRIMARY}
-        />
-      {/if}
+      <ShortcutText
+        {shortcut}
+        {size}
+        parentBgIndex={style === ButtonStyle.PLAIN
+          ? parentBgIndex
+          : style === ButtonStyle.OUTLINED && type !== ButtonVariant.PRIMARY
+            ? parentBgIndex + 1
+            : undefined}
+        isAccentOutlined={style === ButtonStyle.OUTLINED &&
+          type === ButtonVariant.PRIMARY}
+      />
       {#if badge}
         <Badge text={badge} />
       {/if}

--- a/client/elements/button/ButtonTooltip.svelte
+++ b/client/elements/button/ButtonTooltip.svelte
@@ -2,9 +2,6 @@
   import { Size } from "$lib/client/types/size.enum";
   import ShortcutText from "../text/ShortcutText.svelte";
   import type { IKeyboardShortcut } from "$lib/client/components/shortcuts/shortcut.type";
-  import { uiStateDerived } from "$lib/client/stores/uiState/uiState.store";
-  import context from "$lib/client/stores/context.store";
-  import { Embed } from "$lib/client/types/context.type";
   import { fade } from "svelte/transition";
 
   export let tooltip: string;
@@ -20,7 +17,7 @@
   <div class="whitespace-nowrap">
     {tooltip}
   </div>
-  {#if $uiStateDerived?.isShowHotKeyHints && shortcut && $context.embed !== Embed.HANDSET}
+  {#if shortcut}
     <div class="border border-brs3 rounded-md">
       <ShortcutText {shortcut} {size} {parentBgIndex} isPlainText={true} />
     </div>

--- a/client/elements/text/ShortcutText.svelte
+++ b/client/elements/text/ShortcutText.svelte
@@ -9,11 +9,15 @@
   import Icon from "../Icon.svelte";
   import type { IKeyboardShortcut } from "$lib/client/components/shortcuts/shortcut.type";
   import { KeyboardKey } from "$lib/client/types/keyboard.type";
-  export let shortcut: string | IKeyboardShortcut;
+  import { Embed } from "$lib/client/types/context.type";
+  import { uiStateDerived } from "$lib/client/stores/uiState/uiState.store";
+
+  export let shortcut: string | IKeyboardShortcut | undefined;
   export let parentBgIndex: number | undefined = undefined;
   export let isPlainText: boolean = false;
   export let isAccentOutlined: boolean = false;
   export let size: Size.xs | Size.sm | Size.md | Size.lg = Size.md;
+  export let isAlwaysShown: boolean = false;
   let detail: IKeyboardShortcut | undefined = undefined;
 
   $: text = resolveText(shortcut);
@@ -44,34 +48,38 @@
   });
 </script>
 
-<span
-  class={cn(
-    "flex justify-center items-center whitespace-nowrap rounded-md",
-    {
-      border: !isPlainText,
-      "border-ccs2": isAccentOutlined,
-      "px-1.5 py-[1px] text-b4": size === Size.md || size === Size.lg,
-      "px-1 py-[0.5px] text-b5": size === Size.xs || size === Size.sm
-    },
-    !isPlainText &&
-      !isAccentOutlined && {
-        [bg(parentBgIndex)]: parentBgIndex !== undefined,
-        "text-fgs3 border-brs3": parentBgIndex !== undefined,
-        "border-abg": parentBgIndex === undefined
-      }
-  )}
->
-  {text?.replace("ENTER", "") ?? ""}
-  {#if detail?.key === KeyboardKey.ENTER}
-    &nbsp;
-    <Icon
-      icon="arrow-turn-down-left"
-      size={Size.xs}
-      class={cn({
-        "stroke-fgs3": parentBgIndex !== undefined,
-        "fill-abg stroke-abg": parentBgIndex === undefined && !isAccentOutlined,
-        "fill-aps1 stroke-aps1": parentBgIndex === undefined && isAccentOutlined
-      })}
-    />
-  {/if}
-</span>
+{#if ($uiStateDerived?.isShowHotKeyHints || isAlwaysShown) && shortcut && $context.embed !== Embed.HANDSET}
+  <span
+    class={cn(
+      "flex justify-center items-center whitespace-nowrap rounded-md",
+      {
+        border: !isPlainText,
+        "border-ccs2": isAccentOutlined,
+        "px-1.5 py-[1px] text-b4": size === Size.md || size === Size.lg,
+        "px-1 py-[0.5px] text-b5": size === Size.xs || size === Size.sm
+      },
+      !isPlainText &&
+        !isAccentOutlined && {
+          [bg(parentBgIndex)]: parentBgIndex !== undefined,
+          "text-fgs3 border-brs3": parentBgIndex !== undefined,
+          "border-abg": parentBgIndex === undefined
+        }
+    )}
+  >
+    {text?.replace("ENTER", "") ?? ""}
+    {#if detail?.key === KeyboardKey.ENTER}
+      &nbsp;
+      <Icon
+        icon="arrow-turn-down-left"
+        size={Size.xs}
+        class={cn({
+          "stroke-fgs3": parentBgIndex !== undefined,
+          "fill-abg stroke-abg":
+            parentBgIndex === undefined && !isAccentOutlined,
+          "fill-aps1 stroke-aps1":
+            parentBgIndex === undefined && isAccentOutlined
+        })}
+      />
+    {/if}
+  </span>
+{/if}

--- a/client/elements/text/Tag.svelte
+++ b/client/elements/text/Tag.svelte
@@ -11,6 +11,8 @@
   import type { IRecordId } from "$lib/client/types/data.type";
   import { Placement } from "$lib/client/types/direction.enum";
   import context from "$lib/client/stores/context.store";
+  import type { IKeyboardShortcut } from "$lib/client/components/shortcuts/shortcut.type";
+  import ShortcutText from "./ShortcutText.svelte";
   const dispatch = createEventDispatcher();
   export let label: string;
   export let parentBgIndex: number = 1;
@@ -19,6 +21,7 @@
   export let isRemovable = true;
   export let isActive = false;
   export let count: number | undefined = undefined;
+  export let shortcut: string | IKeyboardShortcut | undefined = undefined;
   export let id: IRecordId | undefined = undefined;
   export let isShowExpandFeedbackOnActive = false;
   export let expandFeedbackPosition:
@@ -60,6 +63,9 @@
     {label ? truncateString(label, 24) : ""}
     {#if count !== undefined}
       <Badge text={count} size={size === Size.sm ? Size.xs : Size.sm} />
+    {/if}
+    {#if shortcut}
+      <ShortcutText {shortcut} {size} {parentBgIndex} />
     {/if}
     {#if isRemoveIconRenderedInline}
       <button

--- a/client/elements/toggle/Toggle.svelte
+++ b/client/elements/toggle/Toggle.svelte
@@ -9,6 +9,8 @@
   import { hoverable } from "$lib/client/actions/hover.action";
   import { tooltip as tooltipAction } from "$lib/client/actions/popover.action";
   import { Placement } from "$lib/client/types/direction.enum";
+  import type { IKeyboardShortcut } from "$lib/client/components/shortcuts/shortcut.type";
+  import ShortcutText from "../text/ShortcutText.svelte";
   const dispatch = createEventDispatcher();
   export let icon: string;
   export let on: boolean = false;
@@ -19,6 +21,7 @@
   export let isPreventFillOnActive: boolean = false;
   export let count: number | undefined = undefined;
   export let bgSize: Size.sm | Size.md | Size.lg = Size.md;
+  export let shortcut: string | IKeyboardShortcut | undefined = undefined;
   let isHovering: boolean = false;
   function onclick() {
     on = !on;
@@ -59,5 +62,8 @@
     <div class="absolute bottom-1 right-1">
       <Badge text={count} size={Size.sm} />
     </div>
+  {/if}
+  {#if shortcut}
+    <ShortcutText {shortcut} {size} {parentBgIndex} />
   {/if}
 </button>

--- a/client/layout/layers/UserBaseLayer.svelte
+++ b/client/layout/layers/UserBaseLayer.svelte
@@ -525,7 +525,12 @@
         }
       }
     } catch (e) {
-      logger.error({ at: "handleMessageFromParent", error: e, event });
+      logger.error({
+        at: "handleMessageFromParent",
+        error: e,
+        eventType: event?.data?.type,
+        origin: event?.origin
+      });
     }
   }
 

--- a/client/layout/layers/UserBaseLayer.svelte
+++ b/client/layout/layers/UserBaseLayer.svelte
@@ -260,7 +260,7 @@
         });
       }
     }
-    logger.info({
+    logger.log({
       at: "performAppUpdateCheck",
       versionOnClient,
       latestVersion,
@@ -525,7 +525,7 @@
         }
       }
     } catch (e) {
-      logger.error({ at: "handleMessageFromParent", error: e });
+      logger.error({ at: "handleMessageFromParent", error: e, event });
     }
   }
 

--- a/client/layout/leftPanel/LeftNav.svelte
+++ b/client/layout/leftPanel/LeftNav.svelte
@@ -46,6 +46,7 @@
                 <ShortcutText
                   shortcut={Action.GLOBAL_SEARCH}
                   parentBgIndex={2}
+                  isAlwaysShown={true}
                 />
               </button>
             </div>

--- a/client/layout/leftPanel/LeftNavCommandAction.svelte
+++ b/client/layout/leftPanel/LeftNavCommandAction.svelte
@@ -22,7 +22,11 @@
         class="text-fgs2 px-1 py-[1px] rounded-md border border-brs3 hover:bg-bgs3"
         on:click={() => appStore.runAction(Action.CMD)}
       >
-        <ShortcutText shortcut={Action.CMD} isPlainText={true} />
+        <ShortcutText
+          shortcut={Action.CMD}
+          isPlainText={true}
+          isAlwaysShown={true}
+        />
       </button> for cmd bar
     </div>
   {/if}

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -88,7 +88,11 @@
           on:click={() => appStore.runAction(Action.GLOBAL_SEARCH)}
         >
           <span>Search</span>
-          <ShortcutText shortcut={Action.GLOBAL_SEARCH} parentBgIndex={2} />
+          <ShortcutText
+            shortcut={Action.GLOBAL_SEARCH}
+            parentBgIndex={2}
+            isAlwaysShown={true}
+          />
         </button>
       </div>
     {/if}

--- a/client/persistence/dexie/dexie.local.ts
+++ b/client/persistence/dexie/dexie.local.ts
@@ -244,18 +244,28 @@ export class DexiePersistence implements IPersistence {
           return Promise.reject(new Error("Record id is required for merge"));
         }
         if (this.searchIndices.has(resource)) {
-          const searchIndex = this.searchIndices.get(resource);
-          if (searchIndex) {
-            const text = this.extractFlatText(params.record, resource);
-            if (params.record.id && text) {
-              try {
-                searchIndex.index.updateAsync(params.record.id, text);
-                searchIndex.contextualIndex.updateAsync(params.record.id, text);
-              } catch (error) {
-                searchIndex.index.addAsync(params.record.id, text);
-                searchIndex.contextualIndex.addAsync(params.record.id, text);
+          try {
+            const searchIndex = this.searchIndices.get(resource);
+            if (searchIndex) {
+              const text = this.extractFlatText(params.record, resource);
+              if (params.record.id && text) {
+                try {
+                  searchIndex.index.updateAsync(params.record.id, text);
+                  searchIndex.contextualIndex.updateAsync(
+                    params.record.id,
+                    text
+                  );
+                } catch (error) {
+                  searchIndex.index.addAsync(params.record.id, text);
+                  searchIndex.contextualIndex.addAsync(params.record.id, text);
+                }
               }
             }
+          } catch (error) {
+            logger.error({
+              at: "DexiePersistence.mutation merge - searchIndex update error",
+              error
+            });
           }
         }
         return this.merge(resource, params.record.id, params.record);

--- a/client/persistence/dexie/dexie.local.ts
+++ b/client/persistence/dexie/dexie.local.ts
@@ -264,6 +264,7 @@ export class DexiePersistence implements IPersistence {
           } catch (error) {
             logger.error({
               at: "DexiePersistence.mutation merge - searchIndex update error",
+              id: params.record.id,
               error
             });
           }

--- a/client/products/memotron/audio/AudioContent.svelte
+++ b/client/products/memotron/audio/AudioContent.svelte
@@ -84,7 +84,7 @@
       ) {
         jobId = result.jobId as string;
       }
-      logger.info({
+      logger.log({
         at: "AudioContent.svelte - initiateTranscription",
         result,
         jobId

--- a/client/products/memotron/capture/Capture.svelte
+++ b/client/products/memotron/capture/Capture.svelte
@@ -36,6 +36,7 @@
   import CaptureTopBar from "./CaptureTopBar.svelte";
   import { fly } from "svelte/transition";
   import { Placement } from "$lib/client/types/direction.enum";
+  import ComponentShortcutListener from "$lib/client/components/shortcuts/ComponentShortcutListener.svelte";
   export let captureId: IRecordId = generateResourceId(Resource.capture);
   export let isWindowDnD = false;
   const captureContext = {
@@ -47,7 +48,7 @@
   isInEditMode.set(true);
   let writerRef: Writer | undefined = undefined;
   let subs: any[] = [];
-
+  let captureTopBarRef: CaptureTopBar | undefined = undefined;
   onMount(async () => {
     const appEventSub = appEvents.subscribe(async (x: IEvent) => {
       if (x.event === GlobalEvent.ENTER && x.value.metaKey === true) {
@@ -118,6 +119,7 @@
       <div class="w-full max-w-5xl h-full flex flex-col p-4 bg-bgs1">
         {#if !$captureStore.isSaving}
           <CaptureTopBar
+            bind:this={captureTopBarRef}
             {captureStore}
             on:focusBody={() => writerRef?.focus()}
             on:clear={reset}
@@ -206,3 +208,14 @@
 {/if}
 
 <ComponentBaseLayer hasDragAndDrop={!isWindowDnD} />
+<ComponentShortcutListener
+  isAllowFromTextInput={true}
+  shortcuts={[
+    {
+      shortcut: { key: "l", modifiers: [ModifierKey.META, ModifierKey.SHIFT] },
+      callback: () => {
+        captureTopBarRef?.toggleLinkBox();
+      }
+    }
+  ]}
+/>

--- a/client/products/memotron/capture/Capture.svelte
+++ b/client/products/memotron/capture/Capture.svelte
@@ -37,11 +37,13 @@
   import { fly } from "svelte/transition";
   import { Placement } from "$lib/client/types/direction.enum";
   import ComponentShortcutListener from "$lib/client/components/shortcuts/ComponentShortcutListener.svelte";
+  import { MemotronAction } from "../memotronAction.enum";
   export let captureId: IRecordId = generateResourceId(Resource.capture);
   export let isWindowDnD = false;
   const captureContext = {
     id: captureId
   };
+
   setContext("capture", captureContext);
   let captureStore: IActiveCaptureStore;
   if (captureId) captureStore = ActiveCaptureStore.resolve(captureId);
@@ -212,7 +214,7 @@
   isAllowFromTextInput={true}
   shortcuts={[
     {
-      shortcut: { key: "l", modifiers: [ModifierKey.META, ModifierKey.SHIFT] },
+      shortcut: MemotronAction.ACTIVATE_LINK_BOX,
       callback: () => {
         captureTopBarRef?.toggleLinkBox();
       }

--- a/client/products/memotron/capture/CaptureTopBar.svelte
+++ b/client/products/memotron/capture/CaptureTopBar.svelte
@@ -16,7 +16,7 @@
   import type { IActiveCaptureStore } from "./capture.store";
   import { LinkType } from "../linking/link.type";
   import { CollectionType } from "$lib/client/components/collection/collection.type";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, tick } from "svelte";
   import Icon from "$lib/client/elements/Icon.svelte";
   import { haptic } from "$lib/client/utils/embed.utils";
   import { MemotronAction } from "../memotronAction.enum";
@@ -46,12 +46,11 @@
     dispatch("save");
   }
 
-  export function toggleLinkBox() {
+  export async function toggleLinkBox() {
     toggleLinkExpansion();
     if (!$captureStore.isLinksExpanded) return;
-    setTimeout(() => {
-      linkBoxRef?.focus();
-    }, 100);
+    await tick();
+    linkBoxRef?.focus();
   }
 
   function toggleLinkExpansion() {

--- a/client/products/memotron/capture/CaptureTopBar.svelte
+++ b/client/products/memotron/capture/CaptureTopBar.svelte
@@ -19,6 +19,7 @@
   import { createEventDispatcher } from "svelte";
   import Icon from "$lib/client/elements/Icon.svelte";
   import { haptic } from "$lib/client/utils/embed.utils";
+  import { MemotronAction } from "../memotronAction.enum";
   const dispatch = createEventDispatcher();
   export let captureStore: IActiveCaptureStore;
   export let isHomeContext: boolean = $view.isConstrainedWidth;
@@ -102,6 +103,7 @@
             on={$captureStore.isLinksExpanded}
             bgSize={Size.md}
             on:change={toggleLinkExpansion}
+            shortcut={MemotronAction.ACTIVATE_LINK_BOX}
           />
         {:else}
           <Tag
@@ -112,6 +114,7 @@
             isShowExpandFeedbackOnActive={true}
             isRemovable={false}
             on:click={toggleLinkExpansion}
+            shortcut={MemotronAction.ACTIVATE_LINK_BOX}
           />
           <div class="h-full py-2">
             <Divider

--- a/client/products/memotron/capture/CaptureTopBar.svelte
+++ b/client/products/memotron/capture/CaptureTopBar.svelte
@@ -19,9 +19,11 @@
   import { createEventDispatcher } from "svelte";
   import Icon from "$lib/client/elements/Icon.svelte";
   import { haptic } from "$lib/client/utils/embed.utils";
+  const dispatch = createEventDispatcher();
   export let captureStore: IActiveCaptureStore;
   export let isHomeContext: boolean = $view.isConstrainedWidth;
-  const dispatch = createEventDispatcher();
+  let linkBoxRef: LinkboxOnCapture;
+
   async function onLink(e: CustomEvent) {
     if (e.detail.id && e.detail.type === CollectionType.TYPED) {
       $captureStore.expandedType = e.detail.id;
@@ -41,6 +43,14 @@
   function onSave() {
     haptic();
     dispatch("save");
+  }
+
+  export function toggleLinkBox() {
+    toggleLinkExpansion();
+    if (!$captureStore.isLinksExpanded) return;
+    setTimeout(() => {
+      linkBoxRef?.focus();
+    }, 100);
   }
 
   function toggleLinkExpansion() {
@@ -147,6 +157,7 @@
       })}
     >
       <LinkboxOnCapture
+        bind:this={linkBoxRef}
         {captureStore}
         on:linked={onLink}
         expand={$captureStore.expandedType}

--- a/client/products/memotron/common/linkbox/LinkboxOnCapture.svelte
+++ b/client/products/memotron/common/linkbox/LinkboxOnCapture.svelte
@@ -13,12 +13,17 @@
   export let expand: IRecordId | null = null;
   const dispatch = createEventDispatcher();
   let link: string;
+  let searchRef: LinkSearch;
   async function propagatePropertyChanges(e: CustomEvent) {
     if (!e.detail || !e.detail?.id || e.detail?.value === undefined) return;
     captureStore.updateProperty({
       id: e.detail.id,
       value: e.detail.value
     });
+  }
+
+  export function focus() {
+    searchRef?.focus();
   }
   $: hasLinks = isValidArrayWithData($captureStore.links);
 </script>
@@ -40,6 +45,7 @@
         link = "";
         dispatch("linked", e.detail.item);
       }}
+      bind:this={searchRef}
     />
   </div>
 

--- a/client/products/memotron/memotronAction.enum.ts
+++ b/client/products/memotron/memotronAction.enum.ts
@@ -33,5 +33,6 @@ export enum MemotronAction {
   IMPORT_APP_DATA = "import-app-data",
   EDIT_CAPTURE_SHORTCUTS = "edit-capture-shortcuts",
   CAPTURE_SETTINGS = "capture-settings",
-  RELATIONS_AS_SETTINGS = "relations-as-settings"
+  RELATIONS_AS_SETTINGS = "relations-as-settings",
+  ACTIVATE_LINK_BOX = "ACTIVATE_LINK_BOX"
 }

--- a/client/products/pointron/focus/zen/FocusItemsHeading.svelte
+++ b/client/products/pointron/focus/zen/FocusItemsHeading.svelte
@@ -4,7 +4,6 @@
   import { TextStyle } from "$lib/client/types/text.enum";
   import { isInEditMode } from "$lib/client/stores/app.store";
   import { focusItemsStore } from "../session.store";
-  import { uiStateDerived } from "$lib/client/stores/uiState/uiState.store";
   import { Action } from "$lib/client/types/action.enum";
   import ShortcutText from "$lib/client/elements/text/ShortcutText.svelte";
 </script>
@@ -14,9 +13,7 @@
     <Text style={TextStyle.PANEL_HEADING_SMALL} content="Focus Items" />
     <span class="flex items-center gap-1">
       <EditToggleButton />
-      {#if $uiStateDerived.isShowHotKeyHints}
-        <ShortcutText shortcut={Action.EDIT_MODE} parentBgIndex={1} />
-      {/if}
+      <ShortcutText shortcut={Action.EDIT_MODE} parentBgIndex={1} />
     </span>
   </div>
   <div class="flex flex-col items-center gap-1 text-fgs3">

--- a/client/products/product.config.ts
+++ b/client/products/product.config.ts
@@ -37,10 +37,19 @@ interface ProductConfig {
   sectionLabel: string;
   displayName: string;
   tagline: string;
+  configurableShortcuts?: string[];
   features: {
     fileUploadAvailable: boolean;
   };
 }
+
+const commonConfigurableShortcuts = [
+  Action.EDIT_MODE,
+  Action.CMD,
+  Action.GLOBAL_SEARCH,
+  Action.GO_BACK,
+  Action.GO_FORWARD
+];
 
 export const products: Record<Product, ProductConfig> = {
   [Product.NUCLEUS]: {
@@ -58,6 +67,11 @@ export const products: Record<Product, ProductConfig> = {
     features: {
       fileUploadAvailable: true
     },
+    configurableShortcuts: [
+      ...commonConfigurableShortcuts,
+      "SAVE_CAPTURE_SHORTCUT",
+      "ACTIVATE_LINK_BOX"
+    ],
     settings: [
       {
         children: [
@@ -111,6 +125,11 @@ export const products: Record<Product, ProductConfig> = {
     features: {
       fileUploadAvailable: true
     },
+    configurableShortcuts: [
+      ...commonConfigurableShortcuts,
+      "SAVE_CAPTURE_SHORTCUT",
+      "ACTIVATE_LINK_BOX"
+    ],
     settings: [
       {
         children: [

--- a/client/utils/browser.utils.ts
+++ b/client/utils/browser.utils.ts
@@ -238,6 +238,14 @@ export function isTextElement(target: EventTarget | null) {
   );
 }
 
+export function hasActivePopovers(): boolean {
+  const popovers = document.querySelectorAll("div.popover");
+  return Array.from(popovers).some((popover) => {
+    const element = popover as HTMLElement;
+    return getComputedStyle(element).display !== "none";
+  });
+}
+
 /**
  *
  *


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Cmd/Ctrl+Shift+L to open and focus the Linkbox in Capture, even while typing (TASK-519). Also fixes Markdown editor focus/keyboard behavior and improves shortcut handling when popovers are open.

- **Bug Fixes**
  - Replaced Markdown button wrapper with a div (role="textbox") to fix Enter/click quirks and focus issues.
  - Global ESC is not dispatched to app shortcuts when a popover is open, letting the popover handle it.
  - Guarded Dexie search-index updates in merge with try/catch to avoid breaking mutations on index errors.

<!-- End of auto-generated description by cubic. -->


 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New Capture shortcut (Meta+L) to toggle and focus the link box; programmatic toggle/focus APIs added.
- Accessibility
  - Markdown editor given ARIA role/label; some controls excluded from tab order for better focus behavior.
- Behavior Changes
  - ESC no longer triggers system shortcuts while a popover is open.
  - Shortcuts can be allowed from text inputs when explicitly enabled.
- UI/Style
  - Calendar tiles use consistent large-display text sizing.
  - Hotkey indicators now optionally always shown across several UI elements.
- Bug Fixes
  - Search-index updates during merges are more resilient to errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

**Overview:** This PR addresses a markdown bug related to the linkbox activation shortcut and makes several enhancements to improve the user experience. It modifies shortcut text visibility, updates logging practices, refactors styling, and improves search functionality.

**Key Changes:**
- Updated shortcut text visibility logic across multiple components, ensuring consistent display.
- Replaced `logger.info` with `logger.log` for more standardized logging.
- Removed unnecessary styling classes in `CalendarTileIndicator.svelte` and `MonthTileIndicator.svelte`.
- Improved search functionality in `LibrarySearchBox.svelte` and added semantic search capabilities.
- Enhanced markdown editor accessibility and added a new `isAlwaysShown` prop to `ShortcutText.svelte` for better control over shortcut visibility.
- Updated search index handling in `dexie.local.ts` to improve error handling and robustness.
- Added a new `ACTIVATE_LINK_BOX` shortcut for Memotron capture.

**Recommendations:**
Not deployment ready. Refactor the shortcut visibility logic to a centralized location to improve maintainability and reduce redundancy.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 134 (54%)     |
| Churn       | 20 (8%)       |
| Rework      | 94 (38%)      |
| Total Changes | 248         |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>