### PR TITLE
release testing fixes

### DIFF
--- a/apps/memotron/src/local.ts
+++ b/apps/memotron/src/local.ts
@@ -1,7 +1,7 @@
 import config from "$lib/client/products/memotron/memotron.config";
 
 const version = "0.61.3";
-const build = 9;
+const build = 10;
 
 export default {
   version,

--- a/apps/nucleus/src/local.ts
+++ b/apps/nucleus/src/local.ts
@@ -1,7 +1,7 @@
 import config from "$lib/client/products/nucleus/nucleus.config";
 
 const version = "0.3.2";
-const build = 9;
+const build = 10;
 
 export default {
   version,

--- a/apps/pointron/src/local.ts
+++ b/apps/pointron/src/local.ts
@@ -1,7 +1,7 @@
 import config from "$lib/client/products/pointron/pointron.config";
 
 const version = "0.83.1";
-const build = 8;
+const build = 9;
 
 export default {
   version,

--- a/client/components/calendar/CalendarLayout.svelte
+++ b/client/components/calendar/CalendarLayout.svelte
@@ -46,7 +46,7 @@
   }
 </script>
 
-<div class="flex flex-col h-full w-full">
+<div class="flex flex-col h-full w-full otop:pt-12">
   <div
     class="flex items-center gap-4 border-b border-brs3 h-[3.2rem] 2k:h-14 px-4"
   >

--- a/client/components/calendar/classic/ClassicCalendar.svelte
+++ b/client/components/calendar/classic/ClassicCalendar.svelte
@@ -341,7 +341,11 @@
 
   <div class="flex h-full">
     <!-- <CalendarSidebar {events} /> -->
-    <div class="flex-1 overflow-auto min-w-60">
+    <div
+      class={cn("flex-1 overflow-auto", {
+        "min-w-60": selectedView !== TimeScaleUnit.DAY
+      })}
+    >
       {#if selectedView === TimeScaleUnit.MONTH}
         <MonthView
           bind:selectedDate

--- a/client/components/collection/Collection.svelte
+++ b/client/components/collection/Collection.svelte
@@ -534,7 +534,7 @@
 </script>
 
 {#if !$collection || $collection.isPageLoading || !isReady}
-  <div class="w-full h-full p-4 embed-ios:pt-12">
+  <div class="w-full h-full p-4 otop:pt-12">
     <PageLoadingPulse />
   </div>
 {:else if $collection}
@@ -611,7 +611,7 @@
             "pb-8": isSingleViewMode && !isShowMetaViews && !isConstrainedWidth,
             "pt-6": !isConstrainedWidth,
             "p-2": isConstrainedWidth,
-            "embed-ios:pt-12": !$collection.cover || positionFromTop === 0,
+            "otop:pt-12": !$collection.cover || positionFromTop === 0,
             "max-w-full overflow-x-auto":
               accessPoint === ResourceAccessPoint.MARKDOWN_EMBED
           })}
@@ -708,7 +708,7 @@
               "sticky top-0 z-10 flex flex-col gap-6 w-full transition-all duration-300",
               bg(parentBgIndex - 1),
               {
-                "pt-4 embed-ios:pt-12": isStickied
+                "pt-4 otop:pt-12": isStickied
               }
             )}
           >

--- a/client/components/commandBar/CommandBar.svelte
+++ b/client/components/commandBar/CommandBar.svelte
@@ -101,7 +101,7 @@
 </script>
 
 <div
