### PR TITLE
Tidy 7 release - Nucleus v0.3.2, Memotron v0.61.3, Pointron v0.83.1

### DIFF
--- a/apps/memotron/package.json
+++ b/apps/memotron/package.json
@@ -1,6 +1,7 @@
 {
   "name": "memotron-app",
-  "version": "0.61.0",
+  "version": "0.61.3",
+  "build": 11,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5002",

--- a/apps/memotron/src/local.ts
+++ b/apps/memotron/src/local.ts
@@ -1,7 +1,8 @@
+import packageJson from "../package.json";
 import config from "$lib/client/products/memotron/memotron.config";
 
-const version = "0.61.3";
-const build = 10;
+const version = packageJson.version;
+const build = packageJson.build;
 
 export default {
   version,

--- a/apps/memotron/src/local.ts
+++ b/apps/memotron/src/local.ts
@@ -1,8 +1,7 @@
 import packageJson from "../package.json";
 import config from "$lib/client/products/memotron/memotron.config";
 
-const version = packageJson.version;
-const build = packageJson.build;
+const { version, build } = packageJson;
 
 export default {
   version,

--- a/apps/nucleus/package.json
+++ b/apps/nucleus/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nucleus-app",
-  "version": "0.3.0",
+  "version": "0.3.2",
+  "build": 11,
   "private": true,
   "scripts": {
     "dev": "vite dev --port 5050",

--- a/apps/nucleus/src/local.ts
+++ b/apps/nucleus/src/local.ts
@@ -1,7 +1,7 @@
-import config from "$lib/client/products/nucleus/nucleus.config";
+import packageJson from "../package.json";
+import config from "$lib/client/products/memotron/memotron.config";
 
-const version = "0.3.2";
-const build = 10;
+const { version, build } = packageJson;
 
 export default {
   version,

--- a/apps/nucleus/src/local.ts
+++ b/apps/nucleus/src/local.ts
@@ -1,5 +1,5 @@
 import packageJson from "../package.json";
-import config from "$lib/client/products/memotron/memotron.config";
+import config from "$lib/client/products/nucleus/nucleus.config";
 
 const { version, build } = packageJson;
 

--- a/apps/pointron/package.json
+++ b/apps/pointron/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pointron-app",
-  "version": "0.83.0",
+  "version": "0.83.1",
+  "build": 10,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5001",

--- a/apps/pointron/src/local.ts
+++ b/apps/pointron/src/local.ts
@@ -1,5 +1,5 @@
 import packageJson from "../package.json";
-import config from "$lib/client/products/memotron/memotron.config";
+import config from "$lib/client/products/pointron/pointron.config";
 
 const { version, build } = packageJson;
 

--- a/apps/pointron/src/local.ts
+++ b/apps/pointron/src/local.ts
@@ -1,7 +1,7 @@
-import config from "$lib/client/products/pointron/pointron.config";
+import packageJson from "../package.json";
+import config from "$lib/client/products/memotron/memotron.config";
 
-const version = "0.83.1";
-const build = 9;
+const { version, build } = packageJson;
 
 export default {
   version,

--- a/client/components/collection/Collection.svelte
+++ b/client/components/collection/Collection.svelte
@@ -23,13 +23,12 @@
     type IProperty
   } from "$lib/client/components/collection/properties/property.type";
   import { activeResourceFilter } from "$lib/client/utils/utils";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { DropdownItem } from "$lib/client/types/dropdownItem.type";
   import type {
     ISelectItem,
     ISelectValue
   } from "$lib/client/types/select.type";
-  import FullScreenCloseButton from "$lib/client/elements/button/FullScreenCloseButton.svelte";
   import {
     ResourceAccessMode,
     ResourceAccessPoint,
@@ -120,6 +119,7 @@
 
   $: isConstrainedWidth =
     $view.isConstrainedWidth ||
+    $view.isPortrait ||
     $collection?.accessMode === ResourceAccessMode.SPLIT ||
     $collection?.accessMode === ResourceAccessMode.FSPLIT ||
     (containerWidth < 1000 &&
@@ -129,8 +129,7 @@
   $: coverPlacement =
     $collection?.coverLayout?.placement === Placement.Top ||
     !$collection?.coverLayout?.placement ||
-    isConstrainedWidth ||
-    $view.isPortrait
+    isConstrainedWidth
       ? Placement.Top
       : $collection?.coverLayout?.placement;
 
@@ -164,6 +163,10 @@
     refreshViewsLane();
     isReady = true;
     await refresh({ isNewView: true });
+  });
+
+  onDestroy(() => {
+    ActiveCollectionStore.destroy(id, accessMode);
   });
 
   async function resolvePropertyList() {
@@ -585,7 +588,7 @@
     {:else}
       <div
         class={cn("flex flex-col flex-1", {
-          "mo:gap-4 gap-8": !isSingleViewMode || isShowMetaViews,
+          "mo:gap-4 gap-6": !isSingleViewMode || isShowMetaViews,
           "h-full overflow-auto": coverPlacement !== Placement.Top,
           "w-full": coverPlacement === Placement.Top
         })}
@@ -609,7 +612,7 @@
             // When in edit mode, interfering with view settings dropdown when the dropdown opens on top if z-20 is set
             "z-20": isSingleViewMode && !$collection.isInEditMode,
             "pb-8": isSingleViewMode && !isShowMetaViews && !isConstrainedWidth,
-            "pt-6": !isConstrainedWidth,
+            "pt-4": !isConstrainedWidth,
             "p-2": isConstrainedWidth,
             "otop:pt-12": !$collection.cover || positionFromTop === 0,
             "max-w-full overflow-x-auto":
@@ -831,12 +834,6 @@
         on:repositionDebounced={onCoverRepositionDebounced}
         on:resize={onCoverResize}
         on:resizeDebounced={onCoverResizeDebounced}
-      />
-    {/if}
-    {#if $collection?.accessMode === ResourceAccessMode.SPLIT || $collection?.accessMode === ResourceAccessMode.FULL || $collection?.accessMode === ResourceAccessMode.FSPLIT}
-      <FullScreenCloseButton
-        style={ButtonVariant.DANGER}
-        accessMode={$collection.accessMode}
       />
     {/if}
   </div>

--- a/client/components/collection/CollectionTitleBar.svelte
+++ b/client/components/collection/CollectionTitleBar.svelte
@@ -7,6 +7,7 @@
   import ContextMenuAction from "$lib/client/elements/contextMenu/ContextMenuAction.svelte";
   import { resolveCollectionContextMenu } from "./collection.store";
   import {
+    ResourceAccessMode,
     ResourceAccessPoint,
     ResourceActionType
   } from "$lib/client/components/flux/resourceStores/resource.type";
@@ -28,12 +29,12 @@
   import { PopoverTriggerMethod } from "$lib/client/types/popover.type";
   import FormLabelTooltip from "$lib/client/elements/text/formLabel/FormLabelTooltip.svelte";
   import { isValidAvatar } from "$lib/client/elements/avatarPicker/avatar.utils";
-  import { fade } from "svelte/transition";
   import { resourceAction } from "../flux/resourceStores/resource.utils";
   import { Resource } from "../flux/resourceStores/resource.enum";
   import CollectionDescriptionEditPopover from "./CollectionDescriptionEditPopover.svelte";
   import RecordStarStatusFeedback from "../record/RecordStarStatusFeedback.svelte";
   import BackButton from "$lib/client/elements/button/BackButton.svelte";
+  import ResourceInlineCloseButton from "$lib/client/elements/button/ResourceInlineCloseButton.svelte";
 
   const dispatch = createEventDispatcher();
   export let searchQuery: string = "";
@@ -82,15 +83,28 @@
 </script>
 
 <div
-  class="w-full flex gap-1 justify-between items-center sticky- top--0 py--6"
+  class={cn(
+    "min-w-0 flex-1 gap-2 items-center sticky- top--0 py--6",
+    {
+      "flex justify-between": isConstrainedWidth,
+      grid: !isConstrainedWidth
+    },
+    !isConstrainedWidth && {
+      "grid-cols-[auto_1fr]": !$collection.isInEditMode,
+      "grid-cols-[1fr_auto]": $collection.isInEditMode
+    }
+  )}
 >
   <!-- TODO breadcrumbs - if launched as child from a combination i.e. if parent present, back button to previous resource - if launched from a mention or links -->
 
   <BackButton
     isEnabled={!$collection.isInEditMode &&
       isConstrainedWidth &&
-      accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
+      accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED &&
+      $collection.accessMode !== ResourceAccessMode.INLINE &&
+      $collection.accessMode !== ResourceAccessMode.FULL}
     accessMode={$collection.accessMode}
+    class="truncate"
   >
     {#if $collection.type === CollectionType.TYPED}
       {@const avatar =
@@ -99,7 +113,7 @@
           : $collection.avatar}
       {@const isAvatarPresent = isValidAvatar(avatar)}
       <span
-        class={cn("flex h-12 items-center justify-center", {
+        class={cn("flex h-10 items-center justify-center", {
           "w-12": $collection.isInEditMode,
           "w-8": isAvatarPresent && !$collection.isInEditMode
         })}
@@ -109,19 +123,19 @@
             bind:avatar={$collection.avatar}
             isInEditMode={true}
             on:change={onAvatarChange}
-            size={Size.lg}
+            size={Size.md}
           />
         {:else if isAvatarPresent}
-          <Avatar {avatar} isInEditMode={false} size={Size.lg} />
+          <Avatar {avatar} isInEditMode={false} size={Size.md} />
         {/if}
       </span>
     {/if}
     <span
       class={cn(
-        "flex items-center gap-4 font-medium cw:text-h4 cw:h-12 text-h1 whitespace-nowrap flex-1 min-w-0 border rounded-md text-left cw:mr-0 mr-6",
+        "flex items-center gap-4 font-medium cw:text-h4 cw:h-12 text-h2 whitespace-nowrap flex-1 min-w-0 border rounded-md text-left cw:mr-0 mr-6",
         {
           "border-transparent": !$collection.isInEditMode,
-          "border-brs3 px-2": $collection.isInEditMode
+          "border-brs3 px-2 max-w-xl": $collection.isInEditMode
         }
       )}
     >
@@ -130,7 +144,7 @@
     {/if} -->
       {#if $collection.isInEditMode}
         <TextInput
-          size={Size.lg}
+          size={Size.md}
           bind:value={$collection.label}
           placeholder="Collection title"
           style={InputStyle.PLAIN}
@@ -138,13 +152,16 @@
           on:debouncedChange={onLabelChange}
         />
       {:else}
-        {@const title = ($collection.label ?? "").trim() || "Untitled collection"}
+        {@const title =
+          ($collection.label ?? "").trim() || "Untitled collection"}
         <div class="truncate userdata">{title}</div>
       {/if}
       {#if ($collection.description && isDetailsBesideTitleRenderable) || $collection.isInEditMode}
-        {@const popoverComponent = $collection.isInEditMode ? CollectionDescriptionEditPopover : Tooltip}
-        {@const popoverProps = $collection.isInEditMode 
-          ? { collection } 
+        {@const popoverComponent = $collection.isInEditMode
+          ? CollectionDescriptionEditPopover
+          : Tooltip}
+        {@const popoverProps = $collection.isInEditMode
+          ? { collection }
           : { info: { body: $collection.description, size: Size.sm } }}
         <button
           class="flex justify-center items-center"
@@ -171,7 +188,9 @@
           class="flex items-center justify-center"
           type="button"
           aria-pressed={$collection.isStarred}
-          on:click={() => { collection.modify({ isStarred: false }); }}
+          on:click={() => {
+            collection.modify({ isStarred: false });
+          }}
           use:tooltip={{ text: "Unstar collection" }}
         >
           <RecordStarStatusFeedback
@@ -191,7 +210,7 @@
           <span class="flex gap-2 items-center px-2 py-0.5">
             <Icon icon="ph:cube-light" size={Size.sm} class="stroke-fgs3" />
             {$collection.properties?.length ?? 0}
-            {#if !isConstrainedWidth && !isMiniSearch}
+            {#if !isConstrainedWidth && rightPartWidth > 1000}
               {($collection.properties?.length ?? 0) === 1
                 ? "property"
                 : "properties"}
@@ -216,45 +235,54 @@
   </BackButton>
 
   {#if isConstrainedWidth && accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
-    <ContextMenuAction
-      menuResolver={() =>
-        resolveCollectionContextMenu($collection, ResourceAccessPoint.SELF)}
-      position={Placement.Left}
-      id="collectionContextMenu"
-      size={Size.lg}
-    />
+    <div class="flex gap-2 justify-center items-center">
+      <ContextMenuAction
+        menuResolver={() =>
+          resolveCollectionContextMenu($collection, ResourceAccessPoint.SELF, {
+            accessMode: $collection.accessMode
+          })}
+        position={Placement.Left}
+        id="collectionContextMenu"
+        size={Size.lg}
+      />
+      <ResourceInlineCloseButton
+        accessMode={$collection.accessMode}
+        id={$collection.id}
+      />
+    </div>
   {:else if accessPoint !== ResourceAccessPoint.MARKDOWN_EMBED}
     <span
-      class={cn("flex gap-3 justify-end items-center", {
-        "w-1/2": !$collection.isInEditMode && !isMiniSearch,
-        "w-2/3": !$collection.isInEditMode && isMiniSearch && isSearchFocused,
-        "w-1/3": $collection.isInEditMode
-      })}
+      class="flex gap-3 justify-end items-center"
       use:resizeListener={(e) => {
+        if (isSearchFocused) return;
         rightPartWidth = e.width;
       }}
     >
       {#if !$collection.isInEditMode && $collection.totalItemCount}
         <div
-          class={cn("flex rounded-full", {
-            "border-aps1": isSearchFocused,
-            "border-brs3": !isSearchFocused,
-            // "ml-2": isSingleViewMode && !isMiniSearch,
-            "flex-1 border px-3 py-2": !isMiniSearch || isSearchFocused
-          })}
-          transition:fade={{ duration: 100 }}
+          class={cn(
+            "flex rounded-full h-full transition-all duration-250 ease-in-out",
+            {
+              "border-aps1": isSearchFocused,
+              "border-brs3 max-w-2xl": !isSearchFocused,
+              "min-w-0 flex-1 border px-3 py-1.5":
+                !isMiniSearch || isSearchFocused
+            }
+          )}
         >
           {#if isMiniSearch && !isSearchFocused}
-            <Button
-              icon="search"
-              tooltip={resolveSearchPlaceholder($collection.totalItemCount)}
+            <button
               on:click={() => {
                 isSearchFocused = true;
                 setTimeout(() => {
                   searchBoxRef?.focus();
                 }, 10);
               }}
-            />
+              class="flex items-center justify-center"
+              title={resolveSearchPlaceholder($collection.totalItemCount)}
+            >
+              <Icon icon="search" />
+            </button>
           {:else}
             <TextInput
               style={InputStyle.PLAIN}
@@ -263,7 +291,13 @@
               icon="search"
               placeholder={resolveSearchPlaceholder($collection.totalItemCount)}
               on:focus={() => (isSearchFocused = true)}
-              on:blur={() => (isSearchFocused = false)}
+              on:blur={(e) => (isSearchFocused = false)}
+              isShowClearControl={searchQuery !== "" || isSearchFocused}
+              on:cancel={() => {
+                searchQuery = "";
+                dispatch("search");
+                isSearchFocused = false;
+              }}
               on:input={onSearchQueryChange}
             />
           {/if}
@@ -287,7 +321,13 @@
         {/if}
         <ContextMenuAction
           menuResolver={() =>
-            resolveCollectionContextMenu($collection, ResourceAccessPoint.SELF)}
+            resolveCollectionContextMenu(
+              $collection,
+              ResourceAccessPoint.SELF,
+              {
+                accessMode: $collection.accessMode
+              }
+            )}
           position={Placement.BottomCenter}
           id="collectionContextMenu"
           size={Size.lg}
@@ -295,6 +335,10 @@
         {#if isSingleViewMode}
           <AddResourceAction on:add variant="default" />
         {/if}
+        <ResourceInlineCloseButton
+          accessMode={$collection.accessMode}
+          id={$collection.id}
+        />
       {/if}
     </span>
   {/if}

--- a/client/components/collection/CreateCollection.svelte
+++ b/client/components/collection/CreateCollection.svelte
@@ -151,7 +151,7 @@
 </script>
 
 <div class="flex w-full h-full items-start">
-  {#if !$view.isConstrainedWidth}
+  {#if !$view.isConstrainedWidth && !$view.isPortrait}
     <button
       class="relative flex flex-col items-center justify-center w-48 h-full"
       use:hoverable={{

--- a/client/components/collection/boardView/BoardPane.svelte
+++ b/client/components/collection/boardView/BoardPane.svelte
@@ -70,7 +70,7 @@
         "border-brs3 bg-bgs1": !group.color || !dev_isRenderColors
       }
     )}
-    style="height: calc(100vh - 120px);"
+    style="height: calc(100vh - 150px);"
     use:dropzone={{
       duringDragoverClasses: "!border-ccs1",
       itemRequirement: "resource",

--- a/client/components/collection/collection.store.ts
+++ b/client/components/collection/collection.store.ts
@@ -59,7 +59,7 @@ import { resolveCollectionResource } from "./collection.utils";
 import { viewStore } from "./view.store";
 import { uiState } from "$lib/client/stores/uiState/uiState.store";
 import { UIState } from "$lib/client/stores/uiState/uiState.type";
-import view from "@21n/stores/view.store";
+import view from "$lib/client/stores/view.store";
 
 const defaults: Partial<ICollection> = {
   type: CollectionType.UNTYPED,

--- a/client/components/collection/collection.store.ts
+++ b/client/components/collection/collection.store.ts
@@ -59,6 +59,7 @@ import { resolveCollectionResource } from "./collection.utils";
 import { viewStore } from "./view.store";
 import { uiState } from "$lib/client/stores/uiState/uiState.store";
 import { UIState } from "$lib/client/stores/uiState/uiState.type";
+import view from "@21n/stores/view.store";
 
 const defaults: Partial<ICollection> = {
   type: CollectionType.UNTYPED,
@@ -565,7 +566,13 @@ export const collectionLayoutOptions = [
 
 export function resolveCollectionContextMenu(
   collection: ICollection,
-  accessPoint: ResourceAccessPoint
+  accessPoint: ResourceAccessPoint,
+  params?: {
+    accessPointId?: IRecordId;
+    accessMode?: ResourceAccessMode;
+    accessPointContext?: string;
+    isConstrainedWidth?: boolean;
+  }
 ): IContextMenu {
   const resourceActions = new ResourceActions(
     collection,
@@ -573,12 +580,24 @@ export function resolveCollectionContextMenu(
     accessPoint
   );
   const ctx = get(context);
+  const viewStore = get(view);
   let commonGroups: { group: string; items: IContextMenuItem[] }[] = [];
+  const moreGroup = {
+    group: "more",
+    items: [resourceActions.archive(), resourceActions.trash()]
+  };
   if (ctx.isEmbed && ctx.embed === Embed.HANDSET) {
+    commonGroups = [moreGroup];
+  } else if (
+    viewStore.isPortrait &&
+    accessPoint === ResourceAccessPoint.SELF &&
+    params?.accessMode === ResourceAccessMode.INLINE
+  ) {
     commonGroups = [
+      moreGroup,
       {
-        group: "more",
-        items: [resourceActions.archive(), resourceActions.trash()]
+        group: "open",
+        items: [resourceActions.openAsFull()]
       }
     ];
   } else {
@@ -591,10 +610,7 @@ export function resolveCollectionContextMenu(
           resourceActions.openAsFull()
         ]
       },
-      {
-        group: "more",
-        items: [resourceActions.archive(), resourceActions.trash()]
-      }
+      moreGroup
     ];
   }
   if (accessPoint != ResourceAccessPoint.SELF) {
@@ -619,7 +635,6 @@ export function resolveCollectionContextMenu(
       type: ContextMenuType.SWITCH,
       initialValue: collection.isCaptureShortcutEnabled,
       callback: async (checked) => {
-        console.log({ checked });
         const result = await collectionStore.modify(collection.id, {
           isCaptureShortcutEnabled: checked
         });

--- a/client/components/collection/properties/PropertiesEditor.svelte
+++ b/client/components/collection/properties/PropertiesEditor.svelte
@@ -56,6 +56,7 @@
   import { objIsEmpty } from "$lib/shared/utils/obj.utils";
   import CollectionTitleLabelPart from "../thumbnail/CollectionThumbnailLabel.svelte";
   import { Product } from "$lib/client/products/product.type";
+  import Table3 from "$lib/client/elements/table/Table3.svelte";
   export let id: IRecordId | undefined = undefined;
   let collection: IActiveCollectionStore | undefined = id
     ? ActiveCollectionStore.resolve(id)
@@ -355,7 +356,7 @@
       </div>
       <div class="flex flex-col items-start w-full gap-2 flex-grow">
         <Text content="Properties" style={TextStyle.SECTION_HEADING} />
-        <Table2
+        <Table3
           id={tableId}
           isStyled={true}
           width="min-w-[60rem]"

--- a/client/components/collection/properties/PropertiesEditor.svelte
+++ b/client/components/collection/properties/PropertiesEditor.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Table2 from "$lib/client/elements/table/Table2.svelte";
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import { Size } from "$lib/client/types/size.enum";
   import {

--- a/client/components/collection/properties/propertyConfig/PropertyConfig.svelte
+++ b/client/components/collection/properties/propertyConfig/PropertyConfig.svelte
@@ -19,7 +19,7 @@
 
 {#if propertyTypesWithConfiguration.includes(row.type)}
   <div
-    class={cn("rounded-md w-full border flex items-center", {
+    class={cn("rounded-md w-full border flex items-center h-11", {
       "border-aps1": isPopoverOpen,
       "border-brs3": !isPopoverOpen
     })}

--- a/client/components/collection/properties/propertyTypeSelector/PropertyTypeSelector.svelte
+++ b/client/components/collection/properties/propertyTypeSelector/PropertyTypeSelector.svelte
@@ -86,7 +86,7 @@
 
 <div
   class={cn(
-    "flex w-full justify-between items-center gap-2 rounded-md border p-2",
+    "flex w-full justify-between items-center gap-2 rounded-md border p-2 h-11",
     {
       "border-brs3": !isPopoverVisible,
       "border-aps1": isPopoverVisible

--- a/client/components/flux/resourceStores/resource.store.ts
+++ b/client/components/flux/resourceStores/resource.store.ts
@@ -21,12 +21,13 @@ import {
 import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
 import { ObservableStore } from "../../../stores/client.store";
 import { resolveCurrentUserId } from "../../../utils/account.utils";
-import type {
-  IMultiSelectContext,
-  IMultiSelectStore,
-  IResource,
-  IResourceMutationParams,
-  IResourceCaptureV2
+import {
+  type IMultiSelectContext,
+  type IMultiSelectStore,
+  type IResource,
+  type IResourceMutationParams,
+  type IResourceCaptureV2,
+  ResourceAccessMode
 } from "./resource.type";
 import { flux } from "../flux";
 import {
@@ -38,10 +39,13 @@ import { FluxMethod } from "../flux.type";
 import { generateResourceId } from "../flux.utils";
 import { toasts } from "$lib/client/stores/notification.store";
 import { logger } from "../../debug/logger.client";
-import { isSameResource, resourceInList } from "./resource.utils";
+import {
+  determineResourceAccessMode,
+  isSameResource,
+  resourceInList
+} from "./resource.utils";
 import { GlobalEvent } from "$lib/client/types/event.enum";
 import { isValidArrayWithData } from "$lib/shared/utils/obj.utils";
-import { AppSearchParam } from "$lib/client/types/appStore.type";
 import { stringify } from "$lib/shared/utils/json.utils";
 
 const activeResources = new Map<string, ActiveResourceStore<any, any, any>>();
@@ -180,7 +184,20 @@ export class ActiveResourceStore<
     return val! as T;
   }
 
-  static destroy(id: IRecordId) {
+  static destroy(id: IRecordId, accessMode?: ResourceAccessMode) {
+    if (accessMode === ResourceAccessMode.FULL) {
+      const _accessMode = determineResourceAccessMode(id);
+      if (_accessMode !== ResourceAccessMode.FULL) {
+        const resource = activeResources.get(id.toString());
+        if (resource) {
+          resource.update((prev) => ({
+            ...prev,
+            accessMode: _accessMode
+          }));
+        }
+        return;
+      }
+    }
     activeResources.delete(id.toString());
   }
 }

--- a/client/components/flux/resourceStores/resource.utils.ts
+++ b/client/components/flux/resourceStores/resource.utils.ts
@@ -1,5 +1,9 @@
 import { Resource } from "./resource.enum";
-import { ResourceActionType, type ResourceAccessPoint } from "./resource.type";
+import {
+  ResourceAccessMode,
+  ResourceActionType,
+  type ResourceAccessPoint
+} from "./resource.type";
 import type { IRecordId } from "$lib/client/types/data.type";
 import { logger } from "../../debug/logger.client";
 import { properCase } from "$lib/shared/utils/text.utils";
@@ -324,3 +328,14 @@ export function resolveResourceActionIcon(action: ResourceActionType) {
       return "question";
   }
 }
+
+export const determineResourceAccessMode = (
+  id: IRecordId
+): ResourceAccessMode => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const mode = (Object.values(ResourceAccessMode) as string[]).find(
+    (m) =>
+      m !== ResourceAccessMode.INLINE && searchParams.get(m) === id.toString()
+  );
+  return (mode as ResourceAccessMode) || ResourceAccessMode.INLINE;
+};

--- a/client/components/flux/resourceStores/resource.utils.ts
+++ b/client/components/flux/resourceStores/resource.utils.ts
@@ -332,7 +332,7 @@ export function resolveResourceActionIcon(action: ResourceActionType) {
 export const determineResourceAccessMode = (
   id: IRecordId
 ): ResourceAccessMode => {
-  const searchParams = new URLSearchParams(window.location.search);
+  const searchParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
   const mode = (Object.values(ResourceAccessMode) as string[]).find(
     (m) =>
       m !== ResourceAccessMode.INLINE && searchParams.get(m) === id.toString()

--- a/client/components/goals/Goal.svelte
+++ b/client/components/goals/Goal.svelte
@@ -20,7 +20,7 @@
   import { appStore } from "$lib/client/stores/app.store";
   import GoalHistory from "./history/GoalHistory.svelte";
   import GoalTasks from "./tasks/GoalTasks.svelte";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
   import PropertiesPane from "../collection/properties/PropertiesPane.svelte";
   import { cn } from "$lib/client/utils/ui.utils";
@@ -63,6 +63,10 @@
     return () => {
       pageSub();
     };
+  });
+
+  onDestroy(() => {
+    ActiveGoalStore.destroy(id);
   });
 
   async function initialize() {

--- a/client/components/modal/Modal.svelte
+++ b/client/components/modal/Modal.svelte
@@ -133,6 +133,7 @@
       </div>
     </div>
   {:else}
+    {@const isBlurredBg = $userPreferences.appearance?.isBlurredBgForPopups}
     <div
       class={cn(
         "pop-overlay fixed w-screen h-screen inset-0 z-50",
@@ -145,10 +146,9 @@
         isShowOverlay &&
           !isUseDialog &&
           !isInFocusMode && {
-            "bg-black bg-opacity-70":
-              !$userPreferences.appearance?.isBlurredBgForPopups,
+            "bg-black bg-opacity-70": !isBlurredBg,
             "backdrop-blur-2xl backdrop-opacity--80 backdrop-brightness--50 backdrop-grayscale bg-fgs4 bg-opacity-50 backdrop-saturate--50":
-              $userPreferences.appearance?.isBlurredBgForPopups
+              isBlurredBg
           }
       )}
       {id}
@@ -202,16 +202,15 @@
       {:else}
         <div
           id={id + "-modal"}
-          class={cn(
-            "bg-bgs1 max-h-full cursor-default landscape:embed-ios:pt-12 landscape:embed-ios:bg-transparent",
-            {
-              ...resolveSizeClasses(),
-              "rounded-md": size !== Size.full,
-              "mo:rounded-none": size !== Size.full && size !== Size.xs,
-              "mo:w-9/10": size === Size.xs,
-              "mo:w-full mo:h-full": size !== Size.xs
-            }
-          )}
+          class={cn("bg-bgs1 max-h-full cursor-default otopl:pt-12", {
+            ...resolveSizeClasses(),
+            "rounded-md otopl:bg-transparent": size !== Size.full,
+            "otopl:bg-bgs1": size === Size.full,
+            "mo:rounded-none": size !== Size.full && size !== Size.xs,
+            "mo:w-9/10": size === Size.xs,
+            "mo:w-full mo:h-full": size !== Size.xs,
+            "portrait:w-full": size !== Size.xs && size !== Size.sm
+          })}
         >
           <ColorLayer>
             <slot />

--- a/client/components/modal/ModalLayout.svelte
+++ b/client/components/modal/ModalLayout.svelte
@@ -58,7 +58,7 @@
     if (path === Action.CONFIRMATION) confirmationNotification.reset();
     else if (resource)
       appStore.closeResource({
-        inlineRestoreId: resource,
+        id: resource,
         accessMode: accessMode
       });
     else modalEvent.hide(path, "ModalLayout.svelte");
@@ -67,7 +67,7 @@
 
 {#if size === Size.full}
   <div
-    class="w-full h-full flex justify-center items-center embed-ios:pt-12 embed-ios:bg-bgs1"
+    class="w-full h-full flex justify-center items-center embed-ios:bg-bgs1"
     in:fly={{
       duration: 400,
       delay: 0,
@@ -78,7 +78,11 @@
     }}
   >
     {#if $context.embed === Embed.HANDSET && !$context.isSheet}
-      <div class="flex flex-col w-full h-full gap-2 p-2">
+      <div
+        class={cn("flex flex-col w-full h-full gap-2", {
+          "p-2 otop:pt-12": params.title
+        })}
+      >
         {#if params.title}
           <ModalHeader
             title={params.title}

--- a/client/components/record/resource.actions.ts
+++ b/client/components/record/resource.actions.ts
@@ -8,11 +8,13 @@ import { copyResourceLinkToClipboard } from "../../products/memotron/memotron.ut
 import {
   ResourceAccessPoint,
   ResourceAccessMode,
-  ResourceActionType
+  ResourceActionType,
+  type IResourceCaptureV2
 } from "$lib/client/components/flux/resourceStores/resource.type";
 import { uiState } from "$lib/client/stores/uiState/uiState.store";
 import { get } from "svelte/store";
 import {
+  determineResourceAccessMode,
   determineResourceType,
   isSameResource,
   resolveResourceActionIcon,
@@ -34,14 +36,20 @@ import { AppSearchParam } from "$lib/client/types/appStore.type";
 import { UIStateScope } from "$lib/client/stores/uiState/uiState.type";
 
 export class ResourceActions<T extends IMemotronItemBase> {
+  accessPoint?: ResourceAccessPoint;
+  accessMode?: ResourceAccessMode;
   constructor(
     private resource: T,
-    private store: ResourceStore<T>,
-    private accessPoint: ResourceAccessPoint
+    private store: ResourceStore<T, IResourceCaptureV2<T>>,
+    params?: {
+      accessPoint?: ResourceAccessPoint;
+      accessMode?: ResourceAccessMode;
+    }
   ) {
     this.resource = resource;
     this.store = store;
-    this.accessPoint = accessPoint;
+    this.accessPoint = params?.accessPoint;
+    this.accessMode = params?.accessMode;
   }
   copyLink(): IContextMenuItem {
     return {
@@ -271,7 +279,7 @@ export class ResourceActions<T extends IMemotronItemBase> {
     };
   }
   openAsSplit(): IContextMenuItem {
-    const currentMode = appStore.determineResourceAccessMode(this.resource.id);
+    const currentMode = determineResourceAccessMode(this.resource.id);
     return {
       value: "open-as-split",
       label:
@@ -295,7 +303,7 @@ export class ResourceActions<T extends IMemotronItemBase> {
     };
   }
   openAsFull(): IContextMenuItem {
-    const currentMode = appStore.determineResourceAccessMode(this.resource.id);
+    const currentMode = determineResourceAccessMode(this.resource.id);
     return {
       value: "open-in-full-screen",
       label:

--- a/client/elements/Icon.svelte
+++ b/client/elements/Icon.svelte
@@ -137,8 +137,10 @@
   import One80RingWithBg from "../iconsV2/svgSpinners/One80RingWithBg.svelte";
   import NinetyRingWithBg from "../iconsV2/svgSpinners/NinetyRingWithBg.svelte";
   import ThreeDotsFade from "../iconsV2/svgSpinners/ThreeDotsFade.svelte";
+  import { generateSimpleRandomId } from "$lib/shared/utils/crypto.utils";
 
   export let icon: string | undefined = undefined;
+  export let id: string = generateSimpleRandomId();
   export let size:
     | Size.xs
     | Size.sm
@@ -359,6 +361,7 @@
 </script>
 
 <button
+  {id}
   class={cn("relative inline-flex items-center justify-center")}
   tabindex={isTabbable ? 0 : -1}
   on:click

--- a/client/elements/button/ResourceInlineCloseButton.svelte
+++ b/client/elements/button/ResourceInlineCloseButton.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Button from "$lib/client/elements/button/Button.svelte";
+  import { ButtonStyle } from "$lib/client/types/button.type";
+  import { appStore } from "@21n/stores/app.store";
+  import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
+  import { generateSimpleRandomId } from "$lib/shared/utils/crypto.utils";
+  export let id: string;
+  export let accessMode: ResourceAccessMode;
+  const elementId = id + "-closeButton-" + generateSimpleRandomId();
+</script>
+
+{#if accessMode === ResourceAccessMode.SPLIT || accessMode === ResourceAccessMode.FULL || accessMode === ResourceAccessMode.FSPLIT}
+  <div
+    class="flex justify-center items-center"
+    id={elementId}
+    data-accessMode={accessMode}
+  >
+    <Button
+      icon="cross"
+      tooltip="Close"
+      style={ButtonStyle.OUTLINED}
+      on:click={() => {
+        appStore.closeResource({ id, accessMode });
+      }}
+    />
+  </div>
+{/if}

--- a/client/elements/button/ResourceInlineCloseButton.svelte
+++ b/client/elements/button/ResourceInlineCloseButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Button from "$lib/client/elements/button/Button.svelte";
   import { ButtonStyle } from "$lib/client/types/button.type";
-  import { appStore } from "@21n/stores/app.store";
+  import { appStore } from "$lib/client/stores/app.store";
   import { ResourceAccessMode } from "$lib/client/components/flux/resourceStores/resource.type";
   import { generateSimpleRandomId } from "$lib/shared/utils/crypto.utils";
   export let id: string;

--- a/client/elements/input/TextInput.svelte
+++ b/client/elements/input/TextInput.svelte
@@ -95,10 +95,12 @@
     }
     dispatch("keyup", { value, event });
   }
-  function onBlur() {
+  function onBlur(e: any) {
     if (isLinkType) {
       isValidLink = isValidHyperlink(value);
     }
+    if (isShowClearControl && e.relatedTarget?.id === "input-cancel-control")
+      return;
     isFocused = false;
     dispatch("blur");
   }
@@ -258,21 +260,22 @@
         </div>
       {/if} -->
       {#if isShowSaveControl || isShowClearControl}
-        <div class="flex items-center">
+        <div class="flex items-center gap-1">
           {#if isShowSaveControl}
-            <Button
+            <Icon
               icon="check"
               id="input-save-control"
-              size={Size.sm}
               on:click={(e) => dispatch("save", { event: e, value })}
             />
           {/if}
-          {#if (isShowSaveControl || isShowClearControl) && !($context.isEmbed && $context.os === OperatingSystem.IOS)}
-            <Button
+          {#if isShowSaveControl || isShowClearControl}
+            <Icon
               icon="cross"
               id="input-cancel-control"
-              size={Size.sm}
-              on:click={(e) => dispatch("cancel", { event: e })}
+              on:click={(e) => {
+                e.stopPropagation();
+                dispatch("cancel", { event: e });
+              }}
             />
           {/if}
         </div>

--- a/client/elements/select/OptionSelectorItem.svelte
+++ b/client/elements/select/OptionSelectorItem.svelte
@@ -88,7 +88,7 @@
         "gap-2":
           iconOrientation === Orientation.Horizontal ||
           (size === Size.sm && iconOrientation === Orientation.Vertical),
-        "portrait:text-base portrait:font-medium": size === Size.md,
+        "portrait:text-base": size === Size.md,
         "text-b3": size === Size.sm,
         "text-base": size === Size.lg,
         "text-aps1": isActive,

--- a/client/elements/table/Table3.svelte
+++ b/client/elements/table/Table3.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { reorderList } from "$lib/client/actions/rearrange.action";
+  import ComponentResolver from "$lib/client/layout/paint/ComponentResolver.svelte";
+  import { ButtonStyle, ButtonVariant } from "$lib/client/types/button.type";
+  import { InputStyle } from "$lib/client/types/input.type";
+  import {
+    TableCellDefaultAction,
+    TableCellType,
+    type TableColumn
+  } from "$lib/client/types/table.type";
+  import { cn } from "$lib/client/utils/ui.utils";
+  import Button from "../button/Button.svelte";
+  import Divider from "../Divider.svelte";
+  import DropDown from "../dropdown/DropDown.svelte";
+  import TextInput from "../input/TextInput.svelte";
+  import FormLabelTooltip from "../text/formLabel/FormLabelTooltip.svelte";
+  import Switch from "../toggle/Switch.svelte";
+  import { createEventDispatcher } from "svelte";
+  const dispatch = createEventDispatcher();
+  export let columns: TableColumn[] = [];
+  export let data: any = [];
+  export let actions: { action: TableCellDefaultAction; index: number }[] = [];
+  export let isStyled: boolean = false;
+  export let addAction: string | undefined = undefined;
+  export let id: string = "table";
+  export let width: string = "";
+  $: if (actions.length > 0) {
+    actions.forEach((action) => {
+      columns = [
+        ...columns.slice(0, action.index),
+        resolveDefaultAction(action.action),
+        ...columns.slice(action.index)
+      ].filter((column) => column);
+    });
+  }
+  function resolveDefaultAction(action: string) {
+    switch (action) {
+      case TableCellDefaultAction.REORDER:
+        return {
+          key: "rearrange-horizontal",
+          type: TableCellType.ACTION
+        };
+      case TableCellDefaultAction.REMOVE:
+        return {
+          key: "cross",
+          type: TableCellType.ACTION,
+          actionTooltip: {
+            body: "Remove"
+          },
+          action: (row: any) => {
+            data = data?.filter((d) => d.id !== row.id);
+          }
+        };
+      case TableCellDefaultAction.SELECT_ROW:
+        return {
+          key: "circle",
+          type: TableCellType.ACTION,
+          action: (row: any) => {
+            dispatch("select", row);
+          }
+        };
+      case TableCellDefaultAction.MULTI_SELECT_ROW:
+        return {
+          key: "check",
+          type: TableCellType.ACTION,
+          action: (row: any) => {
+            dispatch("multiSelect", row);
+          }
+        };
+    }
+  }
+  function resolveAction(column: TableColumn, row: any) {
+    if (!("action" in column)) return;
+    return column.action(row);
+  }
+</script>
+
+<div
+  class={cn("w-full overflow-x-auto", width, {
+    "rounded-md border border-brs2": isStyled
+  })}
+>
+  <div class={cn("table w-full text-b2", { "bg--bgs2 rounded-md": isStyled })}>
+    <div class="table-header-group">
+      <div class="table-row text-fgs3">
+        {#each columns as column (column.key)}
+          <div
+            class={cn("table-cell border-b border-brs2 align-middle p-3", {
+              "w-8": column.type === TableCellType.ACTION
+            })}
+            style={column.type === TableCellType.ACTION ? "width:2rem" : ""}
+          >
+            <div class="flex items-center gap-1">
+              {"label" in column ? column.label : ""}
+              {#if column.tooltip}
+                <FormLabelTooltip info={column.tooltip} />
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+    <!-- {#if isStyled}
+      <Divider />
+    {/if} -->
+    <div
+      class="table-row-group"
+      use:reorderList={{
+        listId: id,
+        draggedOverClass: "!bg-bgs3",
+        dragImage: "dragimage"
+      }}
+      on:reorder
+    >
+      {#each data as row, i (row.id)}
+        <div class="table-row" draggable="true" data-index={i}>
+          {#each columns as column}
+            <div class="table-cell align-middle px-3 py-2 text-left">
+              {#if column.type === TableCellType.TEXT_INPUT}
+                <TextInput
+                  bind:value={row[column.key]}
+                  placeholder={"placeholder" in column &&
+                  typeof column.placeholder === "string"
+                    ? column.placeholder
+                    : "placeholder" in column &&
+                        column.placeholder instanceof Function
+                      ? column.placeholder(row)
+                      : ""}
+                />
+              {:else if column.type === TableCellType.TOGGLE}
+                <Switch
+                  bind:on={row[column.key]}
+                  isDisabled={column.disabledCriteria?.(row) ?? false}
+                />
+              {:else if column.type === TableCellType.DROPDOWN && "options" in column}
+                <DropDown
+                  items={column.options}
+                  groups={column.groups}
+                  bind:value={row[column.key]}
+                  style={column.style ?? InputStyle.BORDERED}
+                />
+              {:else if column.type === TableCellType.ACTION}
+                <Button
+                  icon={column.key}
+                  tooltip={column.actionTooltip?.body}
+                  on:click={() => resolveAction(column, row)}
+                />
+              {:else if column.type === TableCellType.CUSTOM && "component" in column}
+                {@const componentProps =
+                  typeof column.componentProps === "function"
+                    ? column.componentProps(row)
+                    : column.componentProps}
+                {#if typeof column.component === "string"}
+                  <ComponentResolver
+                    path={column.component}
+                    params={{ row, ...componentProps }}
+                  />
+                {:else}
+                  <svelte:component
+                    this={column.component}
+                    {row}
+                    {...componentProps}
+                  />
+                {/if}
+              {:else}
+                <div>{row[column.key] ?? "NA"}</div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/each}
+    </div>
+  </div>
+  {#if addAction}
+    <div class="flex justify--center items-center p-3 pt-6 w-full">
+      <Button
+        label={addAction}
+        icon="plus"
+        style={ButtonStyle.PLAIN}
+        type={ButtonVariant.SECONDARY}
+        on:click={() => {
+          dispatch("add");
+        }}
+      />
+    </div>
+  {/if}
+</div>

--- a/client/elements/table/Table3.svelte
+++ b/client/elements/table/Table3.svelte
@@ -10,7 +10,6 @@
   } from "$lib/client/types/table.type";
   import { cn } from "$lib/client/utils/ui.utils";
   import Button from "../button/Button.svelte";
-  import Divider from "../Divider.svelte";
   import DropDown from "../dropdown/DropDown.svelte";
   import TextInput from "../input/TextInput.svelte";
   import FormLabelTooltip from "../text/formLabel/FormLabelTooltip.svelte";
@@ -24,16 +23,28 @@
   export let addAction: string | undefined = undefined;
   export let id: string = "table";
   export let width: string = "";
-  $: if (actions.length > 0) {
+
+  $: renderColumns =
+    actions.length > 0 ? injectDefaultActions(columns, actions) : columns;
+
+  function injectDefaultActions(
+    base: TableColumn[],
+    actions: { action: TableCellDefaultAction; index: number }[]
+  ): TableColumn[] {
+    let result = base;
     actions.forEach((action) => {
-      columns = [
-        ...columns.slice(0, action.index),
+      result = [
+        ...result.slice(0, action.index),
         resolveDefaultAction(action.action),
-        ...columns.slice(action.index)
-      ].filter((column) => column);
+        ...result.slice(action.index)
+      ].filter((column) => column !== undefined);
     });
+    return result;
   }
-  function resolveDefaultAction(action: string) {
+
+  function resolveDefaultAction(
+    action: TableCellDefaultAction
+  ): TableColumn | undefined {
     switch (action) {
       case TableCellDefaultAction.REORDER:
         return {
@@ -83,7 +94,7 @@
   <div class={cn("table w-full text-b2", { "bg--bgs2 rounded-md": isStyled })}>
     <div class="table-header-group">
       <div class="table-row text-fgs3">
-        {#each columns as column (column.key)}
+        {#each renderColumns as column (column.key)}
           <div
             class={cn("table-cell border-b border-brs2 align-middle p-3", {
               "w-8": column.type === TableCellType.ACTION
@@ -114,7 +125,7 @@
     >
       {#each data as row, i (row.id)}
         <div class="table-row" draggable="true" data-index={i}>
-          {#each columns as column}
+          {#each renderColumns as column}
             <div class="table-cell align-middle px-3 py-2 text-left">
               {#if column.type === TableCellType.TEXT_INPUT}
                 <TextInput

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -65,9 +65,10 @@
 </script>
 
 {#if !isInFocusMode}
+  <div class="hidden otopl:!block w-full min-h-6 h-6 bg-bgs2"></div>
   <div
     class={cn(
-      "w-full h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata embed-ios:mt-6 embed-tablet:mt-6 relative embed-ios:before:absolute embed-ios:before:-top-6 embed-ios:before:bottom-0 embed-ios:before:left-0 embed-ios:before:right-0 embed-ios:before:bg-bgs2",
+      "w-full h-11 max-h-11 min-h-11 2k:h-12 2k:max-h-12 2k:min-h-12 bg-bgs2 pr-4 border-b border-brs3 userdata",
       {
         "flex gap-3 justify-between items-center":
           pinnedItems.length > 0 || isInterimTab,

--- a/client/products/memotron/audio/AudioContentMainPanel.svelte
+++ b/client/products/memotron/audio/AudioContentMainPanel.svelte
@@ -170,12 +170,9 @@
             size={Size.sm}
             style={InputStyle.PLAIN}
             icon="search"
-            isShowClearControl={searchQuery !== ""}
-            on:cancel={() => {
-              searchQuery = "";
-            }}
+            isShowClearControl={true}
+            on:cancel={toggleSearch}
           />
-          <Button icon="cross" tooltip="Close search" on:click={toggleSearch} />
         </div>
       {:else if selectedView === AudioView.TRANSCRIPTION && body?.transcription}
         <Button

--- a/client/products/memotron/library/search/ResourceSearchBase.svelte
+++ b/client/products/memotron/library/search/ResourceSearchBase.svelte
@@ -134,6 +134,10 @@
     }
   }
 
+  /**
+   * Defaulting to FULL access mode for portrait - since in this layout - tab bar isn't available
+   * @param e
+   */
   function onSelect(
     e: CustomEvent<{ item: any; event: MouseEvent | undefined; group?: any }>
   ) {
@@ -147,8 +151,8 @@
       }
       return;
     }
-    if ($view.isConstrainedWidth) {
-      appStore.openResource(item.id, ResourceAccessMode.POP);
+    if ($view.isPortrait) {
+      appStore.openResource(item.id, ResourceAccessMode.FULL);
       return;
     }
     const clickAccessMode = e.detail.event

--- a/client/products/memotron/node/Node.svelte
+++ b/client/products/memotron/node/Node.svelte
@@ -74,7 +74,7 @@
   setContext("node", nodeContext);
 
   onDestroy(() => {
-    ActiveNodeStore.destroy(id);
+    ActiveNodeStore.destroy(id, accessMode);
   });
   const debouncedInitialize = debouncer(initialize, 1500);
 </script>

--- a/client/products/memotron/node/content/NodeContent.svelte
+++ b/client/products/memotron/node/content/NodeContent.svelte
@@ -33,7 +33,10 @@
   import view from "$lib/client/stores/view.store";
   import context from "$lib/client/stores/context.store";
   import { generateMarkdownText, resolveHeadingParent } from "../node.utils";
-  import { resourceInList } from "$lib/client/components/flux/resourceStores/resource.utils";
+  import {
+    determineResourceAccessMode,
+    resourceInList
+  } from "$lib/client/components/flux/resourceStores/resource.utils";
   import { tabs } from "$lib/client/layout/topNav/tabs/tabs.store";
 
   export let node: IActiveNodeStore;
@@ -99,7 +102,7 @@
         id: $node.id
       });
       if (!x) return;
-      const currentAccessMode = appStore.determineResourceAccessMode($node.id);
+      const currentAccessMode = determineResourceAccessMode($node.id);
       const clickedAccessMode = appStore.determineClickAccessMode(x.event);
       if (clickedAccessMode && clickedAccessMode !== currentAccessMode) {
         appStore.openResource(x.id, clickedAccessMode);
@@ -132,12 +135,10 @@
       currentAccessMode?: ResourceAccessMode;
     }
   ) {
-
     if (id === $node.id) return;
-    
+
     const currentAccessMode =
-      params?.currentAccessMode ??
-      appStore.determineResourceAccessMode($node.id);
+      params?.currentAccessMode ?? determineResourceAccessMode($node.id);
     if (
       currentAccessMode === ResourceAccessMode.TAB &&
       (!params?.accessMode || params?.accessMode === ResourceAccessMode.TAB)

--- a/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
+++ b/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
@@ -32,6 +32,7 @@
   import { isShowStatusBanner } from "$lib/client/components/flux/resourceStores/resource.utils";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
   import BackButton from "$lib/client/elements/button/BackButton.svelte";
+  import ResourceInlineCloseButton from "$lib/client/elements/button/ResourceInlineCloseButton.svelte";
   const dispatch = createEventDispatcher();
   export let node: IActiveNodeStore;
   export let isHovering: boolean = false;
@@ -101,7 +102,10 @@
       <div class="flex gap-3 justify-between items-center w-full">
         <span class="flex items-center gap-4 flex-1 min-w-0">
           <BackButton
-            isEnabled={$view.isConstrainedWidth && !$node.isInEditMode}
+            isEnabled={$view.isConstrainedWidth &&
+              !$node.isInEditMode &&
+              $node.accessMode !== ResourceAccessMode.INLINE &&
+              $node.accessMode !== ResourceAccessMode.FULL}
             accessMode={$node.accessMode}
             class="min-w-0 flex-1"
           >
@@ -122,7 +126,12 @@
             </div>
           {/if}
         </span>
-        <span class="flex gap-5">
+        <span
+          class={cn("flex", {
+            "gap-5": !isConstrainedWidth,
+            "gap-2": isConstrainedWidth
+          })}
+        >
           {#if !isConstrainedWidth}
             <Toggle
               icon="bird"
@@ -191,16 +200,10 @@
               }}
             />
           {/if}
-          {#if $node.accessMode === ResourceAccessMode.FULL || $node.accessMode === ResourceAccessMode.SLIDESHOW}
-            <Button
-              {...buttonCommonProps}
-              icon="cross-circled"
-              tooltip="Close"
-              on:click={() => {
-                appStore.closeResource({ inlineRestoreId: $node.id });
-              }}
-            />
-          {/if}
+          <ResourceInlineCloseButton
+            accessMode={$node.accessMode}
+            id={$node.id}
+          />
         </span>
       </div>
       {#if dev_isShowMainProperties}

--- a/client/products/memotron/node/floatingBar/NodeFloatingBar.svelte
+++ b/client/products/memotron/node/floatingBar/NodeFloatingBar.svelte
@@ -49,6 +49,13 @@
   export function resetToggle() {
     toggleGroupRef?.reset();
   }
+
+  function close() {
+    appStore.closeResource({
+      id: $node.id,
+      accessMode: $node.accessMode
+    });
+  }
 </script>
 
 <div
@@ -84,17 +91,15 @@
         />
       </div>
     {:else}
+      {@const isCloseVariant =
+        $node.accessMode === ResourceAccessMode.FULL ||
+        $node.accessMode === ResourceAccessMode.INLINE}
       <Button
-        label="Back"
-        icon="back-sm"
+        label={isCloseVariant ? "Close" : "Back"}
+        icon={isCloseVariant ? "cross" : "chevron-left"}
         size={Size.sm}
         style={ButtonStyle.PLAIN}
-        on:click={() => {
-          appStore.closeResource({
-            id: $node.id,
-            accessMode: $node.accessMode
-          });
-        }}
+        on:click={close}
       />
     {/if}
   {:else}
@@ -200,9 +205,7 @@
           {...buttonCommonProps}
           icon="cross-circled"
           tooltip="Close split view"
-          on:click={() => {
-            appStore.closeResource({ accessMode: $node.accessMode });
-          }}
+          on:click={close}
         />
       {/if}
     {/if}

--- a/client/products/memotron/node/node.store.ts
+++ b/client/products/memotron/node/node.store.ts
@@ -832,27 +832,37 @@ export function resolveNodeContextMenu(
     ];
   }
   const ctx = get(context);
+  const viewStore = get(view);
   let commonGroups: { group: string; items: IContextMenuItem[] }[] = [];
+  const moreGroup = {
+    group: "more",
+    items: [resourceActions.archive(), resourceActions.trash()]
+  };
   if (ctx.isEmbed && ctx.embed === Embed.HANDSET) {
-    commonGroups = [
-      {
-        group: "more",
-        items: [resourceActions.archive(), resourceActions.trash()]
-      }
-    ];
+    commonGroups = [moreGroup];
   } else if (
     accessPoint === ResourceAccessPoint.SELF &&
-    params?.accessMode !== ResourceAccessMode.SPLIT
+    params?.accessMode !== ResourceAccessMode.SPLIT &&
+    !viewStore.isPortrait
   ) {
     commonGroups = [
       {
         group: "open",
         items: [resourceActions.openAsTab(), resourceActions.openAsFull()]
       },
+      moreGroup
+    ];
+  } else if (
+    accessPoint === ResourceAccessPoint.SELF &&
+    params?.accessMode === ResourceAccessMode.INLINE &&
+    viewStore.isPortrait
+  ) {
+    commonGroups = [
       {
-        group: "more",
-        items: [resourceActions.archive(), resourceActions.trash()]
-      }
+        group: "open",
+        items: [resourceActions.openAsFull()]
+      },
+      moreGroup
     ];
   } else {
     commonGroups = [
@@ -864,10 +874,7 @@ export function resolveNodeContextMenu(
           resourceActions.openAsFull()
         ]
       },
-      {
-        group: "more",
-        items: [resourceActions.archive(), resourceActions.trash()]
-      }
+      moreGroup
     ];
   }
   let mediaShareAndExportGroup = {
@@ -985,7 +992,6 @@ export function resolveNodeContextMenu(
           resourceActions.toggleFocusMode()
         ]
       : [resourceActions.toggleFocusMode()];
-  const viewStore = get(view);
   const secondGroupItems = viewStore.isConstrainedWidth
     ? [
         resourceActions.toggleReadMode(),

--- a/client/stores/app.store.ts
+++ b/client/stores/app.store.ts
@@ -39,7 +39,10 @@ import { Size } from "../types/size.enum";
 import type { IRecordId } from "../types/data.type";
 import account from "./account.store";
 import { tabs } from "../layout/topNav/tabs/tabs.store";
-import { resourceAction } from "../components/flux/resourceStores/resource.utils";
+import {
+  determineResourceAccessMode,
+  resourceAction
+} from "../components/flux/resourceStores/resource.utils";
 import { Product } from "$lib/client/products/product.type";
 import { EmbedDataMessage } from "../types/embedMessage.enum";
 
@@ -611,15 +614,6 @@ function initAppStore(seed: IAppStore) {
     else return ResourceAccessMode.INLINE;
   };
 
-  const determineResourceAccessMode = (id: IRecordId): ResourceAccessMode => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const mode = (Object.values(ResourceAccessMode) as string[]).find(
-      (m) =>
-        m !== ResourceAccessMode.INLINE && searchParams.get(m) === id.toString()
-    );
-    return (mode as ResourceAccessMode) || ResourceAccessMode.INLINE;
-  };
-
   /**
    *
    * TODO - shortcuts from user settings
@@ -785,7 +779,6 @@ function initAppStore(seed: IAppStore) {
     id?: IRecordId;
     accessMode?: ResourceAccessMode;
     isRestrictToModals?: boolean;
-    inlineRestoreId?: IRecordId;
   }) => {
     appEvents.nav(props?.id?.toString() ?? "");
     const url =
@@ -794,11 +787,13 @@ function initAppStore(seed: IAppStore) {
       }) ?? new URL(window.location.href);
     if (props?.accessMode) {
       toggleSearchParam([props.accessMode], { url });
+      restoreInlineResourceIfPrev();
       return;
     } else if (props?.id) {
       const accessMode = determineResourceAccessMode(props.id);
       if (accessMode) {
         toggleSearchParam([accessMode], { url });
+        restoreInlineResourceIfPrev();
       }
       return;
     }
@@ -808,9 +803,7 @@ function initAppStore(seed: IAppStore) {
       });
       return;
     }
-    const prevMode = url.searchParams.get("prev");
-    if (prevMode === ResourceAccessMode.INLINE && props?.inlineRestoreId)
-      url.searchParams.set(prevMode, props?.inlineRestoreId.toString());
+    restoreInlineResourceIfPrev();
     removeSearchParam("prev");
     removeSearchParam(ResourceAccessMode.SPLIT);
     removeSearchParam(ResourceAccessMode.FULL);
@@ -821,6 +814,12 @@ function initAppStore(seed: IAppStore) {
     function removeSearchParam(param: string) {
       if (!url.searchParams.get(param)) return;
       url.searchParams.delete(param);
+    }
+
+    function restoreInlineResourceIfPrev() {
+      const prevMode = url.searchParams.get("prev");
+      if (prevMode === ResourceAccessMode.INLINE && props?.id)
+        url.searchParams.set(prevMode, props?.id.toString());
     }
   };
 
@@ -957,7 +956,6 @@ function initAppStore(seed: IAppStore) {
     resourceClickHandlerForGraph,
     openResource,
     toggleFullScreen: toggleFullAccessMode,
-    determineResourceAccessMode,
     determineClickAccessMode,
     isOverlay,
     closeResource,

--- a/client/stores/app.store.ts
+++ b/client/stores/app.store.ts
@@ -816,11 +816,11 @@ function initAppStore(seed: IAppStore) {
       url.searchParams.delete(param);
     }
 
-    function restoreInlineResourceIfPrev() {
+    const restoreInlineResourceIfPrev = () => {
       const prevMode = url.searchParams.get("prev");
       if (prevMode === ResourceAccessMode.INLINE && props?.id)
         url.searchParams.set(prevMode, props?.id.toString());
-    }
+    };
   };
 
   const toggleFullAccessMode = (

--- a/client/theme/tidigit.tailwind.js
+++ b/client/theme/tidigit.tailwind.js
@@ -326,6 +326,7 @@ export default {
       addVariant("embed-linux", ".embed.os-linux &");
       // offset on top (otop) - for iphone and ipad - as edges default padding is ignored on SwiftUI
       addVariant("otop", ".embed.os-ios.device-portrait &");
+      addVariant("otopl", ".embed.os-ios.device-landscape &");
     }
     // require("@iconify/tailwind").addIconSelectors({
     //   prefixes: ["ph"]

--- a/client/theme/tidigit.tailwind.js
+++ b/client/theme/tidigit.tailwind.js
@@ -325,8 +325,8 @@ export default {
       addVariant("embed-android", ".embed.os-android &");
       addVariant("embed-linux", ".embed.os-linux &");
       // offset on top (otop) - for iphone and ipad - as edges default padding is ignored on SwiftUI
-      addVariant("otop", ".embed.os-ios.device-portrait &");
-      addVariant("otopl", ".embed.os-ios.device-landscape &");
+      addVariant("otop", ".device-portrait.embed.os-ios &");
+      addVariant("otopl", ".device-landscape.embed.os-ios &");
     }
     // require("@iconify/tailwind").addIconSelectors({
     //   prefixes: ["ph"]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized resource closing and access-mode behavior, improved portrait/iOS embed UX, and introduced a new lightweight table. Also bumped versions: Nucleus 0.3.2, Memotron 0.61.3, Pointron 0.83.1.

- New Features
  - Added ResourceInlineCloseButton and used it in Collection/Node headers for consistent close in FULL/SPLIT/FSPLIT.
  - Introduced Table3 (reorder/remove/select actions) and switched PropertiesEditor to it.
  - Apps now read version/build from package.json in local.ts.

- Bug Fixes
  - Access mode handling: moved determineResourceAccessMode to resource.utils; ActiveResourceStore.destroy preserves inline state when exiting FULL; added onDestroy cleanup for Collection/Node/Goal.
  - Portrait/iOS (TASK-554): default open as FULL from search on portrait; refined Back vs Close behavior; layout tweaks in TopNav, Modal, CollectionTitleBar; board pane height adjusted.
  - Search UX: clear/cancel controls in TextInput; cancel no longer triggers unwanted blur.

<!-- End of auto-generated description by cubic. -->

