### PR TITLE
Fix month view navigation bug

### DIFF
--- a/client/components/calendar/classic/ClassicCalendar.svelte
+++ b/client/components/calendar/classic/ClassicCalendar.svelte
@@ -352,7 +352,10 @@
           {indicatorData}
           {indicatorRefreshId}
           on:monthChange={handleMonthChange}
-          on:dateChange={onDateChange}
+          on:dateChange={(e) => {
+            selectedScale = TimeScaleUnit.DAY;
+            onDateChange();
+          }}
         />
       {:else if selectedView === TimeScaleUnit.WEEK}
         <WeekView


### PR DESCRIPTION
### **User description**
Set calendar scale to Day when clicking dates in Month view to resolve a navigation bug.

Previously, clicking a date in Month view would not change the `selectedScale` to `TimeScaleUnit.DAY`, leading to an inconsistent user experience compared to Year view, which correctly transitions to the Day scale. This fix aligns the Month view behavior with the expected navigation flow.

---
Linear Issue: [TIDY-294](https://linear.app/21n/issue/TIDY-294/switching-back-to-month-view-from-year-view-after-focusing-month-notes)

<a href="https://cursor.com/background-agent?bcId=bc-e0514997-05d8-4685-be64-b15ff4413a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0514997-05d8-4685-be64-b15ff4413a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a bug where clicking a date in Month view didn’t switch to Day view. Now it reliably transitions to Day view for the selected date, addressing Linear TIDY-294.

- **Bug Fixes**
  - In ClassicCalendar.svelte, set selectedScale = TimeScaleUnit.DAY in MonthView’s on:dateChange before calling onDateChange().

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix month view navigation to switch to day scale when clicking dates

- Align month view behavior with year view navigation consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Month View"] -- "click date" --> B["Set selectedScale to DAY"] --> C["Navigate to selected date"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClassicCalendar.svelte</strong><dd><code>Fix date selection navigation in month view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/components/calendar/classic/ClassicCalendar.svelte

<ul><li>Modified <code>on:dateChange</code> handler in MonthView component<br> <li> Added <code>selectedScale = TimeScaleUnit.DAY</code> before calling <code>onDateChange()</code><br> <li> Changed from direct function reference to inline event handler</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/nucleus/pull/342/files#diff-ca4327d831e768fc902e9f823c0241e974a4663da12fb8e3043b2c5db1e0814a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Bug Fixes:
- Set the calendar’s selectedScale to TimeScaleUnit.DAY when a date is clicked in Month view to reliably transition to Day view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Selecting a date in Month or Year views now automatically switches to the Day view for that date, ensuring immediate context and consistent navigation.
  - Aligns behavior across views to prevent remaining on a broader scale after picking a specific date.
  - Improves clarity and reduces extra clicks when drilling down from Month/Year to Day, delivering a smoother calendar experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->