-  class={cn("flex flex-col w-full embed-ios:pt-12", {
+  class={cn("flex flex-col w-full otop:pt-12", {
     "border border-brs2 rounded-md": isFullPageContext,
     "h-full": !isFullPageContext || (isFullPageContext && isFocusing)
   })}

--- a/client/components/goals/Goal.svelte
+++ b/client/components/goals/Goal.svelte
@@ -222,7 +222,7 @@
       <main class="flex flex-col gap-4 flex-1 overflow-auto">
         <div
           class={cn(
-            "relative flex flex-col w-full overflow-auto gap-3 bg-bgs2 embed-ios:pt-12 shrink-0",
+            "relative flex flex-col w-full overflow-auto gap-3 bg-bgs2 otop:pt-12 shrink-0",
             {
               "rounded-lg border border-brs3": !isConstrainedWidth,
               "border-b border-brs3": isConstrainedWidth

--- a/client/components/modal/Modal.svelte
+++ b/client/components/modal/Modal.svelte
@@ -202,13 +202,16 @@
       {:else}
         <div
           id={id + "-modal"}
-          class={cn("bg-bgs1 max-h-full cursor-default", {
-            ...resolveSizeClasses(),
-            "rounded-md": size !== Size.full,
-            "mo:rounded-none": size !== Size.full && size !== Size.xs,
-            "mo:w-9/10": size === Size.xs,
-            "mo:w-full mo:h-full": size !== Size.xs
-          })}
+          class={cn(
+            "bg-bgs1 max-h-full cursor-default landscape:embed-ios:pt-12 landscape:embed-ios:bg-transparent",
+            {
+              ...resolveSizeClasses(),
+              "rounded-md": size !== Size.full,
+              "mo:rounded-none": size !== Size.full && size !== Size.xs,
+              "mo:w-9/10": size === Size.xs,
+              "mo:w-full mo:h-full": size !== Size.xs
+            }
+          )}
         >
           <ColorLayer>
             <slot />

--- a/client/components/modal/ModalLayout.svelte
+++ b/client/components/modal/ModalLayout.svelte
@@ -67,7 +67,7 @@
 
 {#if size === Size.full}
   <div
-    class="w-full h-full flex justify-center items-center embed-ios:pt-12"
+    class="w-full h-full flex justify-center items-center embed-ios:pt-12 embed-ios:bg-bgs1"
     in:fly={{
       duration: 400,
       delay: 0,
@@ -95,10 +95,10 @@
 {:else}
   <div
     class={cn(
-      "relative modal flex flex-col items-center justify-between w-full h-full  rounded-md",
+      "relative modal flex flex-col items-center justify-between w-full h-full  rounded-md embed-ios:bg-bgs1",
       {
         "dark:border border-brs3": !isInFocusMode && !$view.isConstrainedWidth,
-        "embed-ios:pt-12": !resource || params.title
+        "otop:pt-12": !resource || params.title
       },
       !params.layout?.ignoreSafeArea && {
         "gap-4": size === Size.xs,

--- a/client/components/settings/SettingsAsModal.svelte
+++ b/client/components/settings/SettingsAsModal.svelte
@@ -45,7 +45,7 @@
 
 <div class="flex w-full h-full">
   <div
-    class="flex flex-col overflow-auto gap-8 w-72 min-w-72 dp:w-[21rem] dp:min-w-[21rem] shrink-0 bg-bgs2 rounded-l-md py-4 items-start embed-ios:pt-12"
+    class="flex flex-col overflow-auto gap-8 w-72 min-w-72 dp:w-[21rem] dp:min-w-[21rem] shrink-0 bg-bgs2 rounded-l-md py-4 items-start otop:pt-12"
   >
     <div class="pl-4">
       <BackButton
@@ -112,7 +112,7 @@
       {/if}
     </div>
   </div>
-  <div class="flex flex-col items-start flex-grow h-full p-4 embed-ios:pt-12">
+  <div class="flex flex-col items-start flex-grow h-full p-4 otop:pt-12">
     {#if pageAction}
       <div class="flex justify-start h-10">
         <Text

--- a/client/components/settings/asPage/SettingsAsPageLayout.svelte
+++ b/client/components/settings/asPage/SettingsAsPageLayout.svelte
@@ -21,7 +21,7 @@
 </script>
 
 {#if $view.isPortrait && !isCpHome}
-  <div class="flex flex-col h-full w-full gap-2 px-4 py-2 embed-ios:pt-12">
+  <div class="flex flex-col h-full w-full gap-2 px-4 py-2 otop:pt-12">
     <NavigationHeader
       label={$appStore.currentComponent?.label ?? ""}
       backCallback={() => {

--- a/client/components/tasks/Task.svelte
+++ b/client/components/tasks/Task.svelte
@@ -257,7 +257,7 @@
 </script>
 
 <div
-  class={cn("flex p-4 mo:w-full mo:h-full embed-ios:pt-12 h-[28rem]", {
+  class={cn("flex p-4 mo:w-full mo:h-full otop:pt-12 h-[28rem]", {
     "w-[32rem]": accessMode !== ResourceAccessMode.INLINE,
     "w-full": accessMode === ResourceAccessMode.INLINE
   })}

--- a/client/iconsV2/icon.store.ts
+++ b/client/iconsV2/icon.store.ts
@@ -2,7 +2,7 @@ import { isExtensionEnvironment } from "$lib/client/utils/browser.utils";
 import { bundleNumber } from "./icons-list";
 import { iconMappings, type IconSet } from "./icons.map";
 //TODO - temp for landing
-// import { assetPath } from "@21n/static";
+import { assetPath } from "@21n/static";
 
 export const spriteVersion = bundleNumber;
 export const extensionSprites = new Map<string, string>();
@@ -44,9 +44,9 @@ export function resolveSpriteSheetPath(sheet: string) {
   if (isExtensionEnvironment()) {
     return `assets/icons/${sheet}.svg`;
   }
-  return assetPath(`/icons/${sheet}-v${spriteVersion}.svg`);
+  return assetPath(`icons/${sheet}-v${spriteVersion}.svg`);
 }
 
-function assetPath(arg0: string) {
-  return arg0;
-}
+// function assetPath(arg0: string) {
+//   return arg0;
+// }

--- a/client/iconsV2/icon.store.ts
+++ b/client/iconsV2/icon.store.ts
@@ -2,7 +2,7 @@ import { isExtensionEnvironment } from "$lib/client/utils/browser.utils";
 import { bundleNumber } from "./icons-list";
 import { iconMappings, type IconSet } from "./icons.map";
 //TODO - temp for landing
-import { assetPath } from "@21n/static";
+// import { assetPath } from "@21n/static";
 
 export const spriteVersion = bundleNumber;
 export const extensionSprites = new Map<string, string>();
@@ -47,6 +47,6 @@ export function resolveSpriteSheetPath(sheet: string) {
   return assetPath(`icons/${sheet}-v${spriteVersion}.svg`);
 }
 
-// function assetPath(arg0: string) {
-//   return arg0;
-// }
+function assetPath(arg0: string) {
+  return arg0;
+}

--- a/client/iconsV2/icon.store.ts
+++ b/client/iconsV2/icon.store.ts
@@ -44,7 +44,7 @@ export function resolveSpriteSheetPath(sheet: string) {
   if (isExtensionEnvironment()) {
     return `assets/icons/${sheet}.svg`;
   }
-  return assetPath(`icons/${sheet}-v${spriteVersion}.svg`);
+  return assetPath(`/icons/${sheet}-v${spriteVersion}.svg`);
 }
 
 function assetPath(arg0: string) {

--- a/client/landing/shared/PrivacyPolicy.svelte
+++ b/client/landing/shared/PrivacyPolicy.svelte
@@ -59,8 +59,9 @@
             class="w-full h-full outline-none font-medium p-2"
             style="max-width: 100%; width: 100%;  word-break: break-word;"
           >
-            "We", "Us" or "Our" in this Agreement refers to Blank labs Private
-            limited, registered H-no: 4-4/B, Kappapahad, Telangana, India.
+            "We", "Us" or "Our" in this Agreement refers to Phinative Soft
+            Private limited, registered Pent house, Plot 492, Venkataramana
+            colony, Telangana, India.
           </div>
           <div class="absolute top-0 left-0 h-full w-0.5 bg-a1"></div>
         </div>

--- a/client/landing/shared/RefundPolicy.svelte
+++ b/client/landing/shared/RefundPolicy.svelte
@@ -6,7 +6,9 @@
     >.
   </p>
 
-  <p>Thank you for shopping at <strong>Blank Labs Private Limited</strong>.</p>
+  <p>
+    Thank you for shopping at <strong>Phinative Soft Private Limited</strong>.
+  </p>
 
   <p>
     The following terms are applicable for any products that you have purchased

--- a/client/landing/shared/TermsofService.svelte
+++ b/client/landing/shared/TermsofService.svelte
@@ -74,7 +74,7 @@
   <p>
     All content, features, and functionality of our services, including but not
     limited to text, graphics, logos, and software, are the exclusive property
-    of <strong>Blank Labs Private Limited</strong> and are protected by international
+    of <strong>Phinative Soft Private Limited</strong> and are protected by international
     copyright, trademark, and other intellectual property laws.
   </p>
 

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -45,6 +45,7 @@
   import view from "@21n/stores/view.store";
   let timer: any;
   let isMounted = false;
+  let lastOrientation: 'portrait' | 'landscape' | null = null;
   const productConfig = resolveProductConfig();
 
   onMount(async () => {
@@ -221,6 +222,7 @@
       if (isInLowDataMode)
         $context.isInLowDataMode = isInLowDataMode === "true";
       initUserAgentClasses($context);
+      updateOrientationClasses();
     } catch (e) {
       const errorMessage =
         e instanceof Error
@@ -258,6 +260,25 @@
       if (userAgent.includes("handset")) html.classList.add("embed-handset");
       if (userAgent.includes("tablet")) html.classList.add("embed-tablet");
     }
+  }
+
+  function updateOrientationClasses(): boolean {
+    const html = document.documentElement;
+    const isPortrait = window.innerHeight > window.innerWidth;
+    const currentOrientation = isPortrait ? 'portrait' : 'landscape';
+    
+    const hasOrientationChanged = lastOrientation !== null && lastOrientation !== currentOrientation;
+    lastOrientation = currentOrientation;
+    
+    html.classList.remove("device-portrait", "device-landscape");
+    
+    if (isPortrait) {
+      html.classList.add("device-portrait");
+    } else {
+      html.classList.add("device-landscape");
+    }
+    
+    return hasOrientationChanged;
   }
 
   /**
@@ -407,11 +428,16 @@
 
   const windowResizeListener = (event: Event) => {
     view.refresh(window.innerWidth, window.innerHeight);
+    const hasOrientationChanged = updateOrientationClasses();
+    if (hasOrientationChanged) {
+      appStore.gotoPath("/");
+    }
   };
 
   const handleScreenOrientationChange = () => {
     setTimeout(() => {
       view.refresh(window.innerWidth, window.innerHeight);
+      updateOrientationClasses();
       appStore.gotoPath("/");
     }, 100);
   };

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -75,7 +75,7 @@
         "relative flex flex-col h-full",
         {
           "w-full": $view.isConstrainedWidth || isExpanded,
-          "embed-ios:pt-12": !isPreventCwPadding
+          "otop:pt-12": !isPreventCwPadding
         },
         !$view.isConstrainedWidth &&
           !isExpanded && {

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -67,7 +67,7 @@
 {#if !isInFocusMode}
   <div
     class={cn(
-      "w-full h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata embed-ios:mt-12 embed-tablet:mt-12 relative embed-ios:before:absolute embed-ios:before:-top-12 embed-ios:before:bottom-0 embed-ios:before:left-0 embed-ios:before:right-0 embed-ios:before:bg-bgs2",
+      "w-full h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata embed-ios:mt-6 embed-tablet:mt-6 relative embed-ios:before:absolute embed-ios:before:-top-6 embed-ios:before:bottom-0 embed-ios:before:left-0 embed-ios:before:right-0 embed-ios:before:bg-bgs2",
       {
         "flex gap-3 justify-between items-center":
           pinnedItems.length > 0 || isInterimTab,

--- a/client/products/memotron/capture/typeSelector/TypeSelectorItem.svelte
+++ b/client/products/memotron/capture/typeSelector/TypeSelectorItem.svelte
@@ -38,6 +38,7 @@
       $context.os === OperatingSystem.IOS
     ) {
       inputRef?.click();
+      return;
     }
     const val = item.value;
     if (typeof val !== "string") return;

--- a/client/products/memotron/library/search/ResourceSearchBase.svelte
+++ b/client/products/memotron/library/search/ResourceSearchBase.svelte
@@ -175,7 +175,7 @@
 <div
   class={cn("flex flex-col gap-4 w-full h-full", {
     "bg-bgs2": isGlobalSearchModal && resource === Resource.everything,
-    "embed-ios:pt-12": isGlobalSearchModal
+    "otop:pt-12": isGlobalSearchModal
   })}
 >
   <header class={"flex flex-col w-full"}>

--- a/client/products/memotron/node/Node.svelte
+++ b/client/products/memotron/node/Node.svelte
@@ -88,7 +88,7 @@
     <NonMediaNode {node} selectedView={view} />
   {/if}
 {:else}
-  <div class="w-full h-full embed-ios:pt-12 pt-4 mo:px-4 px-20">
+  <div class="w-full h-full otop:pt-12 pt-4 mo:px-4 px-20">
     <NodeLoadingPulse />
   </div>
 {/if}

--- a/client/products/memotron/node/base/NonMediaNode.svelte
+++ b/client/products/memotron/node/base/NonMediaNode.svelte
@@ -158,7 +158,7 @@
     {#if selectedView === NodeView.CONTENT}
       {#key refreshId}
         <div
-          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4 embed-ios:pt-12", {
+          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4 otop:pt-12", {
             "flex px-4 justify-center": !isWidened,
             "dp:grid dp:grid-cols-[1fr_auto_1fr] dp:gap-2":
               !isWidened && !isConstrainedWidth,
@@ -356,7 +356,7 @@
       </BottomFloat>
     {/if}
   {:else}
-    <div class="w-full h-full pt-4 px-20 embed-ios:pt-12">
+    <div class="w-full h-full pt-4 px-20 otop:pt-12">
       <NodeLoadingPulse />
     </div>
   {/if}

--- a/client/products/memotron/node/content/MediaContent.svelte
+++ b/client/products/memotron/node/content/MediaContent.svelte
@@ -45,7 +45,7 @@
   }
 </script>
 
-<div class="flex w-full flex-grow cw:mb-8 tp:embed-ios:pt-12">
+<div class="flex w-full flex-grow cw:mb-8 tp:otop:pt-12">
   {#if !(isConstrainedWidth && rightPane)}
     <main
       class={cn("relative flex w-full justify-center flex-1", {

--- a/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
+++ b/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
@@ -89,7 +89,7 @@
     {/if}
     <div
       class={cn(
-        "flex flex-col gap-2 w-full justify-center items-center bg-bgs1 mo:p-2 p-3 cw:border-b cw:border-b-brs2 cw:border-t-transparent cw:rounded-none cw:bg-bgs2 cw:embed-ios:pt-12 border-t border-t-brs2",
+        "flex flex-col gap-2 w-full justify-center items-center bg-bgs1 mo:p-2 p-3 cw:border-b cw:border-b-brs2 cw:border-t-transparent cw:rounded-none cw:bg-bgs2 cw:otop:pt-12 border-t border-t-brs2",
         {
           "rounded-b-md": $node.accessMode === ResourceAccessMode.POP,
           "w-full": $node.accessMode !== ResourceAccessMode.SLIDESHOW,

--- a/client/products/pointron/analytics/AnalyticsV2.svelte
+++ b/client/products/pointron/analytics/AnalyticsV2.svelte
@@ -62,9 +62,7 @@
   }
 </script>
 
-<main
-  class={cn("flex flex-col w-full h-full embed-ios:pt-12", bg(bgIndex - 1))}
->
+<main class={cn("flex flex-col w-full h-full otop:pt-12", bg(bgIndex - 1))}>
   <div
     class="flex gap-8 w-full items-center justify-between portrait:px-4 portrait:py-2 portrait:pt-4 portrait:pb-2"
   >

--- a/client/products/pointron/focus/Focus.svelte
+++ b/client/products/pointron/focus/Focus.svelte
@@ -70,7 +70,7 @@
 </script>
 
 {#if $view.isPortrait}
-  <main class="relative flex w-full h-full embed-ios:pt-12">
+  <main class="relative flex w-full h-full otop:pt-12">
     <div class="flex flex-col h-full w-full">
       {#if $activeSession.isSessionRunning && !$activeSession.isQuickStartOn && isInlineEnabled}
         <Zen isInline={true} />

--- a/client/products/pointron/logs/logPage/SessionLogPage.svelte
+++ b/client/products/pointron/logs/logPage/SessionLogPage.svelte
@@ -106,7 +106,7 @@
   />
 {:then}
   <div
-    class="flex flex-col gap-6 flex-grow w-full items-center userdata embed-ios:pt-12"
+    class="flex flex-col gap-6 flex-grow w-full items-center userdata otop:pt-12"
   >
     <div class="flex gap-4 w-full items-center justify-between">
       <Text content="Session details" style={TextStyle.PANEL_HEADING} />

--- a/client/theme/tidigit.tailwind.js
+++ b/client/theme/tidigit.tailwind.js
@@ -324,6 +324,8 @@ export default {
       addVariant("embed-windows", ".embed.os-windows &");
       addVariant("embed-android", ".embed.os-android &");
       addVariant("embed-linux", ".embed.os-linux &");
+      // offset on top (otop) - for iphone and ipad - as edges default padding is ignored on SwiftUI
+      addVariant("otop", ".embed.os-ios.device-portrait &");
     }
     // require("@iconify/tailwind").addIconSelectors({
     //   prefixes: ["ph"]

--- a/client/utils/embed.utils.ts
+++ b/client/utils/embed.utils.ts
@@ -37,7 +37,7 @@ export function postDataToParent(key: EmbedDataMessage, data: any) {
 }
 
 /**
- * @deprecated - No longer required - using direct embed-ios:pt-12 at relevant places
+ * @deprecated - No longer required - using direct otop:pt-12 at relevant places
  * @param bg
  */
 export function setEmbedBg(bg: number) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improves iPad/iOS embedded layouts by adding an orientation-aware padding variant and updating components for safer top spacing and stable rendering. Also updates legal pages with the new company name and bumps build numbers for pre-release testing.

- **UI and Responsiveness**
  - Added Tailwind variant otop (iOS embed, portrait) and replaced embed-ios:pt-12 with otop:pt-12 across views.
  - Detects orientation and sets html classes device-portrait/device-landscape; refreshes view on resize and redirects on orientation changes for consistency.
  - Modal tweaks: proper bg in iOS embed, safe-area top padding in landscape embeds.
  - TopNav reduced iOS embed top offset (12 → 6) for better spacing on iPad.
  - Calendar: min width applies only outside Day view.
  - iOS file input fix in Memotron type selector (early return after click).
  - Version/build bump for memotron, nucleus, and pointron for release testing.
  - Addresses Linear TASK-538: iPad responsiveness.

- **Legal**
  - Updated company name to Phinative Soft Private Limited in Privacy, Refund, and Terms pages.

<!-- End of auto-generated description by cubic. -->

