### PR TITLE
feat: TIDY-270_TIDY-278

### DIFF
--- a/client/components/flux/flux.ts
+++ b/client/components/flux/flux.ts
@@ -1484,14 +1484,27 @@ class Flux {
           resource,
           data: data[resource]
         });
-        await this.persistence.mutation(resource as Resource, {
-          records: data[resource],
-          action:
-            resource === Resource.kv || resource === Resource.link
-              ? PersistenceActionType.INSERT
-              : PersistenceActionType.BULK_INSERT
-        });
-        if (!(await determineIfOffline()) && data[resource].length > 0) {
+        const mutationResult = await this.persistence.mutation(
+          resource as Resource,
+          {
+            records: data[resource],
+            action:
+              resource === Resource.kv || resource === Resource.link
+                ? PersistenceActionType.INSERT
+                : PersistenceActionType.BULK_INSERT
+          }
+        );
+        if (!mutationResult) {
+          await this.persistence.mutation(resource as Resource, {
+            records: data[resource],
+            action: PersistenceActionType.INSERT
+          });
+        }
+        if (
+          !this.isLocalMode &&
+          !(await determineIfOffline()) &&
+          data[resource].length > 0
+        ) {
           await this.performSync(SyncMethod.CLONE_UP, {
             resource,
             records: data[resource]
@@ -1506,6 +1519,9 @@ class Flux {
       }
     }
     await this.loadInMemoryStores();
+    if (!this.isExtensionEnvironment) {
+      dispatchCustomEvent(GlobalEvent.SYNC_DOWN);
+    }
     return true;
   }
 }

--- a/client/components/flux/flux.ts
+++ b/client/components/flux/flux.ts
@@ -1484,16 +1484,25 @@ class Flux {
           resource,
           data: data[resource]
         });
-        const mutationResult = await this.persistence.mutation(
-          resource as Resource,
-          {
-            records: data[resource],
-            action:
-              resource === Resource.kv || resource === Resource.link
-                ? PersistenceActionType.INSERT
-                : PersistenceActionType.BULK_INSERT
-          }
-        );
+        let mutationResult;
+        try {
+          mutationResult = await this.persistence.mutation(
+            resource as Resource,
+            {
+              records: data[resource],
+              action:
+                resource === Resource.kv || resource === Resource.link
+                  ? PersistenceActionType.INSERT
+                  : PersistenceActionType.BULK_INSERT
+            }
+          );
+        } catch (error) {
+          logger.error({
+            at: "flux.import - bulkInsert failed, falling back",
+            resource,
+            error
+          });
+        }
         if (!mutationResult) {
           await this.persistence.mutation(resource as Resource, {
             records: data[resource],

--- a/client/persistence/dexie/dexie.local.ts
+++ b/client/persistence/dexie/dexie.local.ts
@@ -247,6 +247,8 @@ export class DexiePersistence implements IPersistence {
           }
         }
         return this.instance?.table(resource).bulkPut(records);
+      case PersistenceActionType.BULK_INSERT:
+        return this.bulkInsert(resource, params.records);
       case PersistenceActionType.REPLACE:
         return this.instance?.table(resource).put(params.record);
       case PersistenceActionType.MERGE:
@@ -303,7 +305,6 @@ export class DexiePersistence implements IPersistence {
       case PersistenceActionType.BULK_MERGE:
         return this.bulkMerge(resource, params.recordIds, params.changes);
       case PersistenceActionType.CUSTOM:
-        //TODO
         return;
     }
   }
@@ -318,6 +319,57 @@ export class DexiePersistence implements IPersistence {
       return result;
     } catch (e) {
       logger.error({ at: "DexiePersistence.merge", id, data, e });
+    }
+  }
+
+  async bulkInsert(resource: Resource, records: any[]) {
+    try {
+      const table = this.instance?.table(resource);
+      if (!table) return;
+
+      const formattedRecords = records.map((record) => ({
+        ...record,
+        id: record.id?.toString()
+      }));
+
+      if (this.searchIndices.has(resource)) {
+        const searchIndex = this.searchIndices.get(resource);
+        if (searchIndex) {
+          formattedRecords.forEach((record) => {
+            const text = this.extractFlatText(record, resource);
+            if (record.id && text) {
+              searchIndex.index.addAsync(record.id, text);
+              searchIndex.contextualIndex.addAsync(record.id, text);
+            }
+          });
+        }
+      }
+
+      if (this.documentSearchIndices.has(resource)) {
+        const documentSearchIndex = this.documentSearchIndices.get(resource);
+        if (documentSearchIndex) {
+          documentSearchIndex.add(formattedRecords as any);
+        }
+      }
+
+      const result = await table.bulkAdd(formattedRecords);
+
+      logger.log({
+        at: "DexiePersistence.bulkInsert",
+        resource,
+        totalRecords: records.length,
+        result
+      });
+
+      return result;
+    } catch (e) {
+      logger.error({
+        at: "DexiePersistence.bulkInsert",
+        resource,
+        totalRecords: records.length,
+        e
+      });
+      throw e;
     }
   }
 

