### PR TITLE
Fix untitled label for audio camera nodes

### DIFF
--- a/client/products/memotron/capture/capture.store.ts
+++ b/client/products/memotron/capture/capture.store.ts
@@ -734,7 +734,7 @@ export class ActiveCaptureStore extends ActiveResourceStore<
         id,
         contentType,
         file: fileId,
-        label: captureStore.label ?? file.name,
+        label: (isValidString(captureStore.label) ? captureStore.label : null) ?? file.name,
         body: {},
         metadata: {
           ...metadata
@@ -981,7 +981,7 @@ export class ActiveCaptureStore extends ActiveResourceStore<
           ? (params?.creationContext ?? this.get().nodeId)
           : undefined,
         label:
-          captureStore.label ??
+          (isValidString(captureStore.label) ? captureStore.label : null) ??
           `Audio Recording - ${new Date().toLocaleString()}`,
         body: {
           duration
@@ -1051,7 +1051,8 @@ export class ActiveCaptureStore extends ActiveResourceStore<
       contentType: NodeType.IMAGE,
       file: fileId,
       label:
-        captureStore.label ?? `Image Capture - ${new Date().toLocaleString()}`,
+        (isValidString(captureStore.label) ? captureStore.label : null) ??
+        `Image Capture - ${new Date().toLocaleString()}`,
       body: {},
       properties: captureStore.properties,
       collections,


### PR DESCRIPTION
### **User description**
Fix audio and camera nodes displaying "Untitled" by ensuring empty labels correctly fall back to timestamped default labels.

Previously, `captureStore.label` could be an empty string, which the nullish coalescing operator (`??`) treats as a truthy value. This prevented the intended timestamped default labels (e.g., 'Audio Recording - [timestamp]') from being used, leading to 'Untitled' being displayed. The fix uses `isValidString()` to explicitly check for non-empty strings, allowing the fallback to occur correctly.

---
Linear Issue: [TIDY-287](https://linear.app/21n/issue/TIDY-287/audio-recording-camera-nodes-showing-untitled-when-no-title-is-set)

<a href="https://cursor.com/background-agent?bcId=bc-4192106b-2515-4bbd-a9be-a4242d8b7bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4192106b-2515-4bbd-a9be-a4242d8b7bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes audio and camera nodes showing “Untitled” by validating capture labels and falling back to descriptive defaults (file name or timestamp) when empty. Addresses TIDY-287 by updating ActiveCaptureStore to use a valid-string check before applying captureStore.label.

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix empty string labels causing "Untitled" display

- Replace nullish coalescing with explicit string validation

- Ensure proper fallback to timestamped default labels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["captureStore.label"] --> B["isValidString() check"]
  B --> C["Valid string?"]
  C -->|Yes| D["Use captureStore.label"]
  C -->|No| E["Use fallback label"]
  E --> F["file.name or timestamped default"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capture.store.ts</strong><dd><code>Fix label validation for capture nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/products/memotron/capture/capture.store.ts

<ul><li>Replace nullish coalescing with <code>isValidString()</code> validation<br> <li> Apply fix to file capture, audio recording, and image capture methods<br> <li> Ensure empty strings properly trigger fallback to default labels</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/nucleus/pull/343/files#diff-a2ea773bfba64f4177085721ca4a4e5e59574e34324948ff5dea5a5d6571a1b9">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Bug Fixes:
- Fix audio, camera, and image capture nodes displaying 'Untitled' by checking for non-empty labels before applying fallback labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label handling for saved items: if a custom label is empty or invalid, a sensible default name is used instead.
  * Applies to file saves, audio recordings, and camera captures, ensuring consistent and readable names.
  * Resolves cases where a label might exist but be unusable, preventing blank or malformed titles in the interface.
  * Enhances overall clarity in lists and histories by enforcing reliable naming defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->