### PR TITLE
TIDY-276 fix

### DIFF
--- a/client/extensions/clipper/contentScripts/ContentScript.svelte
+++ b/client/extensions/clipper/contentScripts/ContentScript.svelte
@@ -106,7 +106,7 @@
       if (!result || result.error) {
         return { error: result?.error ?? "Failed to save page" };
       }
-      return { success: true, pageId: $webpage.id };
+      return { status: "success", pageId: $webpage.id };
     } catch (error) {
       return { error: "Failed to save page" };
     }
@@ -232,12 +232,18 @@
                 message: saveResult.error,
                 pageId: saveResult.pageId
               };
+            } else if (saveResult.status === "success") {
+              return {
+                status: "success",
+                message: "Page saved",
+                pageId: saveResult.pageId
+              };
+            } else {
+              return {
+                status: "error",
+                message: "Unexpected response"
+              };
             }
-            return {
-              status: "success",
-              message: "Page saved",
-              pageId: saveResult.pageId
-            };
 
           case ClipperExtensionEvent.TAKE_SCREENSHOT_SHORTCUT:
             isSnipActive = true;

--- a/client/extensions/clipper/contentScripts/ContentScript.svelte
+++ b/client/extensions/clipper/contentScripts/ContentScript.svelte
@@ -94,6 +94,24 @@
     }
   }
 
+  async function savePageFromSidePanel() {
+    try {
+      if (isDisableClipper || !isLoggedIn || !isBaseMounted) {
+        return { error: "Cannot save page at this time" };
+      }
+      if ($webpage.id) {
+        return { error: "Page already saved", pageId: $webpage.id };
+      }
+      let result = await webpage.savePage({ contentType });
+      if (!result || result.error) {
+        return { error: result?.error ?? "Failed to save page" };
+      }
+      return { success: true, pageId: $webpage.id };
+    } catch (error) {
+      return { error: "Failed to save page" };
+    }
+  }
+
   async function onMutationRelay(data: any, isFromSidePanel: boolean = false) {
     try {
       logger.log({ at: "onMutationRelay", data });
@@ -207,13 +225,19 @@
                 message: "You are not logged in"
               };
             }
-            if ($webpage.id) {
-              feedbackPane.onPageSaved("Page already saved!");
-              feedbackPane.toggle({ isUserInitiated: true });
-            } else {
-              await onSaveClick();
+            const saveResult = await savePageFromSidePanel();
+            if (saveResult.error) {
+              return {
+                status: "error",
+                message: saveResult.error,
+                pageId: saveResult.pageId
+              };
             }
-            return { status: "success", message: "Page saved" };
+            return {
+              status: "success",
+              message: "Page saved",
+              pageId: saveResult.pageId
+            };
 
           case ClipperExtensionEvent.TAKE_SCREENSHOT_SHORTCUT:
             isSnipActive = true;

--- a/client/extensions/clipper/sidePanel/SidePanel.svelte
+++ b/client/extensions/clipper/sidePanel/SidePanel.svelte
@@ -83,6 +83,8 @@
   let isShowHelp = false;
   let isResyncing = false;
   let isBootupSyncInProgress = false;
+  let isSaving = false;
+  let feedbackTimeoutId: number | undefined = undefined;
 
   $: contentType = resolveContentTypeForUrl(currentUrl);
   $: contentTypeStr = resolveContentTypeString(contentType);
@@ -128,6 +130,8 @@
 
   const stores = [...clipperCacheableStores];
   async function onSavePageClick() {
+    if (isSaving) return;
+    isSaving = true;
     feedback = {
       type: AlertType.PROGRESS,
       message: `Saving ${contentTypeStr.toLowerCase()}...`
@@ -164,8 +168,13 @@
         message: "Failed to save page"
       };
     }
-    setTimeout(() => {
+    isSaving = false;
+    if (feedbackTimeoutId !== undefined) {
+      clearTimeout(feedbackTimeoutId);
+    }
+    feedbackTimeoutId = window.setTimeout(() => {
       feedback = undefined;
+      feedbackTimeoutId = undefined;
     }, 3000);
   }
   const messageListener = (message: any, sender: any, sendResponse: any) => {
@@ -234,6 +243,9 @@
       chrome.runtime.onMessage.removeListener(messageListener);
     }
     port?.disconnect();
+    if (feedbackTimeoutId !== undefined) {
+      clearTimeout(feedbackTimeoutId);
+    }
   });
 
   function sendPing() {

--- a/client/extensions/clipper/sidePanel/SidePanel.svelte
+++ b/client/extensions/clipper/sidePanel/SidePanel.svelte
@@ -128,9 +128,45 @@
 
   const stores = [...clipperCacheableStores];
   async function onSavePageClick() {
-    const page = await relayToContentScript({
+    feedback = {
+      type: AlertType.PROGRESS,
+      message: `Saving ${contentTypeStr.toLowerCase()}...`
+    };
+    const result = await relayToContentScript({
       event: ClipperExtensionEvent.SAVE_WEBPAGE
     });
+    logger.log({ at: "onSavePageClick", result });
+    if (result?.status === "error") {
+      if (result.message === "Page already saved" && result.pageId) {
+        isPageSaved = true;
+        feedback = {
+          type: AlertType.SUCCESS,
+          message: "Page already saved!"
+        };
+      } else {
+        feedback = {
+          type: AlertType.ERROR,
+          message: result.message || "Failed to save page"
+        };
+      }
+    } else if (result?.status === "success") {
+      isPageSaved = true;
+      feedback = {
+        type: AlertType.SUCCESS,
+        message: `${contentTypeStr} saved!`
+      };
+      await relayToContentScript({
+        event: ExtensionEvent.PAGE_STATE_TRIGGER
+      });
+    } else {
+      feedback = {
+        type: AlertType.ERROR,
+        message: "Failed to save page"
+      };
+    }
+    setTimeout(() => {
+      feedback = undefined;
+    }, 3000);
   }
   const messageListener = (message: any, sender: any, sendResponse: any) => {
     if (message.event === ExtensionEvent.PAGE_STATE) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the side panel Save button when the toolbar is hidden, so YouTube video and channel pages save correctly. Adds clear feedback and a robust save flow from the side panel. Addresses Linear TIDY-276.

- **Bug Fixes**
  - Added savePageFromSidePanel in ContentScript with guard checks and structured responses (success/error, pageId).
  - Updated SAVE_WEBPAGE handling to use the new save flow and return status to the side panel.
  - SidePanel now shows progress, success, and error messages; handles “already saved”; sets isPageSaved; triggers page state refresh; auto-clears feedback after 3s.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Shows progress while saving from the side panel.
  - Clear success/error messages, including “Already saved” with the saved state.
  - Automatically clears feedback after a short delay.

- Bug Fixes
  - Prevents concurrent/duplicate save attempts.
  - More reliable handling of save outcomes with consistent page state updates.

- Refactor
  - Centralized save logic for consistent responses across panel and content, without affecting other actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->