--- a/client/products/memotron/capture/capture.store.ts
+++ b/client/products/memotron/capture/capture.store.ts
@@ -1095,13 +1095,10 @@ export class ActiveCaptureStore extends ActiveResourceStore<
       creationContext?: IRecordId;
     }
   ) {
-    if (params?.isEmbedContext) {
-      const urlData = resolveUrlData(text);
-      if (urlData?.convertToEmbedUrl) {
-        text = urlData.convertToEmbedUrl(text);
-      }
+    const urlData = resolveUrlData(text);
+    if (urlData?.convertToEmbedUrl) {
+      text = urlData.convertToEmbedUrl(text);
     }
-
     let node: INodeCapture<IWebPage | IClip> = {
       contentType: params?.contentType ?? NodeType.WEB_PAGE,
       label: text.split("://").pop() ?? "",

--- a/client/products/memotron/node/content/web/WebPagePreview.svelte
+++ b/client/products/memotron/node/content/web/WebPagePreview.svelte
@@ -35,6 +35,7 @@
       isIframeable = data.isIframeable || false;
       if (isIframeable) {
         isIframeShown = true;
+        isCheckingIframability = false;
       }
       if (!customMessage && !isIframeable) {
         const result = await resolveIframability(node.url, {
@@ -137,7 +138,7 @@
         No preview available for this page. Please use the link below to view
         the page.
       {:else}
-        -
+        Preview
       {/if}
     </div>
   {/if}

--- a/client/products/memotron/node/content/web/WebPagePreview.svelte
+++ b/client/products/memotron/node/content/web/WebPagePreview.svelte
@@ -14,6 +14,7 @@
   import { ResourceAccessPoint } from "$lib/client/components/flux/resourceStores/resource.type";
   import { resolveUrlData } from "../../url.utils";
   import { parse } from "$lib/shared/utils/json.utils";
+  import context from "$lib/client/stores/context.store";
 
   export let node: IWebPage;
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.SELF;
@@ -29,8 +30,13 @@
 
   async function initialize() {
     try {
-      customMessage = resolveCustomMessage(node.url);
-      if (!customMessage) {
+      const data = resolveCustomSettings(node.url);
+      customMessage = data.customMessage;
+      isIframeable = data.isIframeable || false;
+      if (isIframeable) {
+        isIframeShown = true;
+      }
+      if (!customMessage && !isIframeable) {
         const result = await resolveIframability(node.url, {
           isUseCloud: $account.dataMode === UserDataMode.CLOUD
         });
@@ -90,9 +96,12 @@
     }
   }
 
-  function resolveCustomMessage(url: string) {
+  function resolveCustomSettings(url: string) {
     const urlData = resolveUrlData(url);
-    return urlData?.customMessage;
+    return {
+      customMessage: urlData?.customMessage,
+      isIframeable: urlData?.isIframeable
+    };
   }
 </script>
 
@@ -124,8 +133,12 @@
     <FileView id={node.metadata.screenshotFile} />
   {:else}
     <div class="text-center text-b3 text-fgs3">
-      No preview available for this page. Please use the link below to view the
-      page.
+      {#if !isIframeable}
+        No preview available for this page. Please use the link below to view
+        the page.
+      {:else}
+        -
+      {/if}
     </div>
   {/if}
 
@@ -145,7 +158,7 @@
       />
     </div>
   {/if}
-  {#if isIframeable && isHovering && !isIframeShown}
+  {#if isIframeable && (isHovering || $context.isTouchDevice) && !isIframeShown}
     <div class="absolute m-2 flex gap-2 items-center justify-center">
       <Button
         icon="play"

--- a/client/products/memotron/node/url.utils.ts
+++ b/client/products/memotron/node/url.utils.ts
@@ -160,7 +160,64 @@ const urlMap = [
     isIframeable: false
   },
   {
-    domain: "wikipedia.org",
+    domain: /^https:\/\/(?:www\.)?tldraw\.com\/f\/[a-zA-Z0-9_-]+(?:\?.*)?$/,
+    faviconUrl: "https://www.tldraw.com/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https:\/\/(?:www\.)?excalidraw\.com(?:\/(?:[a-zA-Z0-9_-]+)?)?(?:\?.*)?$/,
+    faviconUrl: "https://excalidraw.com/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https:\/\/(?:www\.)?miro\.com\/app\/board\/[a-zA-Z0-9_=-]+(?:\/.*)?(?:\?.*)?$/,
+    faviconUrl: "https://miro.com/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https:\/\/(?:www\.)?whimsical\.com\/embed\/[a-zA-Z0-9_-]+(?:\?.*)?$/,
+    faviconUrl: "https://whimsical.com/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain: /^https:\/\/(?:www\.)?draw\.io\/(?:\?.*)?$/,
+    faviconUrl: "https://app.diagrams.net/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain: /^https:\/\/(?:viewer|embed)\.diagrams\.net\/.*$/,
+    faviconUrl: "https://app.diagrams.net/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https:\/\/lucid\.app\/documents\/embedded\/[a-zA-Z0-9_-]+(?:\?.*)?$/,
+    faviconUrl: "https://lucid.app/favicon.ico",
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https?:\/\/(?:www\.)?canva\.com\/design\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/view\?embed(?:&.*)?$/,
+    isIframeable: true
+  },
+  {
+    domain:
+      /^https?:\/\/(?:www\.)?canva\.com\/design\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/view(?:\?.*)?$/,
+    customMessage:
+      "Preview not available for this Canva URL. Please use the embed URL instead.",
+    convertToEmbedUrl: (url: string) => {
+      const urlObj = new URL(url);
+      if (!urlObj.searchParams.has("embed")) {
+        urlObj.searchParams.set("embed", "true");
+      }
+      return urlObj.toString();
+    }
+  },
+  {
+    domain: /^https:\/\/(?:[\w-]+\.)?wikipedia\.org\/.+$/,
     faviconUrl: "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
     isIframeable: true
   },

--- a/client/products/memotron/node/url.utils.ts
+++ b/client/products/memotron/node/url.utils.ts
@@ -200,7 +200,7 @@ const urlMap = [
   },
   {
     domain:
-      /^https?:\/\/(?:www\.)?canva\.com\/design\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/view\?embed(?:&.*)?$/,
+      /^https?:\/\/(?:www\.)?canva\.com\/design\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/view\?embed(?:=true)?(?:&.*)?$/,
     isIframeable: true
   },
   {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds external drawing embed support with auto-embed URLs and instant iframe previews for tldraw, Excalidraw, Miro, Whimsical, diagrams.net, Lucid, and Canva. Addresses Linear TIDY-270 by enabling reliable capture and preview of these embeds.

- New Features
  - Detects supported drawing URLs and renders them in iframes when allowed.
  - Auto-converts Canva “view” links to embed URLs; shows a helpful message for non-embed links.
  - Web previews show the iframe immediately when supported; play-on-hover also works on touch devices.

- Refactors
  - Adds Dexie BULK_INSERT with search/doc index updates; falls back to INSERT if needed.
  - Skips CLONE_UP in local mode or offline; emits SYNC_DOWN after in-memory load (non-extension).

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Bulk import support for faster/more reliable record insertion and search indexing.
  - Expanded webpage previews with favicon and iframe support for more sites (tldraw, Excalidraw, Miro, Whimsical, draw.io/diagrams.net, Lucid, Canva, broader Wikipedia).
  - Touch-friendly previews: Play button appears on touch and hover when iframeable; Canva links auto-convert to embeddable URLs with a preview message.

- Bug Fixes
  - More robust import flow with fallback insertion and clearer import error logging.
  - Conditional background sync only runs when online and not in local/extension environments.
  - More reliable embed detection and clearer messaging when a page can’t be previewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->