### PR TITLE
Fix Nucleus web app release testing issues

### DIFF
--- a/apps/memotron/vite.config.ts
+++ b/apps/memotron/vite.config.ts
@@ -4,6 +4,9 @@ import fetchJsonPlugin from "../fetch-json-data.js";
 import { staticPlugin } from "../../client/static/vite-plugin.js";
 
 export default defineConfig({
+  worker: {
+    format: "es"
+  },
   build: {
     target: "esnext",
     rollupOptions: {

--- a/apps/nucleus/vite.config.ts
+++ b/apps/nucleus/vite.config.ts
@@ -6,6 +6,9 @@ import fetchJsonPlugin from "../fetch-json-data.js";
 import { staticPlugin } from "../../client/static/vite-plugin.js";
 
 export default defineConfig({
+  worker: {
+    format: "es"
+  },
   build: {
     target: "esnext",
     rollupOptions: {

--- a/apps/pointron/vite.config.ts
+++ b/apps/pointron/vite.config.ts
@@ -4,6 +4,9 @@ import fetchJsonPlugin from "../fetch-json-data.js";
 import { staticPlugin } from "../../client/static/vite-plugin.js";
 
 export default defineConfig({
+  worker: {
+    format: "es"
+  },
   build: {
     target: "esnext",
     rollupOptions: {

--- a/client/app.css
+++ b/client/app.css
@@ -144,7 +144,11 @@
   }
 
   .default-typeface {
-    font-family: "Sen", "Hanken Grotesk", system-ui, sans-serif;
+    font-family: var(--typeface, "Sen"), "Hanken Grotesk", system-ui, sans-serif;
+  }
+  
+  body {
+    font-family: var(--typeface, "Sen"), "Hanken Grotesk", system-ui, sans-serif;
   }
 }
 

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -43,10 +43,15 @@
     resolveProductConfig
   } from "$lib/client/products/product.config";
   import view from "@21n/stores/view.store";
+  import { userPreferences } from "$lib/client/components/settings/userPreferences.store";
   let timer: any;
   let isMounted = false;
   let lastOrientation: 'portrait' | 'landscape' | null = null;
   const productConfig = resolveProductConfig();
+
+  $: if (browser && $userPreferences?.appearance?.typeface) {
+    document.documentElement.style.setProperty('--typeface', $userPreferences.appearance.typeface);
+  }
 
   onMount(async () => {
     if (browser) {

--- a/client/products/pointron/focus/elements/focusitem/FocusItemList.svelte
+++ b/client/products/pointron/focus/elements/focusitem/FocusItemList.svelte
@@ -241,7 +241,7 @@
       <!-- TODO - input is added to avoid flickering issue on extra wide screens. Without this, causing layout shift when refreshing -->
       <input class="bg-none opacity-0" />
     </div>
-  {:else if $focusItemsStore.items?.length > 0 && focusItems.length > 0}
+  {:else if $focusItemsStore.items?.length > 0 && (focusItems.length > 0 || goals.length > 0 || tasks.length > 0)}
     <div
       use:reorderList={{
         listId: "focusItems",


### PR DESCRIPTION
Resolves multiple UI and build issues by configuring worker loading in Vite, correcting focus item display logic, and enabling dynamic typeface changes.

---
Linear Issue: [TIDY-300](https://linear.app/21n0/issue/TIDY-300/release-testing-oct-06-ar)

<a href="https://cursor.com/background-agent?bcId=bc-810774ee-0e56-4e7a-87ba-1549dc751a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-810774ee-0e56-4e7a-87ba-1549dc751a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Nucleus release testing issues: workers now load correctly, focus items show after starting a session, and user-selected typefaces apply app-wide. Addresses Linear TIDY-300.

- **Bug Fixes**
  - Search indexing workers load by building workers as ES modules in Vite (memotron, nucleus, pointron).
  - Focus items pane shows the reorderable list when goals or tasks exist, even if focusItems is empty.
  - Typeface changes work across the app via a --typeface CSS variable set from userPreferences.

<!-- End of auto-generated description by cubic. -->

