### PR TITLE
TASK-522 - small improv and fixe

### DIFF
--- a/client/branding/SubAtomLogo.svelte
+++ b/client/branding/SubAtomLogo.svelte
@@ -15,7 +15,7 @@
   $: height = size === Size.md ? 61 : size === Size.sm ? 40 : 61;
 </script>
 
-<button on:click>
+<div>
   <svg
     class={cn({
       "w-16 h-16": size === Size.md,
@@ -201,4 +201,4 @@
       />
     {/if}
   </svg>
-</button>
+</div>

--- a/client/components/calendar/CalendarLayout.svelte
+++ b/client/components/calendar/CalendarLayout.svelte
@@ -44,7 +44,7 @@
 
 <div class="flex flex-col h-full w-full">
   <div
-    class="flex items-center gap-4 border-b border-brs3 h-[3.2rem] 2k:h-14 px-4 bg-bgs2"
+    class="flex items-center gap-4 border-b border-brs3 h-[3.2rem] 2k:h-14 px-4"
   >
     <header class="grid grid-cols-3 w-full sticky top-0 z-10">
       <div class="flex items-center gap-4">

--- a/client/components/collection/thumbnail/CollectionThumbnail.svelte
+++ b/client/components/collection/thumbnail/CollectionThumbnail.svelte
@@ -76,7 +76,7 @@
           {#if accessPointState === ResourceAccessPointState.DEFAULT}
             <CollectionNodeCount {item} isShowLabel={true} />
           {/if}
-          <CollectionPropertyCount {item} />
+          <CollectionPropertyCount {item} isShowLabel={size === Size.md} />
         </span>
       </slot>
     </ResourceGridThumbnail>

--- a/client/components/library/LibraryRecordsPane.svelte
+++ b/client/components/library/LibraryRecordsPane.svelte
@@ -515,7 +515,7 @@
         padding="px-2"
         on:search={() => refresh()}
         placeholder={"Search " + resource + "s"}
-        style={InputStyle.FILLED}
+        style={InputStyle.BORDERED}
       >
         <Toggle
           bind:on={isRefineShown}
@@ -632,8 +632,12 @@
           $view.isConstrainedWidth
             ? ResourceAccessMode.POP
             : ResourceAccessMode.INLINE}
-          size={$view.isConstrainedWidth ? Size.sm : Size.md}
+          size={$view.isConstrainedWidth ||
+          accessPoint === ResourceAccessPoint.BROWSER
+            ? Size.sm
+            : Size.md}
           arrangement={resolveArrangement(arrangement)}
+          width={accessPoint === ResourceAccessPoint.BROWSER ? 120 : undefined}
         />
         {#if data.length > 0}
           <div class="mt-4 -mb-2">
@@ -670,10 +674,14 @@
           $view.isConstrainedWidth
             ? ResourceAccessMode.POP
             : ResourceAccessMode.INLINE}
-          size={$view.isConstrainedWidth ? Size.sm : Size.md}
+          size={$view.isConstrainedWidth ||
+          accessPoint === ResourceAccessPoint.BROWSER
+            ? Size.sm
+            : Size.md}
           isShowLoadingPulseAtTheEnd={data.length < totalCountAfterFilter &&
             !searchQuery}
           arrangement={resolveArrangement(arrangement)}
+          width={accessPoint === ResourceAccessPoint.BROWSER ? 120 : undefined}
         />
       </div>
       <div

--- a/client/components/library/resourceBrowser/ResourceBrowser.svelte
+++ b/client/components/library/resourceBrowser/ResourceBrowser.svelte
@@ -35,12 +35,8 @@
   });
   let searchQuery: string = "";
   let id: string | null = null;
-  let arrangement: Arrangement =
-    uiState?.getResourceState(
-      resource,
-      ResourceAccessPoint.BROWSER,
-      UIState.arrangement
-    ) ?? Arrangement.LIST;
+  let arrangement: Arrangement = resolveArrangement();
+
   const createShortcut = keyboardShortcuts?.resolveShortcutForAction("create");
 
   $: tooltip = resolveResourceTooltip(resource);
@@ -66,6 +62,16 @@
     : ResourceAccessPointState.DEFAULT;
 
   let recordsPaneRef: LibraryRecordsPane | null = null;
+
+  function resolveArrangement() {
+    return (
+      uiState?.getResourceState(
+        resource,
+        ResourceAccessPoint.BROWSER,
+        UIState.arrangement
+      ) ?? Arrangement.LIST
+    );
+  }
 
   const addAction = async () => {
     appStore.runAction(resourceAction(resource, ResourceActionType.CREATE), {

--- a/client/components/record/thumbnail/ResourceGridThumbnail.svelte
+++ b/client/components/record/thumbnail/ResourceGridThumbnail.svelte
@@ -24,12 +24,15 @@
   <slot />
   {#if !isMasonry}
     <div
-      class={cn("flex flex-col h-fit gap-2 w-full items-start p-3 truncate", {
-        "border-t rounded-b-md": !isHidePreview,
-        "border rounded-md": isHidePreview,
-        "bg-ccs4 border-ccs2": isApplyCustomColor,
-        "bg-bgs2 border-brs2": !isApplyCustomColor
-      })}
+      class={cn(
+        "flex flex-col h-fit gap-1.5 w-full items-start px-3 py-2 truncate",
+        {
+          "border-t rounded-b-md": !isHidePreview,
+          "border rounded-md": isHidePreview,
+          "bg-ccs4 border-ccs2": isApplyCustomColor,
+          "bg-bgs2 border-brs2": !isApplyCustomColor
+        }
+      )}
     >
       <slot name="bottom" />
     </div>

--- a/client/elements/switcher/VerticalSwitcherItem.svelte
+++ b/client/elements/switcher/VerticalSwitcherItem.svelte
@@ -174,7 +174,7 @@
         "flex-col": labelOrientation === Orientation.Vertical,
         [activeClasses]: isActive,
         [inactiveClasses]: !isActive,
-        "border-ccs1": isActive,
+        "border-ccs1 text-ccs1": isActive,
         "bg-aps1": style === VerticalSwitcherStyle.BG && isActive
       })}
       {...commonVerticalLabelOptions}

--- a/client/layout/layers/UserLayout.svelte
+++ b/client/layout/layers/UserLayout.svelte
@@ -60,25 +60,26 @@
   {:else}
     <div class="flex flex-col w-full h-full">
       <div class="flex w-full flex-grow">
-        {#if !isHideLeftNavBar || $context.embed === Embed.HANDSET}
+        {#if $context.embed === Embed.HANDSET}
           <LeftNav variant="fixed" />
         {/if}
-        <div
-          class="flex flex-col h-full {$view.isPortrait
-            ? 'w-full'
-            : 'flex-grow'}"
-        >
+        <div class="flex flex-col h-full w-full">
           {#if !$view.isPortrait}
             <TopNav>
               <slot name="topnav" slot="topnav" />
             </TopNav>
           {/if}
-          <div class="w-full flex-grow">
-            <AppSplitView>
-              <slot name="main" slot="main">
-                <slot />
-              </slot>
-            </AppSplitView>
+          <div class="flex w-full flex-grow">
+            {#if $context.embed !== Embed.HANDSET && !isHideLeftNavBar}
+              <LeftNav variant="fixed" />
+            {/if}
+            <div class="min-w-0 flex-grow">
+              <AppSplitView>
+                <slot name="main" slot="main">
+                  <slot />
+                </slot>
+              </AppSplitView>
+            </div>
           </div>
         </div>
         <!-- <RightPanel /> -->

--- a/client/layout/leftPanel/LeftBottomBar.svelte
+++ b/client/layout/leftPanel/LeftBottomBar.svelte
@@ -13,10 +13,11 @@
 </script>
 
 <div
-  class={cn("w-full bg-bgs3", {
+  class={cn("w-full", {
     "h-16": isInThinMode && size === Size.lg,
     "h-24": isInThinMode && size === Size.md,
-    "h-12": !isInThinMode
+    "h-12": !isInThinMode,
+    "bg-bgs3": !$appStore.currentComponent?.panel
   })}
 >
   {#if $appStore.appData?.leftPanelFooter === "simple" || !$appStore.appData?.leftPanelFooter}
@@ -26,13 +27,12 @@
       })}
     >
       <button
-        class={cn(
-          "flex gap-2 h-full w-full items-center justify-center px-2 hover:bg-bgs4",
-          {
-            "rounded-bl-lg": !isInThinMode && isRounded,
-            "bg-aps1": isCpActive
-          }
-        )}
+        class={cn("flex gap-2 h-full w-full items-center justify-center px-2", {
+          "rounded-bl-lg": !isInThinMode && isRounded,
+          "bg-aps1": isCpActive,
+          "hover:bg-bgs4": !$appStore.currentComponent?.panel,
+          "hover:bg-bgs3 rounded-tr-lg": $appStore.currentComponent?.panel
+        })}
         on:click={() => appStore.runAction(Action.SETTINGS)}
       >
         <Icon icon="gear" isAccentBgContext={isCpActive} {size} />

--- a/client/layout/leftPanel/LeftNavFixed.svelte
+++ b/client/layout/leftPanel/LeftNavFixed.svelte
@@ -19,7 +19,9 @@
     UIStateScope
   } from "$lib/client/stores/uiState/uiState.type";
   import { onMount } from "svelte";
+  import { appStore } from "$lib/client/stores/app.store";
   export let isRounded = false;
+  const dev_mixedPanel = false;
   let isHideMenuLabels = uiState.getState(UIState.hideLeftNavMenuLabels, {
     scope: UIStateScope.DAP
   });
@@ -40,7 +42,7 @@
 <div
   class={cn(
     "leftnav flex justify-center items-center h-full",
-    !$$slots.panel && {
+    !$appStore.currentComponent?.panel && {
       // "w-[5.5rem] min-w-[5.5rem]": !isHideMenuLabels,
       // "w-[3.5rem] min-w-[3.5rem]": isHideMenuLabels,
       "ml-2": isRounded,
@@ -49,10 +51,13 @@
   )}
 >
   <div
-    class={cn("flex items-center justify-center h-full w-full bg-bgs2", {
-      "rounded-lg border-none": isRounded,
-      "border-r border-bgs4": !isRounded
-    })}
+    class={cn(
+      "flex items-center justify-center h-full w-full bg-bgs2",
+      $appStore.currentComponent?.panel && {
+        "rounded-lg border-none": isRounded,
+        "border-r border-bgs4": !isRounded
+      }
+    )}
   >
     <div
       class={cn(
@@ -60,8 +65,10 @@
         {
           "w-[5.5rem] min-w-[5.5rem]": !isHideMenuLabels,
           "w-[3.5rem] min-w-[3.5rem]": isHideMenuLabels
-          // "rounded-lg border-none": isRounded,
-          // "border-r border-bgs4": !isRounded
+        },
+        (!dev_mixedPanel || !$appStore.currentComponent?.panel) && {
+          "rounded-lg border-none": isRounded,
+          "border-r border-bgs4": !isRounded
         }
       )}
       style={isRounded ? "height: calc(100% - 1rem);" : "height:100%"}
@@ -76,7 +83,7 @@
           size={Size.lg}
           on:click={() => appStore.runAction(Action.GLOBAL_SEARCH)}
         /> -->
-          <SubAtomLogo size={isHideMenuLabels ? Size.sm : Size.md} />
+          <!-- <SubAtomLogo size={isHideMenuLabels ? Size.sm : Size.md} /> -->
         </div>
         <!-- <TrailLeftIndicator orientation={Orientation.Vertical} /> -->
         <div
@@ -92,6 +99,7 @@
             class="flex justify-center items-center w-full mt-2"
             use:popover={{
               content: LeftNavSettingsPopover,
+              id: "leftnav-settings-popover",
               placement: Placement.Right,
               triggerMethod: [PopoverTriggerMethod.CLICK],
               offsetInPx: 10

--- a/client/layout/leftPanel/appMenuSwitcher/AppMenuSwitcherItem.svelte
+++ b/client/layout/leftPanel/appMenuSwitcher/AppMenuSwitcherItem.svelte
@@ -33,6 +33,7 @@
   export let item: IAction;
   export let layoutContext: LayoutContext = LayoutContext.DEFAULT;
   export let parentBackgroundIndex: number;
+  const dev_mixedPanel = false;
   $: isShowHotKeyHint =
     $uiStateDerived?.isShowHotKeyHints &&
     (layoutContext === LayoutContext.DEFAULT || hideMenuLabels);
@@ -187,9 +188,11 @@
         isActive && !isShowLabel,
       "border border-transparent hover:bg-bgs3 transition-all":
         !isActive && !isShowLabel,
-      "border-aps2": isActive && !$appStore.currentComponent?.panel,
-      "border-transparent": isActive && $appStore.currentComponent?.panel,
-      "rounded-md": $appStore.currentComponent?.panel
+      "border-aps2":
+        isActive && (!dev_mixedPanel || !$appStore.currentComponent?.panel),
+      "border-transparent":
+        isActive && dev_mixedPanel && $appStore.currentComponent?.panel,
+      "rounded-r-md": dev_mixedPanel && $appStore.currentComponent?.panel
     }
   )}
   on:click={onClick}

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -26,7 +26,7 @@
   const dispatch = createEventDispatcher();
 
   export let title: string | undefined = undefined;
-  export let titleStyle: TextStyle = TextStyle.PAGE_HEADING_SUBTLE;
+  export let titleStyle: TextStyle = TextStyle.PANEL_HEADING;
   export let floatingButton: IButtonParams | IButtonParams[] | undefined =
     undefined;
   export let panelSize: Size.sm | Size.md | Size.lg | Size.xl = Size.md;

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -2,8 +2,6 @@
   import { uiState } from "$lib/client/stores/uiState/uiState.store";
   import { onMount } from "svelte";
   import type { IRecordId } from "$lib/client/types/data.type";
-  import Button from "$lib/client/elements/button/Button.svelte";
-  import { ButtonStyle } from "$lib/client/types/button.type";
   import { appStore } from "$lib/client/stores/app.store";
   import { Action } from "$lib/client/types/action.enum";
   import ProfilePicture from "$lib/client/components/settings/account/ProfilePicture.svelte";
@@ -23,6 +21,11 @@
   import TopNavLeftMenuItem from "./TopNavLeftMenuItem.svelte";
   import InlineSyncingFeedback from "$lib/client/elements/feedback/InlineSyncingFeedback.svelte";
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
+  import {
+    UIState,
+    UIStateScope
+  } from "$lib/client/stores/uiState/uiState.type";
+  import TopNavLeftLogo from "./TopNavLeftLogo.svelte";
 
   let isInFocusMode = false;
   let pinnedItems: IRecordId[] = tabs.get() ?? [];
@@ -36,6 +39,10 @@
       ? determineIfActiveSubscriber($account.plan)
       : false;
 
+  let isHideMenuLabels = uiState.getState(UIState.hideLeftNavMenuLabels, {
+    scope: UIStateScope.DAP
+  });
+
   function handleFocusMode(e: CustomEvent<boolean>) {
     if (typeof e.detail === "boolean") {
       isInFocusMode = e.detail;
@@ -45,6 +52,9 @@
   onMount(() => {
     const unsubscribe = uiState.subscribe((x) => {
       pinnedItems = tabs.get() ?? [];
+      isHideMenuLabels = uiState.getState(UIState.hideLeftNavMenuLabels, {
+        scope: UIStateScope.DAP
+      });
     });
     return () => {
       if (unsubscribe) unsubscribe();
@@ -55,7 +65,7 @@
 {#if !isInFocusMode}
   <div
     class={cn(
-      "w-full lp:h-10 lp:max-h-10 lp:min-h-10 h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata",
+      "w-full h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata",
       {
         "flex gap-3 justify-between items-center":
           pinnedItems.length > 0 || isInterimTab,
@@ -64,7 +74,8 @@
     )}
   >
     {#if pinnedItems.length > 0}
-      <div class="relative h-full overflow-x-auto">
+      <div class="flex items-center relative h-full overflow-x-auto">
+        <TopNavLeftLogo {isHideMenuLabels} />
         <Tabs {pinnedItems} />
         <div
           class="absolute right-0 top-0 bottom-0 flex items-center pointer-events-none"
@@ -75,7 +86,7 @@
         </div>
       </div>
     {:else}
-      <div class="w-1 h-full"></div>
+      <TopNavLeftLogo {isHideMenuLabels} />
     {/if}
     {#if pinnedItems.length === 0 && !isInterimTab}
       <div class="flex items-center justify-center">

--- a/client/layout/topNav/TopNavLeftLogo.svelte
+++ b/client/layout/topNav/TopNavLeftLogo.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { cn } from "$lib/client/utils/ui.utils";
+  import { Size } from "$lib/client/types/size.enum";
+  import SubAtomLogo from "$lib/client/branding/SubAtomLogo.svelte";
+  export let isHideMenuLabels: boolean = false;
+</script>
+
+<div
+  class={cn("flex items-center h-full w-fit border-r border-brs3", {
+    "px-[0.72rem]": isHideMenuLabels,
+    "px-[1.72rem]": !isHideMenuLabels
+  })}
+>
+  <div class="opacity-50">
+    <SubAtomLogo size={Size.sm} />
+  </div>
+</div>

--- a/client/layout/topNav/tabs/Tabs.svelte
+++ b/client/layout/topNav/tabs/Tabs.svelte
@@ -20,7 +20,7 @@
 >
   {#if isShowHome}
     <div
-      class={cn("flex justify-center items-center px-2 border-r border-bgs3", {
+      class={cn("flex justify-center items-center px-2 border-r border-brs3", {
         "bg-bgs1": !activeTab
       })}
     >

--- a/client/layout/topNav/tabs/TopBarResourceItem.svelte
+++ b/client/layout/topNav/tabs/TopBarResourceItem.svelte
@@ -65,7 +65,7 @@
   }
 </script>
 
-<div class="p-1 border-x border-r-brs3 border-l-transparent">
+<div class="p-1 border--x border--r-brs3 border-l-transparent max-h-full">
   <button
     use:popover={{
       placement: Placement.BottomCenter,
@@ -90,7 +90,7 @@
       {
         "px-4 py-1.5": !isInterimTab,
         "px-2 py-0.5 border border-dashed border-fgs4": isInterimTab,
-        "hover:bg-bgs3": !isActive,
+        "hover:bg-bgs3 text-fgs2 hover:text-fgs1": !isActive,
         "bg-bgs1": isActive
       }
     )}

--- a/client/products/memotron/overview/MemotronOverview.svelte
+++ b/client/products/memotron/overview/MemotronOverview.svelte
@@ -32,9 +32,7 @@
   });
 </script>
 
-{#if selectedPanel === MemotronOverviewPanel.TITLE}
-  <MemotronDefaultOverview />
-{:else if selectedPanel === MemotronOverviewPanel.GRAPH}
+{#if selectedPanel === MemotronOverviewPanel.GRAPH}
   <GlobalGraph />
 {:else if selectedPanel === MemotronOverviewPanel.MAP}
   <MemotronMapOverview />

--- a/client/products/memotron/overview/MemotronOverviewLayout.svelte
+++ b/client/products/memotron/overview/MemotronOverviewLayout.svelte
@@ -51,12 +51,7 @@
 
 <div class="relative w-full h-full flex flex-col justify-center items-center">
   <div
-    class={cn(
-      "flex justify-between items-end gap-4 rounded-md w-full bg-bgs2",
-      {
-        "px-4": isNucleusContext
-      }
-    )}
+    class="flex justify-between items-end gap-4 rounded-md w-full"
     use:resizeListener={(e) => {
       containerWidth = e.width;
     }}
@@ -76,7 +71,6 @@
       ]}
       style={PanelSwitcherStyle.BAR}
       title={isNucleusContext ? "Memory" : "Overview"}
-      parentBgIndex={2}
       isExpandToFullWidth={true}
       isShowNumberShortcut={!isNucleusContext &&
         $uiStateDerived.isShowHotKeyHints}

--- a/client/products/memotron/overview/overview.type.ts
+++ b/client/products/memotron/overview/overview.type.ts
@@ -1,5 +1,4 @@
 export enum MemotronOverviewPanel {
-  TITLE = "$title",
   GRAPH = "graph",
   MAP = "map"
 }

--- a/client/products/nucleus/nucleus.actions.ts
+++ b/client/products/nucleus/nucleus.actions.ts
@@ -8,6 +8,7 @@ import { PointronAction } from "$lib/client/types/pointron/pointronAction.enum";
 import ComingSoonView from "$lib/client/elements/ComingSoonView.svelte";
 import LibraryPanelContentResolver from "$lib/client/components/library/LibraryPanelContentResolver.svelte";
 import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
+import NucleusOverviewPanel from "./overview/NucleusOverviewPanel.svelte";
 
 const actionsToFilterInSub = [
   Action.LIBRARY,
@@ -48,6 +49,7 @@ export const nucleusActions: IAction[] = [
     label: "Overview",
     icon: "heroicons:rectangle-group",
     component: NucleusOverview,
+    panel: NucleusOverviewPanel,
     type: ActionType.PAGE
   },
   {

--- a/client/products/nucleus/overview/NucleusOverview.svelte
+++ b/client/products/nucleus/overview/NucleusOverview.svelte
@@ -7,7 +7,6 @@
   } from "$lib/client/stores/uiState/uiState.type";
   import { OverviewPanel } from "./overview.type";
   import ComingSoonView from "$lib/client/elements/ComingSoonView.svelte";
-  import NucleusOverviewLayout from "./NucleusOverviewLayout.svelte";
   import AnalyticsV2 from "../../pointron/analytics/AnalyticsV2.svelte";
   import MemotronOverview from "../../memotron/overview/MemotronOverview.svelte";
 
@@ -29,14 +28,10 @@
   });
 </script>
 
-<NucleusOverviewLayout>
-  {#if selectedPanel === OverviewPanel.TITLE}
-    <ComingSoonView />
-  {:else if selectedPanel === OverviewPanel.FOCUS}
-    <div class="w-full h-[90vh]">
-      <AnalyticsV2 />
-    </div>
-  {:else if selectedPanel === OverviewPanel.MEMORY}
-    <MemotronOverview />
-  {/if}
-</NucleusOverviewLayout>
+{#if selectedPanel === OverviewPanel.FOCUS}
+  <AnalyticsV2 />
+{:else if selectedPanel === OverviewPanel.MEMORY}
+  <MemotronOverview />
+{:else}
+  <ComingSoonView />
+{/if}

--- a/client/products/nucleus/overview/NucleusOverviewLayout.svelte
+++ b/client/products/nucleus/overview/NucleusOverviewLayout.svelte
@@ -40,7 +40,7 @@
 
 <div class="relative w-full h-full flex flex-col justify-center items-center">
   <div
-    class="flex justify-between items-end gap-4 rounded-md w-full bg-bgs2"
+    class="flex justify-between items-end gap-4 rounded-md w-full"
     use:resizeListener={(e) => {
       containerWidth = e.width;
     }}
@@ -70,7 +70,6 @@
       ]}
       style={PanelSwitcherStyle.BAR}
       title="Overview"
-      parentBgIndex={2}
       isExpandToFullWidth={true}
       isShowNumberShortcut={$uiStateDerived.isShowHotKeyHints}
       size={Size.sm}

--- a/client/products/nucleus/overview/NucleusOverviewPanel.svelte
+++ b/client/products/nucleus/overview/NucleusOverviewPanel.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import VerticalSwitcher from "$lib/client/elements/switcher/VerticalSwitcher.svelte";
+  import { appStore } from "$lib/client/stores/app.store";
+  import { uiState } from "$lib/client/stores/uiState/uiState.store";
+  import {
+    UIState,
+    UIStateScope
+  } from "$lib/client/stores/uiState/uiState.type";
+  import { Placement } from "$lib/client/types/direction.enum";
+  import { Size } from "$lib/client/types/size.enum";
+  import { VerticalSwitcherStyle } from "$lib/client/types/switcher.enum";
+  import { OverviewPanel } from "./overview.type";
+  let selectedPanel: OverviewPanel = resolveSavedState() ?? OverviewPanel.FOCUS;
+
+  function resolveSavedState() {
+    const savedPanel = uiState.getState(UIState.nucleusOverviewPanel, {
+      scope: UIStateScope.DEVICE
+    });
+    if (savedPanel && Object.values(OverviewPanel).includes(savedPanel)) {
+      return savedPanel;
+    }
+  }
+
+  const items = [
+    {
+      label: "Focus",
+      value: OverviewPanel.FOCUS,
+      icon: "circle"
+    },
+    {
+      label: "Memory",
+      value: OverviewPanel.MEMORY,
+      icon: "hexagon"
+    }
+    // {
+    //   label: "Self",
+    //   value: OverviewPanel.SELF,
+    //   icon: "heart"
+    // },
+    // {
+    //   label: "Finance",
+    //   value: OverviewPanel.FINANCE,
+    //   icon: "ph:bank-light"
+    // }
+  ];
+
+  function onSwitch(event: CustomEvent) {
+    const val = event.detail;
+    if (!val || !Object.values(OverviewPanel).includes(val)) return;
+    appStore.toggleSearchParamRecordSpecific("overview", { tab: val });
+    uiState.setState(UIState.nucleusOverviewPanel, val, {
+      scope: UIStateScope.DEVICE
+    });
+  }
+</script>
+
+<div class="h-full">
+  <VerticalSwitcher
+    {items}
+    selected={selectedPanel}
+    itemProps={{ size: Size.sm, activeStatusPlacement: Placement.Right }}
+    style={VerticalSwitcherStyle.GRADIENT}
+    on:switch={onSwitch}
+  />
+</div>

--- a/client/products/nucleus/overview/overview.type.ts
+++ b/client/products/nucleus/overview/overview.type.ts
@@ -1,5 +1,4 @@
 export enum OverviewPanel {
-  TITLE = "$title",
   FOCUS = "focus",
   MEMORY = "memory",
   SELF = "self",

--- a/client/products/pointron/analytics/AnalyticsV2.svelte
+++ b/client/products/pointron/analytics/AnalyticsV2.svelte
@@ -106,11 +106,7 @@
         </div>
       {:else}
         <div class="flex overflow-hidden w-full">
-          <div
-            class={cn("overflow-x-auto w-full", {
-              "px-4": isNucleusContext
-            })}
-          >
+          <div class="overflow-x-auto w-full">
             <PanelSwitcher
               title={isNucleusContext ? "Focus analytics" : "Overview"}
               items={pages}

--- a/shared/utils/text.utils.ts
+++ b/shared/utils/text.utils.ts
@@ -74,12 +74,12 @@ export function isValidString(str: string | undefined | null) {
   return undefined;
 }
 
-export function isValidNumber(str: string) {
-  if (typeof str !== "string") return false;
+export function isValidNumber(str: string | number) {
+  if (typeof str !== "string" && typeof str !== "number") return false;
+  if (typeof str === "number") return Number.isFinite(str);
   const s = str.trim();
   if (s === "") return false;
-  const n = Number(s);
-  return Number.isFinite(n);
+  return Number.isFinite(Number(s));
 }
 
 export function isValidEnumValue(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Polished navigation and overview layouts and introduced a Nucleus overview side panel to improve discoverability and consistency across the app. Addresses TASK-522 by tightening grid/list visuals, refining left/top nav behavior, and fixing minor UI and validation issues.

- New Features
  - Added NucleusOverviewPanel (side panel with VerticalSwitcher) and wired it in nucleus.actions; selection persists via UIState.
  - Added TopNavLeftLogo and updated tabs header to include a subtle logo with proper borders.

- Bug Fixes
  - Made SubAtomLogo non-clickable to prevent accidental actions.
  - LibraryRecordsPane: switched search to bordered style; adjusted thumbnail size/width for browser mode and constrained widths.
  - ResourceBrowser: arrangement now resolved via function for reactive updates.
  - ResourceGridThumbnail: reduced padding/gap for denser cards.
  - LeftNav/BottomBar: consistent borders/hover when a panel is open; improved rounding and width handling in UserLayout.
  - VerticalSwitcherItem: active state now also changes text color.
  - Panel: default title style updated to PANEL_HEADING.
  - Top nav tabs and resource items: fixed border colors and inactive text/hover states.
  - Calendar header: removed extra background for cleaner look.
  - Memotron/Nucleus: removed unused TITLE tab; simplified Nucleus overview defaults; minor padding cleanups.
  - isValidNumber now accepts numeric inputs and validates correctly.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Top navigation now displays a left logo that adapts to hidden menu labels.
  - Nucleus Overview adds a persistent side panel switcher; Overview action now shows a panel.

- Style
  - Updated spacing, padding, borders, and hover states across thumbnails, tabs, switchers, and headers.
  - Simplified layouts and backgrounds for cleaner presentation; adjusted top bar heights.

- Refactor
  - Reorganized user layout and streamlined arrangement initialization.
  - Removed “Title” views from Memotron and Nucleus overviews; defaults remain Graph/Map/Focus.

- Other
  - Search input uses bordered style; record tiles sized/width-optimized for browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->