### PR TITLE
feat: TASK-538

### DIFF
--- a/client/actions/popover.action.ts
+++ b/client/actions/popover.action.ts
@@ -3,7 +3,6 @@ import { Placement } from "../types/direction.enum";
 import { PopoverTriggerMethod } from "../types/popover.type";
 import { detectTouchDevice, getEventPath } from "../utils/browser.utils";
 import { renderMdAsHtml } from "../components/markdown/markdown.utils";
-import { setEmbedBg } from "../utils/embed.utils";
 import { GlobalEvent } from "../types/event.enum";
 
 interface TooltipReturn {
@@ -442,7 +441,6 @@ export function popover(node: HTMLElement, params: PopoverParams) {
             element.style.height = "fit-content";
           }
           element.style.opacity = "1";
-          setEmbedBg(100);
           if (cwModalOverlay) cwModalOverlay.style.opacity = "1";
         }
       });
@@ -704,7 +702,6 @@ export function popover(node: HTMLElement, params: PopoverParams) {
     if (cwModalOverlay) {
       cwModalOverlay.style.opacity = "0";
       cwModalOverlay.remove();
-      setEmbedBg(1);
       propagateNavEvent("popover");
     }
     isShown = false;

--- a/client/components/calendar/Calendar.svelte
+++ b/client/components/calendar/Calendar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import BirdCalendar from "./birdViewV2/BirdCalendar.svelte";
   import ClassicCalendar from "./classic/ClassicCalendar.svelte";
   import { CalendarLayout } from "./calendar.type";
@@ -10,12 +9,7 @@
   } from "$lib/client/stores/uiState/uiState.type";
   import view from "$lib/client/stores/view.store";
   import CalendarCw from "./CalendarCW.svelte";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
   export let panel: CalendarLayout = resolvePanelSelection();
