### PR TITLE
feat: TASK-534 - embed color fixes

### DIFF
--- a/client/actions/popover.action.ts
+++ b/client/actions/popover.action.ts
@@ -438,7 +438,7 @@ export function popover(node: HTMLElement, params: PopoverParams) {
           if (cwModalPosition === Placement.Bottom) {
             element.style.top = `${finalTop}px`;
           } else {
-            element.style.top = "12px";
+            element.style.top = "60px";
             element.style.height = "fit-content";
           }
           element.style.opacity = "1";

--- a/client/components/calendar/CalendarCW.svelte
+++ b/client/components/calendar/CalendarCW.svelte
@@ -9,7 +9,7 @@
   let viewDate = new Date();
 </script>
 
-<div class="flex flex-col gap-6 w-full p-4">
+<main class="flex flex-col gap-6 w-full p-4 cw:pt-16">
   <!-- <Text style={TextStyle.PAGE_HEADING_SUBTLE} content="Calendar" /> -->
   <!-- <DatePickerRow
     density={Size.lg}
@@ -36,4 +36,4 @@
       />
     {/key}
   </div>
-</div>
+</main>

--- a/client/components/collection/Collection.svelte
+++ b/client/components/collection/Collection.svelte
@@ -532,13 +532,14 @@
 </script>
 
 {#if !$collection || $collection.isPageLoading || !isReady}
-  <div class="w-full h-full p-4">
+  <div class="w-full h-full p-4 cw:pt-12">
     <PageLoadingPulse />
   </div>
 {:else if $collection}
   <div
     class={cn("relative flex w-full h-full", {
-      "flex-col overflow-auto": coverPlacement === Placement.Top
+      "flex-col overflow-auto": coverPlacement === Placement.Top,
+      "cw:pt-12": !$collection.cover
     })}
     on:scroll={onScroll}
     use:resizeListener={(e) => {

--- a/client/components/collection/CollectionDescriptionEditPopover.svelte
+++ b/client/components/collection/CollectionDescriptionEditPopover.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <div
-  class="flex flex-col gap-3 p-3 w-96 max-w-full bg-bgs1 border border-brs2 rounded-md"
+  class="flex flex-col gap-3 p-3 w-96 cw:w-full max-w-full bg-bgs1 cw:border-transparent border border-brs2 rounded-md"
 >
   <TextArea
     placeholder="Add a description"

--- a/client/components/collection/CollectionTitleBar.svelte
+++ b/client/components/collection/CollectionTitleBar.svelte
@@ -157,6 +157,7 @@
           content: $collection.isInEditMode
             ? CollectionDescriptionEditPopover
             : Tooltip,
+          isRenderAsModalForCW: $view.isConstrainedWidth,
           componentProps: {
             collection,
             info: {

--- a/client/components/collection/Cover.svelte
+++ b/client/components/collection/Cover.svelte
@@ -32,7 +32,7 @@
       cover?.toString().includes("unsplash_")) &&
     isInEditMode;
 
-  $: height = isConstrainedWidth ? 100 : (size?.height ?? $view.height / 5);
+  $: height = isConstrainedWidth ? 180 : size?.height ?? $view.height / 5;
 
   function onReplace(e: MouseEvent) {
     isCoverPickerOpen = true;
@@ -226,8 +226,7 @@
 
 <style>
   .custom-gradient {
-    background-image:
-      linear-gradient(
+    background-image: linear-gradient(
         to top,
         rgba(var(--colors-fgs1), 0.8) 0%,
         rgba(var(--colors-fgs1), 0.7) 10%,

--- a/client/components/commandBar/CommandBar.svelte
+++ b/client/components/commandBar/CommandBar.svelte
@@ -22,7 +22,6 @@
   import { resolveShortcutText } from "../shortcuts/shortcut.utils";
   import { KeyboardKey, ModifierKey } from "$lib/client/types/keyboard.type";
   import KeyboardToolbar from "$lib/client/elements/keyboardToolbar/KeyboardToolbar.svelte";
-  import FullScreenCloseButton from "$lib/client/elements/button/FullScreenCloseButton.svelte";
 
   export let command: string | undefined = undefined;
   export let commandType: ActionType | undefined = undefined;
@@ -70,7 +69,7 @@
     placeholder =
       typeof searchAction.searchActionParams?.placeholder === "function"
         ? searchAction.searchActionParams.placeholder(componentParams)
-        : (searchAction.searchActionParams?.placeholder ?? "select an item");
+        : searchAction.searchActionParams?.placeholder ?? "select an item";
   }
   function close() {
     value = "";
@@ -102,7 +101,7 @@
 </script>
 
 <div
-  class={cn("flex flex-col w-full", {
+  class={cn("flex flex-col w-full cw:pt-12", {
     "border border-brs2 rounded-md": isFullPageContext,
     "h-full": !isFullPageContext || (isFullPageContext && isFocusing)
   })}
@@ -114,17 +113,17 @@
   >
     {#if isPerformingSearchAction}
       <div
-        class="h-5/6 cw:w-full cw:max-w-full max-w-60 cw:ml-0 ml-2 bg-bgs3 flex items-center cw:justify-start justify-center px-4 cw:rounded-none rounded-md truncate"
+        class="h-5/6 cw:w-full cw:flex cw:justify-between cw:max-w-full max-w-60 cw:ml-0 ml-2 bg-bgs3 flex items-center cw:justify-start justify-center px-4 cw:rounded-none rounded-md truncate"
       >
         <span class="truncate">
           {@html renderMdAsHtml(
             componentParams?.label ?? searchAction.cmdLabel
           )}
         </span>
+        {#if $view.isConstrainedWidth}
+          <Button icon="cross" tooltip="Close" on:click={close} />
+        {/if}
       </div>
-      {#if $view.isConstrainedWidth}
-        <FullScreenCloseButton path={Action.CMD} />
-      {/if}
     {/if}
     <input
       bind:this={inputRef}

--- a/client/components/commandBar/CommandBar.svelte
+++ b/client/components/commandBar/CommandBar.svelte
@@ -113,7 +113,7 @@
   >
     {#if isPerformingSearchAction}
       <div
-        class="h-5/6 cw:w-full cw:flex cw:justify-between cw:max-w-full max-w-60 cw:ml-0 ml-2 bg-bgs3 flex items-center cw:justify-start justify-center px-4 cw:rounded-none rounded-md truncate"
+        class="h-5/6 cw:w-full cw:flex cw:justify-between cw:max-w-full max-w-60 cw:ml-0 ml-2 bg-bgs3 flex items-center justify-center px-4 cw:rounded-none rounded-md truncate"
       >
         <span class="truncate">
           {@html renderMdAsHtml(

--- a/client/components/goals/Goal.svelte
+++ b/client/components/goals/Goal.svelte
@@ -222,7 +222,7 @@
       <main class="flex flex-col gap-4 flex-1 overflow-auto">
         <div
           class={cn(
-            "relative flex flex-col w-full overflow-auto gap-3 bg-bgs2 shrink-0",
+            "relative flex flex-col w-full overflow-auto gap-3 bg-bgs2 cw:pt-12 shrink-0",
             {
               "rounded-lg border border-brs3": !isConstrainedWidth,
               "border-b border-brs3": isConstrainedWidth

--- a/client/components/library/resourceBrowser/ResourceBrowser.svelte
+++ b/client/components/library/resourceBrowser/ResourceBrowser.svelte
@@ -106,6 +106,7 @@
     info={tooltip ? { body: tooltip } : undefined}
     isShowBackButton={hasBack}
     panelSize={determineSize(resource)}
+    isPreventCwPadding={true}
   >
     <div
       class="relative flex flex-col gap-4 h-full overflow-auto py-3"

--- a/client/components/modal/Modal.svelte
+++ b/client/components/modal/Modal.svelte
@@ -153,6 +153,7 @@
       )}
       {id}
       data-blank-modal={index}
+      data-modal-size={size}
       transition:fade={{ duration: 100 }}
       on:click={overlayClicked}
       role="button"

--- a/client/components/modal/ModalLayout.svelte
+++ b/client/components/modal/ModalLayout.svelte
@@ -67,7 +67,7 @@
 
 {#if size === Size.full}
   <div
-    class="w-full h-full flex justify-center items-center"
+    class="w-full h-full flex justify-center items-center cw:pt-12"
     in:fly={{
       duration: 400,
       delay: 0,
@@ -97,7 +97,8 @@
     class={cn(
       "relative modal flex flex-col items-center justify-between w-full h-full  rounded-md",
       {
-        "dark:border border-brs3": !isInFocusMode && !$view.isConstrainedWidth
+        "dark:border border-brs3": !isInFocusMode && !$view.isConstrainedWidth,
+        "cw:pt-12": !resource || params.title
       },
       !params.layout?.ignoreSafeArea && {
         "gap-4": size === Size.xs,

--- a/client/components/record/thumbnail/ResourceThumbnailContextMenu.svelte
+++ b/client/components/record/thumbnail/ResourceThumbnailContextMenu.svelte
@@ -13,6 +13,7 @@
   import { resolveGoalContextMenu } from "$lib/client/components/goals/goal.store";
   import { resolveTaskContextMenu } from "../../tasks/task.store";
   import context from "$lib/client/stores/context.store";
+  import view from "$lib/client/stores/view.store";
 
   const dispatch = createEventDispatcher();
   export let item: any;
@@ -90,7 +91,7 @@
         actionSize={bgSize ?? size}
         on:action={onAction}
         position={Placement.BottomCenter}
-        isRenderAsSibling={true}
+        isRenderAsSibling={!$view.isConstrainedWidth}
         {icon}
       />
     </div>

--- a/client/components/settings/asPage/SettingsAsPageLayout.svelte
+++ b/client/components/settings/asPage/SettingsAsPageLayout.svelte
@@ -21,7 +21,7 @@
 </script>
 
 {#if $view.isPortrait && !isCpHome}
-  <div class="flex flex-col h-full w-full gap-2 px-4 py-2">
+  <div class="flex flex-col h-full w-full gap-2 px-4 py-2 cw:pt-12">
     <NavigationHeader
       label={$appStore.currentComponent?.label ?? ""}
       backCallback={() => {

--- a/client/components/tasks/Task.svelte
+++ b/client/components/tasks/Task.svelte
@@ -257,7 +257,7 @@
 </script>
 
 <div
-  class={cn("flex p-4 mo:w-full mo:h-full h-[28rem]", {
+  class={cn("flex p-4 mo:w-full mo:h-full cw:pt-12 h-[28rem]", {
     "w-[32rem]": accessMode !== ResourceAccessMode.INLINE,
     "w-full": accessMode === ResourceAccessMode.INLINE
   })}

--- a/client/elements/contextMenu/ContextMenu.svelte
+++ b/client/elements/contextMenu/ContextMenu.svelte
@@ -11,12 +11,13 @@
   import ContextMenuItem from "./ContextMenuItem.svelte";
   import { onMount } from "svelte";
   import { ColorStrength } from "$lib/client/types/appearance.type";
+  import view from "$lib/client/stores/view.store";
   export let menuResolver: () => { group: string; items: IContextMenuItem[] }[];
   export let size: Size.sm | Size.md | Size.lg | Size.xl = Size.md;
   export let heading: string | undefined = undefined;
   export let onSelect: (item: IContextMenuItem) => void = () => {};
   export let parentBgIndex: number = 1;
-  export let isFullWidth: boolean = false;
+  export let isFullWidth: boolean = $view.isConstrainedWidth;
   export let bottomRender: string | undefined = undefined;
   let menu: IContextMenuGroup[] = [];
 
@@ -30,8 +31,8 @@
 <div
   class={cn(
     "flex flex-col gap-1 p-1 rounded-md",
-    bg(parentBgIndex),
     {
+      [bg(parentBgIndex)]: !$view.isConstrainedWidth,
       "w-full": isFullWidth,
       "border border-brs2": !isFullWidth,
       "text-b3": size === Size.sm,

--- a/client/elements/contextMenu/ContextMenuAction.svelte
+++ b/client/elements/contextMenu/ContextMenuAction.svelte
@@ -2,6 +2,7 @@
   import { popover } from "$lib/client/actions/popover.action";
   import { logger } from "$lib/client/components/debug/logger.client";
   import { createEventPropagator } from "$lib/client/components/events/event.utils";
+  import view from "$lib/client/stores/view.store";
   import { Placement } from "$lib/client/types/direction.enum";
   import {
     type IPopoverRenderBaseParams,
@@ -104,6 +105,7 @@
   use:popover={{
     placement: position,
     isSpanToTriggerWidth: false,
+    isRenderAsModalForCW: $view.isConstrainedWidth,
     offsetInPx,
     content: ContextMenu,
     triggerMethod: triggerMethod

--- a/client/elements/datetime/absolute/AbsoluteTimeRangePopoverV2.svelte
+++ b/client/elements/datetime/absolute/AbsoluteTimeRangePopoverV2.svelte
@@ -342,8 +342,8 @@
     {/if} -->
   </div>
 
-  <div class="grid grid-rows-2 gap-1">
-    <div class="grid grid-cols-6 gap-1">
+  <div class="grid grid-rows-2 gap-1 w-full">
+    <div class="grid grid-cols-6 gap-1 w-full">
       {#each MONTHS.slice(0, 6) as month, i}
         <button
           class={cn(
@@ -356,7 +356,7 @@
         </button>
       {/each}
     </div>
-    <div class="grid grid-cols-6 gap-1">
+    <div class="grid grid-cols-6 gap-1 w-full">
       {#each MONTHS.slice(6) as month, i}
         <button
           class={cn(

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -40,6 +40,7 @@
   export let isProminentDivider: boolean = false;
   export let extraLargeScreenComponent: string | undefined = undefined;
   export let info: InputLabelInfoToolTip | undefined = undefined;
+  export let isPreventCwPadding: boolean = false;
   let isExplicitlyCollapsed = false;
 
   onMount(() => {
@@ -66,7 +67,7 @@
   $: isExtraLargeScreen = $view.landscapiness > 1.7 && $view.scale > 1.8;
 </script>
 
-<div class="flex w-full h-full">
+<div class={cn("flex w-full h-full", { "cw:pt-12": !isPreventCwPadding })}>
   {#if !isCollapsed}
     <div
       class={cn(

--- a/client/products/memotron/library/search/ResourceSearchBase.svelte
+++ b/client/products/memotron/library/search/ResourceSearchBase.svelte
@@ -171,7 +171,8 @@
 
 <div
   class={cn("flex flex-col gap-4 w-full h-full", {
-    "bg-bgs2": isGlobalSearchModal && resource === Resource.everything
+    "bg-bgs2": isGlobalSearchModal && resource === Resource.everything,
+    "cw:pt-12": isGlobalSearchModal
   })}
 >
   <header class={"flex flex-col w-full"}>

--- a/client/products/pointron/analytics/AnalyticsV2.svelte
+++ b/client/products/pointron/analytics/AnalyticsV2.svelte
@@ -68,7 +68,7 @@
   }
 </script>
 
-<div class={cn("flex flex-col w-full h-full", bg(bgIndex - 1))}>
+<main class={cn("flex flex-col w-full h-full cw:pt-12", bg(bgIndex - 1))}>
   <div
     class="flex gap-8 w-full items-center justify-between portrait:px-4 portrait:py-2 portrait:pt-4 portrait:pb-2"
   >
@@ -168,4 +168,4 @@
       />
     {/if}
   {/key}
-</div>
+</main>

--- a/client/products/pointron/focus/Focus.svelte
+++ b/client/products/pointron/focus/Focus.svelte
@@ -70,7 +70,7 @@
 </script>
 
 {#if $view.isPortrait}
-  <div class="relative flex w-full h-full">
+  <main class="relative flex w-full h-full cw:pt-12">
     <div class="flex flex-col h-full w-full">
       {#if $activeSession.isSessionRunning && !$activeSession.isQuickStartOn && isInlineEnabled}
         <Zen isInline={true} />
@@ -112,7 +112,7 @@
     <!-- {#if mode === 0}
       <FloatingButton params={addManualLogButton} />
     {/if} -->
-  </div>
+  </main>
 {:else}
   <div class="flex w-full h-full">
     {#if $activeSession.isSessionRunning && !$activeSession.isQuickStartOn}

--- a/client/products/pointron/logs/logPage/SessionLogPage.svelte
+++ b/client/products/pointron/logs/logPage/SessionLogPage.svelte
@@ -17,7 +17,7 @@
   import Text from "$lib/client/elements/text/Text.svelte";
   import { TextStyle } from "$lib/client/types/text.enum";
   import ModalFooter from "$lib/client/components/modal/ModalFooter.svelte";
-  import { ButtonVariant } from "$lib/client/types/button.type";
+  import { ButtonStyle, ButtonVariant } from "$lib/client/types/button.type";
   import { PointronAction } from "$lib/client/types/pointron/pointronAction.enum";
   import FocusItem from "../../focus/elements/focusitem/FocusItem.svelte";
   import { appStore } from "$lib/client/stores/app.store";
@@ -41,6 +41,7 @@
   import { resourceInList } from "$lib/client/components/flux/resourceStores/resource.utils";
   import { logger } from "$lib/client/components/debug/logger.client";
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
+  import Button from "$lib/client/elements/button/Button.svelte";
 
   export let id: string;
   export let log: any = undefined;
@@ -104,13 +105,20 @@
     loadingText="Loading..."
   />
 {:then}
-  <div class="flex flex-col gap-4 flex-grow w-full items-center p-4 userdata">
-    {#if accessMode === ResourceAccessMode.SPLIT || accessMode === ResourceAccessMode.FSPLIT || $view.isConstrainedWidth}
-      <div class="flex gap-4 w-full justify-between">
-        <Text content="Session details" style={TextStyle.PANEL_HEADING} />
-      </div>
-      <FullScreenCloseButton {accessMode} />
-    {/if}
+  <div
+    class="flex flex-col gap-6 flex-grow w-full items-center userdata cw:pt-12"
+  >
+    <div class="flex gap-4 w-full items-center justify-between">
+      <Text content="Session details" style={TextStyle.PANEL_HEADING} />
+      {#if accessMode === ResourceAccessMode.SPLIT || accessMode === ResourceAccessMode.FSPLIT || $view.isConstrainedWidth}
+        <Button
+          icon="cross"
+          style={ButtonStyle.OUTLINED}
+          tooltip="Close"
+          on:click={() => appStore.closeResource({ accessMode })}
+        />
+      {/if}
+    </div>
     <LogIntervalBar {log} />
     {#if log?.plannedEndUnix && !isSameDateTime( new Date(log.endUnix), new Date(log.plannedEndUnix), { isIgnoreSeconds: true } ) && new Date(log.endUnix).getTime() < new Date(log.plannedEndUnix).getTime()}
       <InlineInfoBanner>

--- a/client/utils/embed.utils.ts
+++ b/client/utils/embed.utils.ts
@@ -36,6 +36,10 @@ export function postDataToParent(key: EmbedDataMessage, data: any) {
   });
 }
 
+/**
+ * @deprecated - No longer required - using direct cw:pt-12 at relevant places
+ * @param bg
+ */
 export function setEmbedBg(bg: number) {
   postDataToParent(EmbedDataMessage.BG, bg);
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes embed color bleed and header overlap in constrained-width (CW) mode by standardizing top padding and modal/menu behavior. Improves visual consistency for embeds and mobile layouts per TASK-534.

- **Bug Fixes**
  - Standardized CW top spacing using cw:pt-12/16 across Calendar, Collections, Command Bar, Goals, Settings, Tasks, Analytics, Focus, Session Log, Search, Modals, and Panels.
  - Render popovers/menus as modals on CW (isRenderAsModalForCW); default ContextMenu to full-width on CW and drop parent bg to avoid color mismatch; avoid sibling rendering for thumbnail menu on CW.
  - Increased collection cover height on CW to 180px; minor gradient cleanup.
  - Raised popover offset to 60px when not bottom-placed to clear headers in embeds.
  - Replaced FullScreenCloseButton with inline Close buttons in Command Bar and Session Log (shown on CW/split modes).
  - Added Panel prop isPreventCwPadding (used by ResourceBrowser) to opt out where needed.
  - Modal tweaks: cw:pt-12 for full-size/layout containers; expose data-modal-size for styling hooks.
  - Deprecated setEmbedBg in embed.utils; rely on direct CW padding.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Popovers and context menus adapt on constrained screens: popovers render as modals; context menus default to full width.
  - New close button in Command Bar and Session Details headers for easier dismissal on small screens.

- Style
  - Consistent top padding applied across many views on constrained layouts for improved spacing.
  - Calendar, Analytics, and Focus pages use semantic main containers.
  - Cover images are taller on constrained layouts for better visual balance.
  - Various layout tweaks: full-width sections, refined backgrounds, and adjusted popover entry positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->