### PR TITLE
TASK-532 - release testing fixes

### DIFF
--- a/client/components/library/LibraryRecordsPane.svelte
+++ b/client/components/library/LibraryRecordsPane.svelte
@@ -636,7 +636,6 @@
             ? Size.sm
             : Size.md}
           arrangement={resolveArrangement(arrangement)}
-          width={accessPoint === ResourceAccessPoint.BROWSER ? 120 : undefined}
         />
         {#if data.length > 0}
           <div class="mt-4 -mb-2">
@@ -680,7 +679,6 @@
           isShowLoadingPulseAtTheEnd={data.length < totalCountAfterFilter &&
             !searchQuery}
           arrangement={resolveArrangement(arrangement)}
-          width={accessPoint === ResourceAccessPoint.BROWSER ? 120 : undefined}
         />
       </div>
       <div

--- a/client/components/record/Records.svelte
+++ b/client/components/record/Records.svelte
@@ -72,9 +72,13 @@
     <TaskRecords {data} {arrangement} {accessPoint} {parentBgIndex} />
   {:else}
     <div
+      style={arrangement === Arrangement.GRID &&
+      accessPoint !== ResourceAccessPoint.BROWSER
+        ? `--colw: ${width}px`
+        : undefined}
       class={cn(`h-full w-full content-start`, {
         "flex flex-col gap-2": arrangement === Arrangement.LIST,
-        [`grid grid-cols-[repeat(auto-fill,minmax(${width}px,1fr))]`]:
+        "grid grid-cols-[repeat(auto-fill,minmax(var(--colw),1fr))]":
           arrangement === Arrangement.GRID &&
           accessPoint !== ResourceAccessPoint.BROWSER,
         "grid grid-cols-2":

--- a/client/components/record/Records.svelte
+++ b/client/components/record/Records.svelte
@@ -75,8 +75,12 @@
       class={cn(`h-full w-full content-start`, {
         "flex flex-col gap-2": arrangement === Arrangement.LIST,
         [`grid grid-cols-[repeat(auto-fill,minmax(${width}px,1fr))]`]:
-          arrangement === Arrangement.GRID,
-        "gap-4": arrangement === Arrangement.GRID
+          arrangement === Arrangement.GRID &&
+          accessPoint !== ResourceAccessPoint.BROWSER,
+        "grid grid-cols-2":
+          arrangement === Arrangement.GRID &&
+          accessPoint === ResourceAccessPoint.BROWSER,
+        "cw:gap-3 gap-4": arrangement === Arrangement.GRID
       })}
     >
       {#each data as item (item)}

--- a/client/components/settings/account/signup/AccountForm.svelte
+++ b/client/components/settings/account/signup/AccountForm.svelte
@@ -219,7 +219,7 @@
       <div
         class={cn("group flex flex-col justify-between gap-4 p-4", {
           "cw:h-fit h-72 bg-bgs1 border-t-transparent border-x-transparent border-t border-x border-brs3 hover:border-t-brs3 hover:border-x-brs3 hover:rounded-t-md rounded-t-md":
-            mode === "all"
+            mode === "all" && !$view.isConstrainedWidth
         })}
       >
         {#if mode === "all" && !$view.isConstrainedWidth}

--- a/client/layout/leftPanel/LeftBottomBar.svelte
+++ b/client/layout/leftPanel/LeftBottomBar.svelte
@@ -8,6 +8,7 @@
   export let isInThinMode: boolean = false;
   export let isRounded: boolean = false;
   export let size: Size.sm | Size.md | Size.lg = Size.md;
+  export let dev_mixedPanel: boolean = false;
   $: isCpActive =
     $page.params.route?.includes("/cp") || $page.route.id?.includes("/cp");
 </script>
@@ -17,7 +18,7 @@
     "h-16": isInThinMode && size === Size.lg,
     "h-24": isInThinMode && size === Size.md,
     "h-12": !isInThinMode,
-    "bg-bgs3": !$appStore.currentComponent?.panel
+    "bg-bgs3": !dev_mixedPanel || !$appStore.currentComponent?.panel
   })}
 >
   {#if $appStore.appData?.leftPanelFooter === "simple" || !$appStore.appData?.leftPanelFooter}
@@ -30,8 +31,10 @@
         class={cn("flex gap-2 h-full w-full items-center justify-center px-2", {
           "rounded-bl-lg": !isInThinMode && isRounded,
           "bg-aps1": isCpActive,
-          "hover:bg-bgs4": !$appStore.currentComponent?.panel,
-          "hover:bg-bgs3 rounded-tr-lg": $appStore.currentComponent?.panel
+          "hover:bg-bgs4":
+            !dev_mixedPanel || !$appStore.currentComponent?.panel,
+          "hover:bg-bgs3 rounded-tr-lg":
+            dev_mixedPanel && $appStore.currentComponent?.panel
         })}
         on:click={() => appStore.runAction(Action.SETTINGS)}
       >

--- a/client/layout/leftPanel/LeftNavFixed.svelte
+++ b/client/layout/leftPanel/LeftNavFixed.svelte
@@ -5,9 +5,6 @@
   import LeftBottomBar from "./LeftBottomBar.svelte";
   import { cn } from "$lib/client/utils/ui.utils";
   import LeftNavOfflineStatus from "./LeftNavOfflineStatus.svelte";
-  import SubAtomLogo from "$lib/client/branding/SubAtomLogo.svelte";
-  import TrailLeftIndicator from "../topNav/TrailLeftIndicator.svelte";
-  import { Orientation } from "$lib/client/types/direction.enum";
   import { popover, tooltip } from "$lib/client/actions/popover.action";
   import { PopoverTriggerMethod } from "$lib/client/types/popover.type";
   import LeftNavSettingsPopover from "./LeftNavSettingsPopover.svelte";
@@ -76,16 +73,7 @@
       <div class="w-full flex flex-col gap-8 overflow-auto">
         <div
           class="w-full flex justify-center opacity-30 hover:opacity--100 transition-opacity duration-200 py-2"
-        >
-          <!-- <Button
-          icon="search"
-          parentBgIndex={2}
-          size={Size.lg}
-          on:click={() => appStore.runAction(Action.GLOBAL_SEARCH)}
-        /> -->
-          <!-- <SubAtomLogo size={isHideMenuLabels ? Size.sm : Size.md} /> -->
-        </div>
-        <!-- <TrailLeftIndicator orientation={Orientation.Vertical} /> -->
+        ></div>
         <div
           class={cn("flex flex-col gap-3 items-center w-full overflow-auto", {
             "p-2": !isHideMenuLabels
@@ -123,7 +111,12 @@
       <div class="w-full flex flex-col gap-2 items-center">
         <LeftNavOfflineStatus isInThinMode={true} />
         <!-- <LeftNavCommandAction isInThinMode={true} size={Size.lg} /> -->
-        <LeftBottomBar isInThinMode={true} {isRounded} size={Size.lg} />
+        <LeftBottomBar
+          isInThinMode={true}
+          {isRounded}
+          size={Size.lg}
+          {dev_mixedPanel}
+        />
       </div>
     </div>
     <slot name="panel" />

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -155,10 +155,12 @@
   {/if}
   {#if !$view.isConstrainedWidth && !isExpanded}
     <!-- Right split -->
-    <Divider
-      orientation={Orientation.Vertical}
-      colorStrength={ColorStrength.Normal}
-    />
+    {#if $$slots.right}
+      <Divider
+        orientation={Orientation.Vertical}
+        colorStrength={ColorStrength.Normal}
+      />
+    {/if}
     {#if isProminentDivider}
       <div class="w-0.5 bg-bgs2"></div>
       <Divider

--- a/client/products/memotron/home/MemotronHomeOnMobile.svelte
+++ b/client/products/memotron/home/MemotronHomeOnMobile.svelte
@@ -275,6 +275,7 @@
           parentBgIndex={2}
           on:close={() => {
             mode = undefined;
+            searchQuery = "";
           }}
         >
           <div


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes UI issues found in release testing for TASK-532. Stabilizes grid layouts, removes stray dividers, fixes responsive styling, and clears stale mobile search state.

- **Bug Fixes**
  - Records grid: on Browser access point use a 2-column grid; elsewhere use minmax(width) grid. Removed width prop from LibraryRecordsPane.
  - Panel: show the right vertical divider only when a right slot is present.
  - Account signup: apply “all” card styling only on wide screens to match the visibility check.
  - Memotron mobile: clear searchQuery when closing the modal to prevent lingering filters.

<!-- End of auto-generated description by cubic. -->


 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Cleared the mobile search field when closing search in Memotron.
  - Render the right-side divider only when right content exists.
  - Limit “Sync across devices” block and styling to non-constrained widths to avoid layout issues.

- Style
  - Updated grid behavior: two columns in browser view; default responsive widths elsewhere, with consistent gaps in grid mode.
  - Removed hardcoded width from library records, allowing natural component sizing.
  - Simplified left navigation (removed top logo/indicator) and added a styling toggle for the bottom bar (dev_mixedPanel) to control background/hover visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

**Overview**
This PR addresses several UI display and layout issues identified during release testing, focusing on adjusting component rendering based on display modes (e.g., constrained width, browser access) and includes some minor UI cleanup.

**Key Changes**
- Adjusted grid layout behavior in `Records.svelte` for `BROWSER` access points and different arrangements.
- Removed a hardcoded `width` property from `CardWrapper` in `LibraryRecordsPane.svelte`.
- Conditionalized styling in `AccountForm.svelte` to respect constrained width views.
- Introduced a `dev_mixedPanel` prop to control background styling in `LeftBottomBar.svelte` and cleaned up unused components in `LeftNavFixed.svelte`.
- Added conditional rendering for a `Divider` in `Panel.svelte` if a right slot is present.
- Reset the `searchQuery` upon closing a modal in `MemotronHomeOnMobile.svelte`.

**Recommendations**
stable for release. The PR provides targeted UI fixes and minor cleanups that improve visual consistency across different display contexts.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 19 (41.3%)    |
| Churn | 14 (30.4%) |
| Rework | 13 (28.3%) |
| Total Changes | 46 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>