-
-  onMount(() => {
-    setEmbedBg(1);
-  });
 
   function resolvePanelSelection() {
     const layoutState = uiState.getState(UIState.calendarLayout, {

--- a/client/components/calendar/classic/YearViewV2.svelte
+++ b/client/components/calendar/classic/YearViewV2.svelte
@@ -394,7 +394,7 @@
             </button>
           </div>
           <div
-            class="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-x-16 gap-y-12 default-typeface"
+            class="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-x-12 gap-y-8 default-typeface"
           >
             {#each months as { days, monthIndex }}
               {@const isFutureMonth = resolveIfFutureMonth(year, monthIndex)}
@@ -404,14 +404,17 @@
                 selectedDate.getFullYear() === year &&
                 selectedDate.getMonth() === monthIndex}
               <div
-                class={cn("flex flex-col min-w-[240px]", {
-                  "bg-bgs2 rounded-md": isSelectedMonth
-                })}
+                class={cn(
+                  "flex flex-col min-w-[240px] p-4 transition-all duration-300 has-[.first:hover]:bg-bgs2 rounded-md",
+                  {
+                    "bg-bgs2": isSelectedMonth
+                  }
+                )}
                 id="month-{year}-{monthIndex}"
               >
                 <button
                   class={cn(
-                    "flex items-center gap-1 mb-1 ml-3 font-medium text-h5 hover:text-aps1 transition-colors cursor-pointer text-left",
+                    "first flex items-center gap-1 mb-1 ml-3 font-medium text-h5 hover:text-aps1 transition-colors cursor-pointer text-left",
                     {
                       "text-fgs4": isFutureMonth && !isSelectedMonth,
                       "text-fgs1":

--- a/client/components/calendar/classic/YearViewV2.svelte
+++ b/client/components/calendar/classic/YearViewV2.svelte
@@ -7,6 +7,7 @@
   import { preferences } from "$lib/client/stores/preferences/preferences.store";
   import { Preference } from "$lib/client/stores/preferences/preferences.type";
   import { TimeScaleUnit } from "$lib/client/types/time.type";
+  import { logger } from "$lib/client/components/debug/logger.client";
 
   export let selectedDate: Date;
   export let indicatorData: ICalendarIndicatorData[] = [];
@@ -250,9 +251,12 @@
     const targetYear = date.getFullYear();
 
     if (targetYear < BASE_YEAR || targetYear >= BASE_YEAR + YEAR_RANGE) {
-      console.warn(
-        `Year ${targetYear} is outside the supported range (${BASE_YEAR} - ${BASE_YEAR + YEAR_RANGE - 1})`
-      );
+      logger.error({
+        at: "YearViewV2.scrollToDate",
+        message: `Year ${targetYear} is outside the supported range (${BASE_YEAR} - ${BASE_YEAR + YEAR_RANGE - 1})`,
+        targetYear,
+        supportedRange: { min: BASE_YEAR, max: BASE_YEAR + YEAR_RANGE - 1 }
+      });
       return;
     }
 

--- a/client/components/calendar/column/CalendarColumn.svelte
+++ b/client/components/calendar/column/CalendarColumn.svelte
@@ -32,6 +32,7 @@
   import view from "$lib/client/stores/view.store";
   import { resolveCalendarNotesId } from "../calendar.utils";
   import { ResourceAccessMode } from "../../flux/resourceStores/resource.type";
+  import { AppSearchParam } from "$lib/client/types/appStore.type";
   const dispatch = createEventDispatcher();
 
   export let scale: TimeScaleUnit;
@@ -41,7 +42,7 @@
   export let isRewind: boolean = false;
   export let isCwContext: boolean = false;
   let mdId = generateSimpleRandomId();
-  const backPath = $page.url.searchParams.get("back");
+  const backPath = $page.url.searchParams.get(AppSearchParam.RETURN_TO);
 
   let selectedPanel: CalendarColumnPanel = resolvePanelSelection();
 

--- a/client/components/collection/Collection.svelte
+++ b/client/components/collection/Collection.svelte
@@ -84,6 +84,7 @@
   import Icon from "$lib/client/elements/Icon.svelte";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
   import { resolveResourceStore } from "../flux/resourceStores/store.resolver";
+  import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
 
   export let id: string = "";
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.SELF;
@@ -272,9 +273,10 @@
     );
   }
 
+  let positionFromTop: number | undefined = undefined;
   function onScroll() {
     var elementTarget = document.querySelector(".stickyheader");
-    var positionFromTop = elementTarget?.getBoundingClientRect().top;
+    positionFromTop = elementTarget?.getBoundingClientRect().top;
     isStickied = positionFromTop ? positionFromTop <= 0 : false;
   }
 
@@ -538,8 +540,7 @@
 {:else if $collection}
   <div
     class={cn("relative flex w-full h-full", {
-      "flex-col overflow-auto": coverPlacement === Placement.Top,
-      "cw:pt-12": !$collection.cover
+      "flex-col overflow-auto": coverPlacement === Placement.Top
     })}
     on:scroll={onScroll}
     use:resizeListener={(e) => {
@@ -602,7 +603,7 @@
           </button>
         {/if}
         <div
-          class={cn("px-4 stickyheader", {
+          class={cn("px-4 stickyheader transition-all duration-300", {
             "sticky top-0": isSingleViewMode,
             [bg(parentBgIndex - 1)]: isSingleViewMode,
             // When in edit mode, interfering with view settings dropdown when the dropdown opens on top if z-20 is set
@@ -610,6 +611,9 @@
             "pb-8": isSingleViewMode && !isShowMetaViews && !isConstrainedWidth,
             "pt-6": !isConstrainedWidth,
             "p-2": isConstrainedWidth,
+            "cw:pt-12":
+              isConstrainedWidth &&
+              (!$collection.cover || positionFromTop === 0),
             "max-w-full overflow-x-auto":
               accessPoint === ResourceAccessPoint.MARKDOWN_EMBED
           })}
@@ -655,17 +659,18 @@
                 {$collection.description}
               </div>
             {/if} -->
-            <div class="flex items-center justify-center">
+            <div class="flex items-center justify-center gap-1.5">
               <InlineSearchBar
                 bind:query={searchQuery}
                 style={InputStyle.FILLED}
                 on:search={onSearch}
-                placeholder={`Search this collection (${$collection.totalItemCount ?? 0} items)`}
-              >
-                {#if !$collection.isInEditMode}
-                  <AddResourceAction on:add={onAddResource} variant="minimal" />
-                {/if}
-              </InlineSearchBar>
+                placeholder={$collection.totalItemCount
+                  ? `Search this collection (${$collection.totalItemCount ?? 0} items)`
+                  : "No items found"}
+              />
+              {#if !$collection.isInEditMode}
+                <AddResourceAction on:add={onAddResource} variant="minimal" />
+              {/if}
             </div>
           </div>
         {/if}
@@ -702,10 +707,10 @@
         {#if (activeView && isValidString(activeView.tabBy)) || $collection.isInEditMode || !isSingleViewMode}
           <header
             class={cn(
-              "sticky top-0 z-10 flex flex-col gap-6 w-full",
+              "sticky top-0 z-10 flex flex-col gap-6 w-full transition-all duration-300",
               bg(parentBgIndex - 1),
               {
-                "pt-4": isStickied
+                "pt-4 cw:pt-12": isStickied
               }
             )}
           >
@@ -719,7 +724,6 @@
                 isExpandToFullWidth={true}
                 barStyle={BarStyle.EXACT}
                 isInEditMode={$collection.isInEditMode}
-                isRenderDropdownForCW={true}
                 {parentBgIndex}
                 bind:triggerItemEdit
                 on:remove={onViewRemove}
@@ -856,3 +860,4 @@
   subscribeToContext={new Set([id.toString()])}
   on:change={() => refresh()}
 />
+<ComponentEmbedLayer isBackNavigable={true} />

--- a/client/components/collection/Collection.svelte
+++ b/client/components/collection/Collection.svelte
@@ -275,9 +275,9 @@
 
   let positionFromTop: number | undefined = undefined;
   function onScroll() {
-    var elementTarget = document.querySelector(".stickyheader");
+    const elementTarget = document.querySelector(".stickyheader");
     positionFromTop = elementTarget?.getBoundingClientRect().top;
-    isStickied = positionFromTop ? positionFromTop <= 0 : false;
+    isStickied = positionFromTop !== undefined ? positionFromTop <= 0 : false;
   }
 
   async function onViewSwitch() {
@@ -385,7 +385,6 @@
   }
 
   async function onTabSwitch(e: CustomEvent) {
-    // console.log("onTabSwitch", selectedTab);
     await refresh();
   }
 

--- a/client/components/collection/CollectionTitleBar.svelte
+++ b/client/components/collection/CollectionTitleBar.svelte
@@ -138,50 +138,45 @@
           on:debouncedChange={onLabelChange}
         />
       {:else}
-        <div class="truncate userdata">
-          {$collection.label ?? "Untitled collection"}
-        </div>
+        {@const title = ($collection.label ?? "").trim() || "Untitled collection"}
+        <div class="truncate userdata">{title}</div>
       {/if}
       {#if ($collection.description && isDetailsBesideTitleRenderable) || $collection.isInEditMode}
-        <span
+        {@const popoverComponent = $collection.isInEditMode ? CollectionDescriptionEditPopover : Tooltip}
+        {@const popoverProps = $collection.isInEditMode 
+          ? { collection } 
+          : { info: { body: $collection.description, size: Size.sm } }}
+        <button
           class="flex justify-center items-center"
           use:popover={{
             triggerMethod: $collection.isInEditMode
               ? [PopoverTriggerMethod.CLICK]
               : [PopoverTriggerMethod.HOVER, PopoverTriggerMethod.CLICK],
-            content: $collection.isInEditMode
-              ? CollectionDescriptionEditPopover
-              : Tooltip,
-            isRenderAsModalForCW: $view.isConstrainedWidth,
-            componentProps: {
-              collection,
-              info: {
-                body: $collection.description,
-                size: Size.sm
-              }
-            }
+            content: popoverComponent,
+            isRenderAsModalForCW: isConstrainedWidth,
+            componentProps: popoverProps
           }}
           use:tooltip={{
             disabled: !$collection.isInEditMode,
             text: "Collection description"
           }}
+          type="button"
+          aria-label="Collection description"
         >
           <Icon icon="info" size={Size.sm} />
-        </span>
+        </button>
       {/if}
       {#if $collection.isStarred && isDetailsBesideTitleRenderable}
         <button
           class="flex items-center justify-center"
-          use:tooltip={{
-            text: "Unstar collection"
-          }}
+          type="button"
+          aria-pressed={$collection.isStarred}
+          on:click={() => { collection.modify({ isStarred: false }); }}
+          use:tooltip={{ text: "Unstar collection" }}
         >
           <RecordStarStatusFeedback
             isStarred={$collection.isStarred}
             size={Size.md}
-            on:click={() => {
-              collection.modify({ isStarred: false });
-            }}
           />
         </button>
       {/if}
@@ -214,7 +209,7 @@
           on:click={openPropertiesEditor}
         >
           <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
-          edit properties ({$collection.properties?.length ?? 0})
+          Edit properties ({$collection.properties?.length ?? 0})
         </button>
       {/if}
     </span>

--- a/client/components/collection/CollectionTitleBar.svelte
+++ b/client/components/collection/CollectionTitleBar.svelte
@@ -33,6 +33,7 @@
   import { Resource } from "../flux/resourceStores/resource.enum";
   import CollectionDescriptionEditPopover from "./CollectionDescriptionEditPopover.svelte";
   import RecordStarStatusFeedback from "../record/RecordStarStatusFeedback.svelte";
+  import BackButton from "$lib/client/elements/button/BackButton.svelte";
 
   const dispatch = createEventDispatcher();
   export let searchQuery: string = "";
@@ -84,145 +85,140 @@
   class="w-full flex gap-1 justify-between items-center sticky- top--0 py--6"
 >
   <!-- TODO breadcrumbs - if launched as child from a combination i.e. if parent present, back button to previous resource - if launched from a mention or links -->
-  {#if isConstrainedWidth && accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
-    <button
-      class="flex active:bg-bgs2 rounded-md p-1"
-      on:click={() => {
-        appStore.goBack();
-        // appStore.closeResource({
-        //   id: collection.id
-        // });
-      }}
-    >
-      <Icon icon="chevron-left" size={Size.lg} />
-    </button>
-  {/if}
-  {#if $collection.type === CollectionType.TYPED}
-    {@const avatar =
-      !$collection.avatar || objIsEmpty($collection.avatar)
-        ? $collection.typeToExtend?.avatar
-        : $collection.avatar}
-    {@const isAvatarPresent = isValidAvatar(avatar)}
-    <span
-      class={cn("flex h-12 items-center justify-center", {
-        "w-12": $collection.isInEditMode,
-        "w-8": isAvatarPresent && !$collection.isInEditMode
-      })}
-    >
-      {#if $collection.isInEditMode}
-        <Avatar
-          bind:avatar={$collection.avatar}
-          isInEditMode={true}
-          on:change={onAvatarChange}
-          size={Size.lg}
-        />
-      {:else if isAvatarPresent}
-        <Avatar {avatar} isInEditMode={false} size={Size.lg} />
-      {/if}
-    </span>
-  {/if}
-  <span
-    class={cn(
-      "flex items-center gap-4 font-medium cw:text-h4 cw:h-12 text-h1 whitespace-nowrap flex-1 min-w-0 border rounded-md text-left cw:mr-0 mr-6",
-      {
-        "border-transparent": !$collection.isInEditMode,
-        "border-brs3 px-2": $collection.isInEditMode
-      }
-    )}
+
+  <BackButton
+    isEnabled={!$collection.isInEditMode &&
+      isConstrainedWidth &&
+      accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
+    accessMode={$collection.accessMode}
   >
-    <!-- {#if $collection.avatar}
-      <AvatarView avatar={$collection.avatar} size={Size.lg} />
-    {/if} -->
-    {#if $collection.isInEditMode}
-      <TextInput
-        size={Size.lg}
-        bind:value={$collection.label}
-        placeholder="Collection title"
-        style={InputStyle.PLAIN}
-        width="w-full"
-        on:debouncedChange={onLabelChange}
-      />
-    {:else}
-      <div class="truncate userdata">
-        {$collection.label ?? "Untitled collection"}
-      </div>
-    {/if}
-    {#if ($collection.description && isDetailsBesideTitleRenderable) || $collection.isInEditMode}
+    {#if $collection.type === CollectionType.TYPED}
+      {@const avatar =
+        !$collection.avatar || objIsEmpty($collection.avatar)
+          ? $collection.typeToExtend?.avatar
+          : $collection.avatar}
+      {@const isAvatarPresent = isValidAvatar(avatar)}
       <span
-        class="flex justify-center items-center"
-        use:popover={{
-          triggerMethod: $collection.isInEditMode
-            ? [PopoverTriggerMethod.CLICK]
-            : [PopoverTriggerMethod.HOVER, PopoverTriggerMethod.CLICK],
-          content: $collection.isInEditMode
-            ? CollectionDescriptionEditPopover
-            : Tooltip,
-          isRenderAsModalForCW: $view.isConstrainedWidth,
-          componentProps: {
-            collection,
-            info: {
-              body: $collection.description,
-              size: Size.sm
-            }
-          }
-        }}
-        use:tooltip={{
-          disabled: !$collection.isInEditMode,
-          text: "Collection description"
-        }}
+        class={cn("flex h-12 items-center justify-center", {
+          "w-12": $collection.isInEditMode,
+          "w-8": isAvatarPresent && !$collection.isInEditMode
+        })}
       >
-        <Icon icon="info" size={Size.sm} />
+        {#if $collection.isInEditMode}
+          <Avatar
+            bind:avatar={$collection.avatar}
+            isInEditMode={true}
+            on:change={onAvatarChange}
+            size={Size.lg}
+          />
+        {:else if isAvatarPresent}
+          <Avatar {avatar} isInEditMode={false} size={Size.lg} />
+        {/if}
       </span>
     {/if}
-    {#if $collection.isStarred && isDetailsBesideTitleRenderable}
-      <button
-        class="flex items-center justify-center"
-        use:tooltip={{
-          text: "Unstar collection"
-        }}
-      >
-        <RecordStarStatusFeedback
-          isStarred={$collection.isStarred}
-          size={Size.md}
-          on:click={() => {
-            collection.modify({ isStarred: false });
-          }}
+    <span
+      class={cn(
+        "flex items-center gap-4 font-medium cw:text-h4 cw:h-12 text-h1 whitespace-nowrap flex-1 min-w-0 border rounded-md text-left cw:mr-0 mr-6",
+        {
+          "border-transparent": !$collection.isInEditMode,
+          "border-brs3 px-2": $collection.isInEditMode
+        }
+      )}
+    >
+      <!-- {#if $collection.avatar}
+      <AvatarView avatar={$collection.avatar} size={Size.lg} />
+    {/if} -->
+      {#if $collection.isInEditMode}
+        <TextInput
+          size={Size.lg}
+          bind:value={$collection.label}
+          placeholder="Collection title"
+          style={InputStyle.PLAIN}
+          width="w-full"
+          on:debouncedChange={onLabelChange}
         />
-      </button>
-    {/if}
-    {#if !$collection.isInEditMode && $collection.type === CollectionType.TYPED && isDetailsBesideTitleRenderable}
-      <button
-        class="flex text-b3 text-fgs3 rounded-md border border-brs3"
-        on:click={openPropertiesEditor}
-        use:tooltip={{
-          text: "Edit properties"
-        }}
-      >
-        <span class="flex gap-2 items-center px-2 py-0.5">
-          <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
-          {$collection.properties?.length ?? 0}
-          {#if !isConstrainedWidth && !isMiniSearch}
-            {($collection.properties?.length ?? 0) === 1
-              ? "property"
-              : "properties"}
-          {/if}
+      {:else}
+        <div class="truncate userdata">
+          {$collection.label ?? "Untitled collection"}
+        </div>
+      {/if}
+      {#if ($collection.description && isDetailsBesideTitleRenderable) || $collection.isInEditMode}
+        <span
+          class="flex justify-center items-center"
+          use:popover={{
+            triggerMethod: $collection.isInEditMode
+              ? [PopoverTriggerMethod.CLICK]
+              : [PopoverTriggerMethod.HOVER, PopoverTriggerMethod.CLICK],
+            content: $collection.isInEditMode
+              ? CollectionDescriptionEditPopover
+              : Tooltip,
+            isRenderAsModalForCW: $view.isConstrainedWidth,
+            componentProps: {
+              collection,
+              info: {
+                body: $collection.description,
+                size: Size.sm
+              }
+            }
+          }}
+          use:tooltip={{
+            disabled: !$collection.isInEditMode,
+            text: "Collection description"
+          }}
+        >
+          <Icon icon="info" size={Size.sm} />
         </span>
-        {#if $collection.typeToExtend}
-          <span class="flex rounded-r-md bg-bgs2 px-2 py-0.5">
-            + {$collection.typeToExtend.properties?.length ?? 0}
+      {/if}
+      {#if $collection.isStarred && isDetailsBesideTitleRenderable}
+        <button
+          class="flex items-center justify-center"
+          use:tooltip={{
+            text: "Unstar collection"
+          }}
+        >
+          <RecordStarStatusFeedback
+            isStarred={$collection.isStarred}
+            size={Size.md}
+            on:click={() => {
+              collection.modify({ isStarred: false });
+            }}
+          />
+        </button>
+      {/if}
+      {#if !$collection.isInEditMode && $collection.type === CollectionType.TYPED && isDetailsBesideTitleRenderable}
+        <button
+          class="flex text-b3 text-fgs3 rounded-md border border-brs3"
+          on:click={openPropertiesEditor}
+          use:tooltip={{
+            text: "Edit properties"
+          }}
+        >
+          <span class="flex gap-2 items-center px-2 py-0.5">
+            <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
+            {$collection.properties?.length ?? 0}
+            {#if !isConstrainedWidth && !isMiniSearch}
+              {($collection.properties?.length ?? 0) === 1
+                ? "property"
+                : "properties"}
+            {/if}
           </span>
-        {/if}
-      </button>
-    {:else if $collection.isInEditMode && $collection.type === CollectionType.TYPED && !isConstrainedWidth}
-      <button
-        class="flex text-b3 text-fgs3 rounded-md border border-brs3 px-2 py-0.5 items-center gap-1 hover:bg-bgs2"
-        on:click={openPropertiesEditor}
-      >
-        <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
-        edit properties ({$collection.properties?.length ?? 0})
-      </button>
-    {/if}
-  </span>
+          {#if $collection.typeToExtend}
+            <span class="flex rounded-r-md bg-bgs2 px-2 py-0.5">
+              + {$collection.typeToExtend.properties?.length ?? 0}
+            </span>
+          {/if}
+        </button>
+      {:else if $collection.isInEditMode && $collection.type === CollectionType.TYPED && !isConstrainedWidth}
+        <button
+          class="flex text-b3 text-fgs3 rounded-md border border-brs3 px-2 py-0.5 items-center gap-1 hover:bg-bgs2"
+          on:click={openPropertiesEditor}
+        >
+          <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
+          edit properties ({$collection.properties?.length ?? 0})
+        </button>
+      {/if}
+    </span>
+  </BackButton>
 
   {#if isConstrainedWidth && accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
     <ContextMenuAction

--- a/client/components/collection/collection.store.ts
+++ b/client/components/collection/collection.store.ts
@@ -376,7 +376,7 @@ export class ActiveCollectionStore extends ActiveResourceStore<
       });
       if (!result) return;
       this.update((val) => {
-        val.properties = result.properties;
+        val.properties = result.properties ?? [];
         val.typeToExtend = result.typeToExtend;
         return val;
       });

--- a/client/components/flux/resourceStores/resource.store.ts
+++ b/client/components/flux/resourceStores/resource.store.ts
@@ -144,14 +144,17 @@ export class ActiveResourceStore<
   }
   /**
    * Removed dependency on appStore to avoid circular dependency issues on Clipper extension.
+   *
+   * Note: Disabling url search param due to circular loop issue on back click on mobile devices
+   *
    * @param val
    * @returns
    */
   toggleEditMode(val: boolean) {
-    dispatchCustomEvent(
-      GlobalEvent.TOGGLE_SEARCH_PARAM,
-      val ? { [AppSearchParam.EDIT]: true } : [AppSearchParam.EDIT]
-    );
+    // dispatchCustomEvent(
+    //   GlobalEvent.TOGGLE_SEARCH_PARAM,
+    //   val ? { [AppSearchParam.EDIT]: true } : [AppSearchParam.EDIT]
+    // );
     return this.update((prev) => ({ ...prev, isInEditMode: val }));
   }
   toggleLock(val: boolean) {

--- a/client/components/library/Library.svelte
+++ b/client/components/library/Library.svelte
@@ -211,6 +211,7 @@
   <div slot="nav" class="flex flex-grow">
     <ResourceBrowser
       resource={selectedResource}
+      isPreventCwPadding={true}
       onBack={() => {
         selectedResource = Resource.unknown;
         appStore.toggleSearchParam([AppSearchParam.RESOURCE]);

--- a/client/components/library/LibraryRecordsPane.svelte
+++ b/client/components/library/LibraryRecordsPane.svelte
@@ -515,7 +515,7 @@
         padding="px-2"
         on:search={() => refresh()}
         placeholder={"Search " + resource + "s"}
-        style={InputStyle.BORDERED}
+        style={InputStyle.FILLED}
       >
         <Toggle
           bind:on={isRefineShown}

--- a/client/components/library/resourceBrowser/ResourceBrowser.svelte
+++ b/client/components/library/resourceBrowser/ResourceBrowser.svelte
@@ -24,10 +24,11 @@
   import { keyboardShortcuts } from "../../shortcuts/shortcuts.store";
   import ComponentShortcutListener from "../../shortcuts/ComponentShortcutListener.svelte";
   import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
+  import { AppSearchParam } from "$lib/client/types/appStore.type";
   export let resource: Resource;
   export let onBack: (() => void) | undefined = undefined;
   export let isPreventCwPadding: boolean = false;
-  const backPath = $page.url.searchParams.get("back");
+  const backPath = $page.url.searchParams.get(AppSearchParam.RETURN_TO);
   const hasBack = onBack !== undefined || backPath !== null;
 
   let searchQuery: string = "";

--- a/client/components/library/resourceBrowser/ResourceBrowser.svelte
+++ b/client/components/library/resourceBrowser/ResourceBrowser.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import Panel from "$lib/client/layout/paint/Panel.svelte";
   import { ButtonVariant } from "$lib/client/types/button.type";
   import { Arrangement } from "$lib/client/types/direction.enum";
@@ -24,15 +23,13 @@
   import { isHideCreateAction, resolveResourceTooltip } from "../library.utils";
   import { keyboardShortcuts } from "../../shortcuts/shortcuts.store";
   import ComponentShortcutListener from "../../shortcuts/ComponentShortcutListener.svelte";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
+  import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
   export let resource: Resource;
   export let onBack: (() => void) | undefined = undefined;
+  export let isPreventCwPadding: boolean = false;
   const backPath = $page.url.searchParams.get("back");
   const hasBack = onBack !== undefined || backPath !== null;
 
-  onMount(() => {
-    setEmbedBg(1);
-  });
   let searchQuery: string = "";
   let id: string | null = null;
   let arrangement: Arrangement = resolveArrangement();
@@ -106,7 +103,7 @@
     info={tooltip ? { body: tooltip } : undefined}
     isShowBackButton={hasBack}
     panelSize={determineSize(resource)}
-    isPreventCwPadding={true}
+    {isPreventCwPadding}
   >
     <div
       class="relative flex flex-col gap-4 h-full overflow-auto py-3"
@@ -147,3 +144,4 @@
     ]}
   />
 {/if}
+<ComponentEmbedLayer isBackNavigable={true} />

--- a/client/components/settings/asPage/SettingsAsPage.svelte
+++ b/client/components/settings/asPage/SettingsAsPage.svelte
@@ -9,7 +9,7 @@
   import { appStore } from "$lib/client/stores/app.store";
   import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
   $: route = $page.url.searchParams.get(AppSearchParam.SETTING);
-  const backPath = $page.url.searchParams.get("back");
+  const backPath = $page.url.searchParams.get(AppSearchParam.RETURN_TO);
 </script>
 
 {#if $view.isConstrainedWidth}

--- a/client/components/settings/asPage/SettingsAsPage.svelte
+++ b/client/components/settings/asPage/SettingsAsPage.svelte
@@ -6,23 +6,10 @@
   import view from "$lib/client/stores/view.store";
   import SettingsAsModal from "../SettingsAsModal.svelte";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
-  import { onMount } from "svelte";
-  import context from "$lib/client/stores/context.store";
-  import { Embed } from "$lib/client/types/context.type";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
   import { appStore } from "$lib/client/stores/app.store";
+  import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
   $: route = $page.url.searchParams.get(AppSearchParam.SETTING);
   const backPath = $page.url.searchParams.get("back");
-  $: if (route && $context.embed == Embed.HANDSET) {
-    setEmbedBg(1);
-  } else if ($context.embed == Embed.HANDSET) {
-    setEmbedBg(2);
-  }
-  onMount(async () => {
-    if ($context.embed == Embed.HANDSET) {
-      setEmbedBg(2);
-    }
-  });
 </script>
 
 {#if $view.isConstrainedWidth}
@@ -43,3 +30,4 @@
 {:else}
   <SettingsAsModal />
 {/if}
+<ComponentEmbedLayer isBackNavigable={true} />

--- a/client/elements/InlineSearchBar.svelte
+++ b/client/elements/InlineSearchBar.svelte
@@ -12,7 +12,7 @@
   export let query: string = "";
   export let size: Size = Size.md;
   export let placeholder: string = "Search";
-  export let parentBgIndex: number = 0;
+  export let parentBgIndex: number = 1;
   export let style: InputStyle = InputStyle.PLAIN;
   export let isPadded: boolean = false;
   export let padding: string = "";

--- a/client/elements/NavigationHeader.svelte
+++ b/client/elements/NavigationHeader.svelte
@@ -11,6 +11,7 @@
 
 <div class="flex justify-between items-center w-full {height}">
   <BackButton
+    isPreventDefault={true}
     on:click={() => {
       haptic();
       backCallback();

--- a/client/elements/button/BackButton.svelte
+++ b/client/elements/button/BackButton.svelte
@@ -1,14 +1,61 @@
 <script lang="ts">
+  import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
   import { Size } from "$lib/client/types/size.enum";
+  import { bg, cn } from "$lib/client/utils/ui.utils";
+  import { createEventDispatcher } from "svelte";
   import Icon from "../Icon.svelte";
-  export let color: string = "";
+  import view from "$lib/client/stores/view.store";
+  import { appStore } from "$lib/client/stores/app.store";
+  import modalEvent from "$lib/client/components/modal/modal.store";
+  import { haptic } from "$lib/client/utils/embed.utils";
+  const dispatch = createEventDispatcher();
   export let text: string | undefined = undefined;
+  export let parentBgIndex: number = 1;
+  export let isEnabled: boolean = true;
+  export let path: string | undefined = undefined;
+  export let accessMode: ResourceAccessMode = ResourceAccessMode.FULL;
+  export let isPreventDefault: boolean = false;
+  let classList: string = "";
+  export { classList as class };
+
+  function onBack() {
+    if (!isEnabled) return;
+    haptic();
+    if (isPreventDefault) {
+      dispatch("click");
+      return;
+    }
+    if ($view.isConstrainedWidth && !path) appStore.goBack();
+    appStore.closeResource({ accessMode });
+    if (path) modalEvent.hide(path, "ModalCloseButton.svelte");
+  }
 </script>
 
-<button
-  class="flex items-center active:bg-bgs2 notouch:hover:bg-bgs2 rounded-r-md rounded-l-full"
-  on:click
->
-  <Icon icon="chevleft" size={Size.sm} />
-  <div class="pr-1 text-fgs1">{text ?? "Back"}</div>
-</button>
+{#if $$slots.default}
+  <button
+    class={cn(
+      "flex items-center gap-2 rounded-md px-1",
+      classList,
+      `active:${bg(parentBgIndex)}`,
+      {
+        "cursor-pointer": isEnabled,
+        "cursor-default": !isEnabled
+      }
+    )}
+    tabindex={isEnabled ? 0 : -1}
+    on:click={onBack}
+  >
+    {#if isEnabled}
+      <Icon icon="chevron-left" class="text-fgs3 opacity-40" size={Size.lg} />
+    {/if}
+    <slot />
+  </button>
+{:else}
+  <button
+    class="flex items-center active:bg-bgs2 notouch:hover:bg-bgs2 rounded-r-md rounded-l-full p-1"
+    on:click={onBack}
+  >
+    <Icon icon="chevleft" size={Size.sm} />
+    <div class="pr-1 text-fgs1">{text ?? "Back"}</div>
+  </button>
+{/if}

--- a/client/elements/button/BackButton.svelte
+++ b/client/elements/button/BackButton.svelte
@@ -36,13 +36,15 @@
     class={cn(
       "flex items-center gap-2 rounded-md px-1",
       classList,
-      `active:${bg(parentBgIndex)}`,
       {
+[`active:${bg(parentBgIndex)}`]: isEnabled,
         "cursor-pointer": isEnabled,
         "cursor-default": !isEnabled
       }
     )}
     tabindex={isEnabled ? 0 : -1}
+    aria-disabled={!isEnabled}
+    disabled={!isEnabled}
     on:click={onBack}
   >
     {#if isEnabled}
@@ -53,6 +55,8 @@
 {:else}
   <button
     class="flex items-center active:bg-bgs2 notouch:hover:bg-bgs2 rounded-r-md rounded-l-full p-1"
+    aria-disabled={!isEnabled}
+    disabled={!isEnabled}
     on:click={onBack}
   >
     <Icon icon="chevleft" size={Size.sm} />

--- a/client/elements/button/BackButton.svelte
+++ b/client/elements/button/BackButton.svelte
@@ -23,43 +23,45 @@
     haptic();
     if (isPreventDefault) {
       dispatch("click");
+      dispatch("back");
       return;
     }
-    if ($view.isConstrainedWidth && !path) appStore.goBack();
-    appStore.closeResource({ accessMode });
-    if (path) modalEvent.hide(path, "ModalCloseButton.svelte");
+    if ($view.isConstrainedWidth && !path) {
+      appStore.goBack();
+    } else {
+      appStore.closeResource({ accessMode });
+    }
+    if (path) modalEvent.hide(path, "BackButton.svelte");
   }
 </script>
 
-{#if $$slots.default}
-  <button
-    class={cn(
-      "flex items-center gap-2 rounded-md px-1",
-      classList,
-      {
-[`active:${bg(parentBgIndex)}`]: isEnabled,
-        "cursor-pointer": isEnabled,
-        "cursor-default": !isEnabled
-      }
-    )}
-    tabindex={isEnabled ? 0 : -1}
-    aria-disabled={!isEnabled}
-    disabled={!isEnabled}
-    on:click={onBack}
-  >
+<button
+  class={cn(
+    "flex items-center rounded-md",
+    $$slots.default
+      ? "gap-2 px-1"
+      : "gap-0 p-1 rounded-r-md rounded-l-full active:bg-bgs2 notouch:hover:bg-bgs2",
+    classList,
+    {
+      "cursor-pointer": isEnabled,
+      "cursor-default": !isEnabled,
+      [`active:${bg(parentBgIndex)}`]: isEnabled && $$slots.default
+    }
+  )}
+  type="button"
+  tabindex={isEnabled ? 0 : -1}
+  aria-disabled={!isEnabled}
+  disabled={!isEnabled}
+  aria-label={$$slots.default ? undefined : (text ?? "Back")}
+  on:click={onBack}
+>
+  {#if $$slots.default}
     {#if isEnabled}
       <Icon icon="chevron-left" class="text-fgs3 opacity-40" size={Size.lg} />
     {/if}
     <slot />
-  </button>
-{:else}
-  <button
-    class="flex items-center active:bg-bgs2 notouch:hover:bg-bgs2 rounded-r-md rounded-l-full p-1"
-    aria-disabled={!isEnabled}
-    disabled={!isEnabled}
-    on:click={onBack}
-  >
-    <Icon icon="chevleft" size={Size.sm} />
+  {:else}
+    <Icon icon="chevron-left" size={Size.sm} />
     <div class="pr-1 text-fgs1">{text ?? "Back"}</div>
-  </button>
-{/if}
+  {/if}
+</button>

--- a/client/elements/button/FullScreenCloseButton.svelte
+++ b/client/elements/button/FullScreenCloseButton.svelte
@@ -20,7 +20,7 @@
 <!-- TODO - watch - changing z-[1000] to z-40 as this is showing close button on top of resource modal when something is in split screen inline -->
 <button
   class={cn(
-    "absolute w-10 h-10 bg-ars1 opacity-70 hover:opacity-100 flex justify-center items-center z-40 top-0 right-0",
+    "absolute w-10 h-10 bg-ars1 opacity-70 hover:opacity-100 flex justify-center items-center z-40 top-0 right-0 cw:mt-12",
     {
       "rounded-full m-3": isFloat,
       "m-0 rounded-bl-md": !isFloat,

--- a/client/elements/contextMenu/ContextMenuAction.svelte
+++ b/client/elements/contextMenu/ContextMenuAction.svelte
@@ -35,7 +35,9 @@
    * If set to true, the context menu will be rendered as a sibling of the trigger button. By default, popovers are rendered in popovers container to avoid z-index issues with other elements in the DOM.
    */
   export let isRenderAsSibling = false;
-  export let icon: string = "more";
+  export let icon: string = $view.isConstrainedWidth
+    ? "more-outline-horizontal"
+    : "more";
   let classList: string = "";
   export { classList as class };
   let contextMenuPopoverRef: any;

--- a/client/elements/feedback/EmptyStatusView.svelte
+++ b/client/elements/feedback/EmptyStatusView.svelte
@@ -24,7 +24,6 @@
   import OverviewCardsPulse from "./animations/DashboardPulse/OverviewCardsPulse.svelte";
   import OnThisDayPulse from "./animations/DashboardPulse/OnThisDayPulse.svelte";
   import AnalyticsChartPulse from "./animations/DashboardPulse/AnalyticsChartPulse.svelte";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
   export let mainText: string | undefined = undefined;
   export let subText: string | undefined = undefined;
   export let size: Size.sm | Size.md | Size.lg = Size.md;
@@ -40,9 +39,6 @@
   export let parentBgIndex: number = 1;
   export let emptyIllustration: string | undefined = undefined;
   export let isFullPage: boolean = false;
-  if (isFullPage) {
-    setEmbedBg(parentBgIndex);
-  }
 </script>
 
 <div

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -4,11 +4,7 @@
   import { goto } from "$app/navigation";
   import { GlobalEvent } from "$lib/client/types/event.enum";
   import { Embed } from "$lib/client/types/context.type";
-  import {
-    pingParent,
-    postDataToParent,
-    setEmbedBg
-  } from "$lib/client/utils/embed.utils";
+  import { pingParent, postDataToParent } from "$lib/client/utils/embed.utils";
   import account from "$lib/client/stores/account.store";
   import { appStore, currentTime } from "$lib/client/stores/app.store";
   import { toasts } from "$lib/client/stores/notification.store";
@@ -49,7 +45,6 @@
 
   onMount(async () => {
     try {
-      setEmbedBg(1);
       await bootup();
     } catch (e) {
       logger.error({ at: "BaseLayer.onMount", error: e });

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -41,10 +41,12 @@
   let timer: any;
   let isMounted = false;
   const productConfig = resolveProductConfig();
-  pingParent();
-  addWindowEventListeners();
 
   onMount(async () => {
+    if (browser) {
+      pingParent();
+      addWindowEventListeners();
+    }
     try {
       await bootup();
     } catch (e) {
@@ -82,11 +84,38 @@
       }, 1000);
     }
     function initializeServiceWorker() {
-      if (!$context.isEmbed && browser && "serviceWorker" in navigator) {
-        navigator.serviceWorker
-          .register("/worker.js")
-          .catch((e) => logger.error({ at: "BaseLayer.sw.register", error: e }));
+      if (!browser || $context.isEmbed) return;
+      if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+        logger.debug({
+          at: "BaseLayer.sw.register",
+          message: "Service workers not supported"
+        });
+        return;
       }
+
+      navigator.serviceWorker
+        .register("/worker.js")
+        .then((registration) => {
+          logger.debug({
+            at: "BaseLayer.sw.register",
+            message: "Service worker registered",
+            registration
+          });
+        })
+        .catch((error) => {
+          logger.error({
+            at: "BaseLayer.sw.register",
+            error,
+            message: "Service worker registration failed"
+          });
+          if (error.name === "NetworkError") {
+            logger.error({
+              at: "BaseLayer.sw.register",
+              message:
+                "Network error during SW registration - offline features may be limited"
+            });
+          }
+        });
     }
   }
 
@@ -187,9 +216,16 @@
       if (isInLowDataMode)
         $context.isInLowDataMode = isInLowDataMode === "true";
     } catch (e) {
+      const errorMessage =
+        e instanceof Error
+          ? e.message
+          : typeof e === "string"
+            ? e
+            : JSON.stringify(e);
+
       postDataToParent(EmbedDataMessage.ERROR, {
         type: "ERROR",
-        message: e?.message ?? String(e)
+        message: errorMessage
       });
     }
   }
@@ -285,7 +321,9 @@
    */
   function handleCustomAlert(event: any) {
     try {
-      if (event.detail) console.log("custom alert:", event.detail);
+      if (event.detail) {
+        logger.info({ at: "handleCustomAlert", detail: event.detail });
+      }
       if (event.detail?.error === "networkerror") {
         if (
           $context.isEmbed &&
@@ -316,7 +354,11 @@
 
   function handleMessageFromChromeWebview(event: any) {
     const messageFromChromeWebView = event.data;
-    console.log("Received from Chrome Webview:", messageFromChromeWebView);
+    logger.debug({
+      at: "handleMessageFromChromeWebview",
+      message: "Received from Chrome Webview",
+      data: messageFromChromeWebView
+    });
   }
 
   function handleViewportChange() {

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
+  import { browser } from "$app/environment";
   import { GlobalEvent } from "$lib/client/types/event.enum";
   import { Embed } from "$lib/client/types/context.type";
   import { pingParent, postDataToParent } from "$lib/client/utils/embed.utils";
@@ -81,10 +82,10 @@
       }, 1000);
     }
     function initializeServiceWorker() {
-      if (!$context.isEmbed) {
-        if ("serviceWorker" in navigator) {
-          navigator.serviceWorker.register("/worker.js");
-        }
+      if (!$context.isEmbed && browser && "serviceWorker" in navigator) {
+        navigator.serviceWorker
+          .register("/worker.js")
+          .catch((e) => logger.error({ at: "BaseLayer.sw.register", error: e }));
       }
     }
   }
@@ -186,7 +187,10 @@
       if (isInLowDataMode)
         $context.isInLowDataMode = isInLowDataMode === "true";
     } catch (e) {
-      postDataToParent(EmbedDataMessage.ERROR, { type: "ERROR", message: e });
+      postDataToParent(EmbedDataMessage.ERROR, {
+        type: "ERROR",
+        message: e?.message ?? String(e)
+      });
     }
   }
 
@@ -195,7 +199,6 @@
    */
   async function checkForEnvironmentChange() {
     const envCachedOnMachine = await clientStorage.get(ClientStorageKey.ENV);
-    console.log("checkForEnvironmentChange", $appStore.env, envCachedOnMachine);
     if (envCachedOnMachine === null) {
       clientStorage.set(ClientStorageKey.ENV, $appStore.env);
       return;

--- a/client/layout/layers/ComponentEmbedLayer.svelte
+++ b/client/layout/layers/ComponentEmbedLayer.svelte
@@ -1,15 +1,36 @@
 <script lang="ts">
   import NotificationListener from "$lib/client/elements/listeners/NotificationListener.svelte";
+  import { EmbedDataMessage } from "$lib/client/types/embedMessage.enum";
   import { GlobalEvent } from "$lib/client/types/event.enum";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
+  import { postDataToParent } from "$lib/client/utils/embed.utils";
+  import { onMount } from "svelte";
+  /**
+   * @deprecated
+   */
   export let bg: number | undefined = undefined;
+  export let isBackNavigable: boolean = false;
 
-  if (bg) setEmbedBg(bg);
+  onMount(() => {
+    postDataToParent(
+      EmbedDataMessage.ENABLE_GESTURE_NAVIGATION,
+      isBackNavigable
+    );
+
+    return () => {
+      postDataToParent(EmbedDataMessage.ENABLE_GESTURE_NAVIGATION, false);
+    };
+  });
 
   function onNav(event: CustomEvent) {
     const path = event.detail.path;
-    if (bg) setEmbedBg(bg);
-    else if (["popover", "tooltip"].includes(path)) setEmbedBg(1);
+    setTimeout(
+      () =>
+        postDataToParent(
+          EmbedDataMessage.ENABLE_GESTURE_NAVIGATION,
+          isBackNavigable
+        ),
+      200
+    );
   }
 </script>
 

--- a/client/layout/layers/ModalLayer.svelte
+++ b/client/layout/layers/ModalLayer.svelte
@@ -77,7 +77,7 @@
     });
     const modalEventSub = modalEvent.subscribe(modalEventSubscriber);
 
-    () => {
+    return () => {
       appEventSub();
       modalEventSub();
       pageSub();

--- a/client/layout/layers/ModalLayer.svelte
+++ b/client/layout/layers/ModalLayer.svelte
@@ -19,7 +19,7 @@
   import type { ModalEvent, ModalParams } from "$lib/client/types/popup.type";
   import { GlobalEvent } from "$lib/client/types/event.enum";
   import type { IEvent } from "$lib/client/types/event.type";
-  import { postDataToParent, setEmbedBg } from "$lib/client/utils/embed.utils";
+  import { postDataToParent } from "$lib/client/utils/embed.utils";
   import ToastNotification from "$lib/client/elements/feedback/ToastNotification.svelte";
   import { isValidArrayWithData } from "$lib/shared/utils/obj.utils";
   import ModalLayout from "$lib/client/components/modal/ModalLayout.svelte";
@@ -117,7 +117,7 @@
         // modals = [x];
         modals = [...modals, x];
         if ($view.isPortrait) toasts.reset();
-        setEmbedBg(1);
+        postDataToParent(EmbedDataMessage.ENABLE_GESTURE_NAVIGATION, false);
       }
       logger.log({ modals });
     }
@@ -134,7 +134,6 @@
         ...action.modalParams
       }
     };
-    setEmbedBg(1);
   }
 
   const visibilityChangeListener = () => {

--- a/client/layout/layers/UserBaseLayer.svelte
+++ b/client/layout/layers/UserBaseLayer.svelte
@@ -581,19 +581,7 @@
   });
 </script>
 
-{#if isOfflineBannerIsShown}
-  <div
-    class="flex gap-2 w-full p-2 bg-ass2/30 text-ass1 items-center justify-center text-b2"
-  >
-    <Icon icon="ph:wifi-slash" class="text-ass1" />
-    {#if $account.dataMode === UserDataMode.LOCAL}
-      You are using offline mode on a browser. Please use Desktop/mobile app to
-      avoid loss of data or signup as cloud user.
-    {:else}
-      You are using offline mode.
-    {/if}
-  </div>
-{/if}
+
 {#if $appStore?.appData?.isAnalyticsEnabled && $account?.dataMode === UserDataMode.CLOUD && !$context.isInOfflineMode}
   <AnalyticsLayer />
 {/if}
@@ -637,6 +625,19 @@
   {/if}
 {/if}
 <Intercom />
+{#if isOfflineBannerIsShown}
+  <div
+    class="flex gap-2 w-full p-2 cw:pb-4 bg-ass2/30 text-ass1 items-center justify-center text-b2"
+  >
+    <Icon icon="ph:wifi-slash" class="text-ass1" />
+    {#if $account.dataMode === UserDataMode.LOCAL}
+      You are using offline mode on a browser. Please use Desktop/mobile app to
+      avoid loss of data or signup as cloud user.
+    {:else}
+      You are using offline mode.
+    {/if}
+  </div>
+{/if}
 
 <svelte:window
   on:resize={windowResizeListener}

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -22,7 +22,7 @@
   import type { InputLabelInfoToolTip } from "$lib/client/types/input.type";
   import FormLabelTooltip from "$lib/client/elements/text/formLabel/FormLabelTooltip.svelte";
   import { fly } from "svelte/transition";
-  import { haptic } from "$lib/client/utils/embed.utils";
+  import BackButton from "$lib/client/elements/button/BackButton.svelte";
   const dispatch = createEventDispatcher();
 
   export let title: string | undefined = undefined;
@@ -91,32 +91,20 @@
           class={cn(
             "flex justify-between items-center w-full px-4 pt-2 overflow-auto min-h-fit mo:min-h-14"
           )}
-          tabindex={isShowBackButton ? 0 : -1}
-          on:click={() => {
-            if (isShowBackButton) {
-              haptic();
-              dispatch("back");
-            }
-          }}
         >
-          <div
-            class={cn("flex items-center gap-2", {
-              "rounded-md px-1": isShowBackButton,
-              [`active:${bg(parentBgIndex)}`]: isShowBackButton
-            })}
+          <BackButton
+            isEnabled={isShowBackButton}
+            isPreventDefault={true}
+            on:click={() => {
+              if (!isShowBackButton) return;
+              dispatch("back");
+            }}
           >
-            {#if isShowBackButton}
-              <Icon
-                icon="ph:caret-left"
-                class="text-fgs3 opacity-40"
-                size={Size.lg}
-              />
-            {/if}
             <Text style={titleStyle} content={title || ""} />
             {#if info}
               <FormLabelTooltip {info} />
             {/if}
-          </div>
+          </BackButton>
           <slot name="toprightactions">
             {#if !isExpanded && isShowCollapseButton}
               <button

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -87,7 +87,7 @@
       in:fly={{ x: -10 }}
     >
       {#if !isNavActivated && (title || isShowCollapseButton)}
-        <button
+        <div
           class={cn(
             "flex justify-between items-center w-full px-4 pt-2 overflow-auto min-h-fit mo:min-h-14"
           )}
@@ -95,10 +95,7 @@
           <BackButton
             isEnabled={isShowBackButton}
             isPreventDefault={true}
-            on:click={() => {
-              if (!isShowBackButton) return;
-              dispatch("back");
-            }}
+            on:click={() => dispatch("back")}
           >
             <Text style={titleStyle} content={title || ""} />
             {#if info}
@@ -121,7 +118,7 @@
               </button>
             {/if}
           </slot>
-        </button>
+        </div>
       {/if}
       {#if $$slots.nonpadded}
         <slot name="nonpadded" />

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -94,6 +94,7 @@
         >
           <BackButton
             isEnabled={isShowBackButton}
+            parentBgIndex={parentBgIndex}
             isPreventDefault={true}
             on:click={() => dispatch("back")}
           >

--- a/client/layout/paint/ResourceResolver.svelte
+++ b/client/layout/paint/ResourceResolver.svelte
@@ -13,7 +13,8 @@
   export let componentParams: any = {};
   export let accessMode: ResourceAccessMode = ResourceAccessMode.INLINE;
   let refreshId: number = new Date().getTime();
-  setCurrentComponent();
+
+  $: if (accessMode === ResourceAccessMode.TAB && id) setCurrentComponent();
 
   function onReloadResource(e: CustomEvent) {
     const resource = e?.detail?.id;
@@ -21,7 +22,9 @@
     if (isSameResource(resource, id)) {
       refreshId = new Date().getTime();
     }
-    setCurrentComponent();
+    if (accessMode === ResourceAccessMode.TAB && isSameResource(resource, id)) {
+      setCurrentComponent();
+    }
   }
 
   function setCurrentComponent() {

--- a/client/layout/paint/ResourceResolver.svelte
+++ b/client/layout/paint/ResourceResolver.svelte
@@ -1,17 +1,39 @@
 <script lang="ts">
+  import { logger } from "$lib/client/components/debug/logger.client";
+  import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
-  import { isSameResource } from "$lib/client/components/flux/resourceStores/resource.utils";
+  import {
+    determineResourceType,
+    isSameResource
+  } from "$lib/client/components/flux/resourceStores/resource.utils";
+  import { appStore } from "$lib/client/stores/app.store";
   import ComponentResolver from "./ComponentResolver.svelte";
   export let id: string;
   export let isFromSplitView: boolean = false;
   export let componentParams: any = {};
   export let accessMode: ResourceAccessMode = ResourceAccessMode.INLINE;
   let refreshId: number = new Date().getTime();
+  setCurrentComponent();
+
   function onReloadResource(e: CustomEvent) {
     const resource = e?.detail?.id;
     if (!resource) return;
     if (isSameResource(resource, id)) {
       refreshId = new Date().getTime();
+    }
+    setCurrentComponent();
+  }
+
+  function setCurrentComponent() {
+    try {
+      if (accessMode !== ResourceAccessMode.TAB) return;
+      const resource = determineResourceType(id);
+      if (!resource || resource === Resource.unknown) return;
+      const action = appStore.resolveAction(resource);
+      if (!action) return;
+      $appStore.currentComponent = action;
+    } catch (e) {
+      logger.error("ResourceResolver.setCurrentComponent - error", e);
     }
   }
 </script>

--- a/client/layout/paint/ResourceResolver.svelte
+++ b/client/layout/paint/ResourceResolver.svelte
@@ -34,7 +34,7 @@
       if (!resource || resource === Resource.unknown) return;
       const action = appStore.resolveAction(resource);
       if (!action) return;
-      $appStore.currentComponent = action;
+      appStore.update(s => ({ ...s, currentComponent: action }));
     } catch (e) {
       logger.error("ResourceResolver.setCurrentComponent - error", e);
     }

--- a/client/products/memotron/home/MemotronHomeOnMobile.svelte
+++ b/client/products/memotron/home/MemotronHomeOnMobile.svelte
@@ -19,7 +19,7 @@
   } from "../capture/capture.store";
   import { generateResourceId } from "$lib/client/components/flux/flux.utils";
   import HomeTopNav from "./mobile/HomeTopNav.svelte";
-  import { haptic, setEmbedBg } from "$lib/client/utils/embed.utils";
+  import { haptic } from "$lib/client/utils/embed.utils";
   import TypeSelectorOnMobile from "../capture/typeSelector/TypeSelectorOnMobile.svelte";
   import { fly } from "svelte/transition";
   import HomeQuickAccess from "$lib/client/components/home/mobile/HomeQuickAccess.svelte";
@@ -180,7 +180,6 @@
     mode = undefined;
     captureStore.reset();
     initializeCaptureStore();
-    if (inlineToast) setEmbedBg(2);
   }
 
   function onInlineToastEvent(event: CustomEvent<InlineToast>) {
@@ -225,7 +224,7 @@
     isFullPage={true}
   />
 {:else}
-  <div class="flex flex-col w-full bg-bgs2">
+  <div class="flex flex-col w-full bg-bgs2 pt-12">
     <div
       class={cn("transition-all duration-250 ease-out overflow-hidden", {
         "max-h-96 opacity-100": !mode,

--- a/client/products/memotron/home/MemotronHomeOnMobile.svelte
+++ b/client/products/memotron/home/MemotronHomeOnMobile.svelte
@@ -50,6 +50,7 @@
   import InlineInfoBanner from "$lib/client/elements/text/InlineInfoBanner.svelte";
   import { InfoTextType } from "$lib/client/types/text.type";
   import { resolveProductConfig } from "../../product.config";
+  import { AppSearchParam } from "$lib/client/types/appStore.type";
   export let captureId: IRecordId = generateResourceId(Resource.capture);
   let mode: "search" | "capture" | undefined = undefined;
   let searchQuery = "";
@@ -108,7 +109,7 @@
 
   const commonActionParams = {
     searchParams: {
-      back: homePathPt
+      [AppSearchParam.RETURN_TO]: homePathPt
     }
   };
 
@@ -126,7 +127,7 @@
       appStore.runAction(ResourceActionType.BROWSE, {
         componentParams: {
           resource: item.id === "nodes" ? Resource.node : Resource.collection,
-          back: homePathPt
+          [AppSearchParam.RETURN_TO]: homePathPt
         }
       });
     }

--- a/client/products/memotron/library/search/ResourceSearchBase.svelte
+++ b/client/products/memotron/library/search/ResourceSearchBase.svelte
@@ -37,7 +37,6 @@
   import { Embed } from "$lib/client/types/context.type";
   import { createEventDispatcher } from "svelte";
   import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
 
   const dispatch = createEventDispatcher();
 
@@ -248,10 +247,8 @@
         on:switch={() => {
           setTimeout(() => {
             if (resource === Resource.everything) {
-              if ($context.embed === Embed.HANDSET) setEmbedBg(2);
               groupedSearchRef?.search(searchQuery);
             } else {
-              if ($context.embed === Embed.HANDSET) setEmbedBg(1);
               searchResultsPopover?.search(searchQuery);
             }
           }, 100);

--- a/client/products/memotron/node/Node.svelte
+++ b/client/products/memotron/node/Node.svelte
@@ -17,6 +17,7 @@
   import EmptyStatusView from "$lib/client/elements/feedback/EmptyStatusView.svelte";
   import { page } from "$app/stores";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
+  import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
 
   export let id: string;
   export let accessMode: ResourceAccessMode;
@@ -86,7 +87,7 @@
     <NonMediaNode {node} selectedView={view} />
   {/if}
 {:else}
-  <div class="w-full h-full pt-4 mo:px-4 px-20">
+  <div class="w-full h-full cw:pt-12 pt-4 mo:px-4 px-20">
     <NodeLoadingPulse />
   </div>
 {/if}
@@ -95,3 +96,4 @@
   subscribeToResource={new Set([Resource.property])}
   on:change={debouncedInitialize}
 />
+<ComponentEmbedLayer isBackNavigable={true} />

--- a/client/products/memotron/node/Node.svelte
+++ b/client/products/memotron/node/Node.svelte
@@ -18,6 +18,7 @@
   import { page } from "$app/stores";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
   import ComponentEmbedLayer from "$lib/client/layout/layers/ComponentEmbedLayer.svelte";
+  import context from "$lib/client/stores/context.store";
 
   export let id: string;
   export let accessMode: ResourceAccessMode;
@@ -96,4 +97,6 @@
   subscribeToResource={new Set([Resource.property])}
   on:change={debouncedInitialize}
 />
-<ComponentEmbedLayer isBackNavigable={true} />
+{#if $context.isEmbed && accessMode !== ResourceAccessMode.POP && !isFromSplitView}
+  <ComponentEmbedLayer isBackNavigable={true} />
+{/if}

--- a/client/products/memotron/node/base/MediaNode.svelte
+++ b/client/products/memotron/node/base/MediaNode.svelte
@@ -36,7 +36,7 @@
 
 {#if $node}
   <div
-    class="relative flex flex-col cw:flex-col-reverse w-full h-full"
+    class="relative flex flex-col cw:flex-col-reverse cw:gap-8 w-full h-full"
     use:resizeListener={(e) => {
       containerWidth = e.width;
     }}

--- a/client/products/memotron/node/base/MediaNode.svelte
+++ b/client/products/memotron/node/base/MediaNode.svelte
@@ -36,7 +36,7 @@
 
 {#if $node}
   <div
-    class="relative flex flex-col w-full h-full"
+    class="relative flex flex-col cw:flex-col-reverse w-full h-full"
     use:resizeListener={(e) => {
       containerWidth = e.width;
     }}
@@ -58,7 +58,7 @@
         bind:bottomAction={panelAction}
       />
     {/if}
-    {#if ($view.isConstrainedWidth || $node.accessMode === ResourceAccessMode.SPLIT || $node.accessMode === ResourceAccessMode.FSPLIT) && !panelAction}
+    {#if ($node.accessMode === ResourceAccessMode.SPLIT || $node.accessMode === ResourceAccessMode.FSPLIT) && !panelAction}
       <FullScreenCloseButton accessMode={$node.accessMode} isFloat={true} />
     {/if}
   </div>

--- a/client/products/memotron/node/base/NonMediaNode.svelte
+++ b/client/products/memotron/node/base/NonMediaNode.svelte
@@ -158,7 +158,7 @@
     {#if selectedView === NodeView.CONTENT}
       {#key refreshId}
         <div
-          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4", {
+          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4 cw:pt-12", {
             "flex px-4 justify-center": !isWidened,
             "dp:grid dp:grid-cols-[1fr_auto_1fr] dp:gap-2":
               !isWidened && !isConstrainedWidth,
@@ -356,11 +356,11 @@
       </BottomFloat>
     {/if}
   {:else}
-    <div class="w-full h-full pt-4 px-20">
+    <div class="w-full h-full pt-4 px-20 cw:pt-12">
       <NodeLoadingPulse />
     </div>
   {/if}
-  {#if ($view.isConstrainedWidth || $node.accessMode === ResourceAccessMode.SPLIT || $node.accessMode === ResourceAccessMode.FSPLIT) && (!rightPane || rightPane === NodeRightPaneType.NONE)}
+  {#if ($node.accessMode === ResourceAccessMode.SPLIT || $node.accessMode === ResourceAccessMode.FSPLIT) && (!rightPane || rightPane === NodeRightPaneType.NONE)}
     <FullScreenCloseButton accessMode={$node.accessMode} isFloat={true} />
   {/if}
 </div>

--- a/client/products/memotron/node/content/MediaContent.svelte
+++ b/client/products/memotron/node/content/MediaContent.svelte
@@ -46,7 +46,7 @@
   }
 </script>
 
-<div class="flex w-full flex-grow">
+<div class="flex w-full flex-grow cw:mb-8">
   {#if !(isConstrainedWidth && rightPane)}
     <main
       class={cn("relative flex w-full justify-center flex-1", {

--- a/client/products/memotron/node/content/MediaContent.svelte
+++ b/client/products/memotron/node/content/MediaContent.svelte
@@ -26,7 +26,6 @@
   let contentRef: MediaContentResolver;
 
   function contextEventListener(event: string, data: any) {
-    console.log({ event, data });
     if (event === "pdf-trace-click" || event === "yt-trace-click") {
       if ($view.isPortrait && isRecordId(data.id)) {
         appStore.openResource(data.id, ResourceAccessMode.POP);

--- a/client/products/memotron/node/content/NodeContent.svelte
+++ b/client/products/memotron/node/content/NodeContent.svelte
@@ -29,11 +29,12 @@
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import { Size } from "$lib/client/types/size.enum";
   import type { IRecordId } from "$lib/client/types/data.type";
-  import type { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
+  import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
   import view from "$lib/client/stores/view.store";
   import context from "$lib/client/stores/context.store";
   import { generateMarkdownText, resolveHeadingParent } from "../node.utils";
   import { resourceInList } from "$lib/client/components/flux/resourceStores/resource.utils";
+  import { tabs } from "$lib/client/layout/topNav/tabs/tabs.store";
 
   export let node: IActiveNodeStore;
   export let mdId: string;
@@ -108,7 +109,7 @@
         return;
       }
       //TODO - temp direct reload instead of within focus
-      temp_Focus(x.id, currentAccessMode);
+      temp_Focus(x.id, { currentAccessMode, accessMode: clickedAccessMode });
       node.eventStore.set(undefined);
       return;
       const result = markdownRef?.focus(x.id);
@@ -126,8 +127,24 @@
     refreshId = Date.now();
   });
 
-  function temp_Focus(id: IRecordId, accessMode: ResourceAccessMode) {
-    appStore.openResource(id, accessMode);
+  function temp_Focus(
+    id: IRecordId,
+    params?: {
+      accessMode?: ResourceAccessMode;
+      currentAccessMode?: ResourceAccessMode;
+    }
+  ) {
+    const currentAccessMode =
+      params?.currentAccessMode ??
+      appStore.determineResourceAccessMode($node.id);
+    if (
+      currentAccessMode === ResourceAccessMode.TAB &&
+      (!params?.accessMode || params?.accessMode === ResourceAccessMode.TAB)
+    ) {
+      tabs.replace(id, $node.id);
+      return;
+    }
+    appStore.openResource(id, currentAccessMode);
   }
 
   onDestroy(() => {
@@ -262,7 +279,7 @@
   function onFocus(e: CustomEvent) {
     logger.debug({ at: "NodeContent - onFocus", ...e.detail });
     if (e.detail.id && e.detail.parent) {
-      temp_Focus(e.detail.id, appStore.determineResourceAccessMode($node.id));
+      temp_Focus(e.detail.id);
       // node.onFocus(e.detail.id, e.detail.parent);
     }
   }

--- a/client/products/memotron/node/content/NodeContent.svelte
+++ b/client/products/memotron/node/content/NodeContent.svelte
@@ -80,7 +80,6 @@
       const createdBlock = await node.createBlock(id, NodeType.SIMPLE_TEXT, {
         body: ""
       });
-      console.log({ createdBlock });
       if (createdBlock?.[0]) {
         await node.modify(
           {
@@ -102,7 +101,6 @@
       if (!x) return;
       const currentAccessMode = appStore.determineResourceAccessMode($node.id);
       const clickedAccessMode = appStore.determineClickAccessMode(x.event);
-      console.log({ currentAccessMode, clickedAccessMode });
       if (clickedAccessMode && clickedAccessMode !== currentAccessMode) {
         appStore.openResource(x.id, clickedAccessMode);
         node.eventStore.set(undefined);
@@ -134,6 +132,9 @@
       currentAccessMode?: ResourceAccessMode;
     }
   ) {
+
+    if (id === $node.id) return;
+    
     const currentAccessMode =
       params?.currentAccessMode ??
       appStore.determineResourceAccessMode($node.id);

--- a/client/products/memotron/node/content/WebNodeContent.svelte
+++ b/client/products/memotron/node/content/WebNodeContent.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<div class="h-full w-full">
+<div class="relative h-full w-full">
   {#if node.contentType === NodeType.WEB_PAGE || node.contentType === NodeType.YOUTUBE_CHANNEL}
     <WebPagePreview {node} {accessPoint} />
   {:else if node.contentType === NodeType.GIST}

--- a/client/products/memotron/node/content/WebNodeContent.svelte
+++ b/client/products/memotron/node/content/WebNodeContent.svelte
@@ -64,7 +64,7 @@
   }
 </script>
 
-<div class="h-full w-full cw:pt-12">
+<div class="h-full w-full">
   {#if node.contentType === NodeType.WEB_PAGE || node.contentType === NodeType.YOUTUBE_CHANNEL}
     <WebPagePreview {node} {accessPoint} />
   {:else if node.contentType === NodeType.GIST}

--- a/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
+++ b/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
@@ -31,6 +31,7 @@
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import { isShowStatusBanner } from "$lib/client/components/flux/resourceStores/resource.utils";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
+  import BackButton from "$lib/client/elements/button/BackButton.svelte";
   const dispatch = createEventDispatcher();
   export let node: IActiveNodeStore;
   export let isHovering: boolean = false;
@@ -59,8 +60,7 @@
   class={cn("flex flex-col w-full justify-center items-center", {
     "mb-6 absolute z-10 bottom-0":
       $node.accessMode === ResourceAccessMode.SLIDESHOW,
-    "relative mo:mb-8 cw:mb-8":
-      $node.accessMode !== ResourceAccessMode.SLIDESHOW
+    relative: $node.accessMode !== ResourceAccessMode.SLIDESHOW
   })}
 >
   <div
@@ -89,7 +89,7 @@
     {/if}
     <div
       class={cn(
-        "flex flex-col gap-2 w-full justify-center items-center bg-bgs1 mo:p-2 p-3 border-t border-t-brs2",
+        "flex flex-col gap-2 w-full justify-center items-center bg-bgs1 mo:p-2 p-3 cw:border-b cw:border-b-brs2 cw:border-t-transparent cw:rounded-none cw:bg-bgs2 cw:pt-12 border-t border-t-brs2",
         {
           "rounded-b-md": $node.accessMode === ResourceAccessMode.POP,
           "w-full": $node.accessMode !== ResourceAccessMode.SLIDESHOW,
@@ -100,16 +100,22 @@
     >
       <div class="flex gap-3 justify-between items-center w-full">
         <span class="flex items-center gap-4 flex-1 min-w-0">
-          <NodeTitle
-            node={$node}
-            on:labelChange={(e) => {
-              if ($node.label !== undefined)
-                node.modify({ label: $node.label });
-            }}
-            on:editModeChange={(e) => {
-              node.toggleEditMode(e.detail);
-            }}
-          />
+          <BackButton
+            isEnabled={$view.isConstrainedWidth && !$node.isInEditMode}
+            accessMode={$node.accessMode}
+            class="min-w-0 flex-1"
+          >
+            <NodeTitle
+              node={$node}
+              on:labelChange={(e) => {
+                if ($node.label !== undefined)
+                  node.modify({ label: $node.label });
+              }}
+              on:editModeChange={(e) => {
+                node.toggleEditMode(e.detail);
+              }}
+            />
+          </BackButton>
           {#if !isConstrainedWidth && !$node.isInEditMode}
             <div class="text-b3 text-fgs3 whitespace-nowrap default-typeface">
               {formatDatetime($userPreferences, $node.createdAt)}

--- a/client/products/memotron/node/title/NodeTitleLabelPart.svelte
+++ b/client/products/memotron/node/title/NodeTitleLabelPart.svelte
@@ -63,7 +63,7 @@
         accessPoint !== ResourceAccessPoint.TABS &&
         accessPoint !== ResourceAccessPoint.SELF,
       "text-fgs2": accessPoint === ResourceAccessPoint.MARKDOWN_EMBED,
-      "text-h4 font-medium": accessPoint === ResourceAccessPoint.SELF
+      "text-h4 cw:text-h5 font-medium": accessPoint === ResourceAccessPoint.SELF
     })}
     on:click
   >

--- a/client/products/pointron/analytics/AnalyticsV2.svelte
+++ b/client/products/pointron/analytics/AnalyticsV2.svelte
@@ -20,9 +20,6 @@
     onRemovePageClicked,
     onPageRearrange
   } from "./analytics.utils";
-  import context from "$lib/client/stores/context.store";
-  import { Embed } from "$lib/client/types/context.type";
-  import { setEmbedBg } from "$lib/client/utils/embed.utils";
   import { confirmationNotification } from "$lib/client/stores/notification.store";
   import { ButtonStyle, ButtonVariant } from "$lib/client/types/button.type";
   import {
@@ -40,9 +37,6 @@
   const isNucleusContext = $appStore.product === Product.NUCLEUS;
   $selectedPageId = resolvePageSelection();
   onMount(async () => {
-    if ($context.embed == Embed.HANDSET) {
-      setEmbedBg(2);
-    }
     if (!$selectedPageId) {
       $selectedPageId = $analyticsConfigStore.pages[0]?.id;
     }

--- a/client/stores/actionMap.ts
+++ b/client/stores/actionMap.ts
@@ -82,6 +82,7 @@ import { resolveResourceStore } from "../components/flux/resourceStores/store.re
 import CollectionCache from "../components/collection/CollectionCache.svelte";
 import DataSettings from "../components/settings/DataSettings.svelte";
 import DexieConsole from "../components/debug/DexieConsole.svelte";
+import { AppSearchParam } from "../types/appStore.type";
 
 export const globalActions: IAction[] = [
   {
@@ -1030,7 +1031,8 @@ export const globalActions: IAction[] = [
       const resource = params?.componentParams?.resource;
       appStore.runAction(resourceAction(resource, ResourceActionType.BROWSE), {
         searchParams: {
-          back: params?.componentParams?.back ?? "home"
+          [AppSearchParam.RETURN_TO]:
+            params?.componentParams?.[AppSearchParam.RETURN_TO] ?? "home"
         }
       });
     }

--- a/client/types/appStore.type.ts
+++ b/client/types/appStore.type.ts
@@ -103,6 +103,8 @@ export type IAppData = {
 };
 
 export enum AppSearchParam {
+  RETURN_TO = "returnTo",
+  BACK = "back",
   EDIT = "edit",
   TYPE = "type",
   /**

--- a/client/types/embedMessage.enum.ts
+++ b/client/types/embedMessage.enum.ts
@@ -32,5 +32,6 @@ export enum EmbedDataMessage {
   ACCOUNT = "account",
   OAUTH = "oauth",
   LINK = "link",
-  LOG = "log"
+  LOG = "log",
+  ENABLE_GESTURE_NAVIGATION = "enableGestureNavigation"
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enables gesture-based back navigation in embeds and unifies back behavior across constrained-width views. Removes embed background toggles and tightens CW spacing for a more consistent mobile experience. (TASK-538)

- New Features
  - Added gesture back: ComponentEmbedLayer now posts ENABLE_GESTURE_NAVIGATION; used in Collection, ResourceBrowser, Settings, and Node views.
  - Refined BackButton: supports slot content, isPreventDefault, accessMode, and goBack/closeResource; integrated into CollectionTitleBar, Panel header, NavigationHeader, and MediaNodeFloatingBar.

- Refactors
  - Removed setEmbedBg usage and deprecated bg in ComponentEmbedLayer; ModalLayer disables gesture nav when modals open.
  - Consistent CW padding and headers (cw:pt-12) across Collection, Node (loading/content), Memotron Home, and floats.
  - Search/UI tweaks: InlineSearchBar parentBgIndex=1, LibraryRecordsPane uses FILLED style, Collection search shows “No items found” when empty, ResourceBrowser supports isPreventCwPadding.
  - Tab navigation correctness: NodeContent replaces current tab via tabs.replace in TAB mode; ResourceResolver updates currentComponent for tab context.
  - Visual polish: Calendar Year view spacing/hover, ContextMenuAction shows horizontal “more” on CW, MediaContent adds bottom spacing on CW.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified BackButton across headers with improved enable/disable and default-prevention behavior.
  - Embeds now support gesture-based back navigation and back-navigable embed layers.

- UI/UX
  - Tighter calendar year grid with hover animations.
  - More consistent constrained-width padding and sticky-header spacing; added top padding in collections, library, and node views.
  - Inline search shows dynamic placeholder and updated visual style; compact context-menu icon on small screens.

- Refactor
  - Removed legacy embed-background manipulation in favor of gesture-navigation signaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->