### PR TITLE
Resolve tidy testing issue TIDY-301

### DIFF
--- a/apps/fetch-json-data.js
+++ b/apps/fetch-json-data.js
@@ -45,6 +45,13 @@ export default function fetchJsonPlugin(outputPath) {
     },
     async buildStart() {
       console.log("Fetching JSON from:", url);
+      
+      if (!url || !url.startsWith('http')) {
+        console.log("🔄 Setting up shared static assets...");
+        console.log("⚠️  Skipping fetch in test/dev mode - VITE_STATIC_URL not configured");
+        return;
+      }
+      
       try {
         const response = await fetch(url);
         

--- a/apps/memotron/vitest.config.ts
+++ b/apps/memotron/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true
+  }
+});

--- a/apps/nucleus/vitest.config.ts
+++ b/apps/nucleus/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true
+  }
+});

--- a/client/static/assets-manifest.json
+++ b/client/static/assets-manifest.json
@@ -4,100 +4,100 @@
   "assets": {
     ".turbo/turbo-build.log": {
       "size": 0,
-      "modified": "2025-10-05T15:02:12.634Z"
+      "modified": "2025-10-07T06:52:48.430Z"
     },
     "README.md": {
       "size": 2095,
-      "modified": "2025-09-13T10:15:53.962Z"
+      "modified": "2025-10-07T06:15:03.740Z"
     },
     "example.svelte": {
       "size": 1277,
-      "modified": "2025-09-13T10:15:53.964Z"
+      "modified": "2025-10-07T06:15:03.740Z"
     },
     "icons/arrow_back.svg": {
       "size": 189,
-      "modified": "2025-09-13T10:15:53.965Z"
+      "modified": "2025-10-07T06:15:03.740Z"
     },
     "icons/arrow_forward.svg": {
       "size": 190,
-      "modified": "2025-09-13T10:15:53.965Z"
+      "modified": "2025-10-07T06:15:03.740Z"
     },
     "icons/arrows_outward.svg": {
       "size": 252,
-      "modified": "2025-09-13T10:15:53.965Z"
+      "modified": "2025-10-07T06:15:03.740Z"
     },
     "icons/sprite-lucide-base-v58.svg": {
       "size": 57857,
-      "modified": "2025-10-05T13:57:03.579Z"
+      "modified": "2025-10-07T06:15:03.744Z"
     },
     "icons/sprite-ph-base-v58.svg": {
       "size": 196663,
-      "modified": "2025-10-05T13:57:03.562Z"
+      "modified": "2025-10-07T06:15:03.748Z"
     },
     "icons/sprite-ph-duotone-v58.svg": {
       "size": 245117,
-      "modified": "2025-10-05T13:57:03.645Z"
+      "modified": "2025-10-07T06:15:03.748Z"
     },
     "icons/sprite-ph-fill-v58.svg": {
       "size": 177803,
-      "modified": "2025-10-05T13:57:03.639Z"
+      "modified": "2025-10-07T06:15:03.748Z"
     },
     "icons/sprite-ph-light-v58.svg": {
       "size": 207008,
-      "modified": "2025-10-05T13:57:03.596Z"
+      "modified": "2025-10-07T06:15:03.752Z"
     },
     "icons/sprite-solar-base-v58.svg": {
       "size": 1532,
-      "modified": "2025-10-05T13:57:03.562Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite-solar-bold-duotone-v58.svg": {
       "size": 100055,
-      "modified": "2025-10-05T13:57:03.700Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite-solar-bold-v58.svg": {
       "size": 92339,
-      "modified": "2025-10-05T13:57:03.640Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite-solar-line-duotone-v58.svg": {
       "size": 82130,
-      "modified": "2025-10-05T13:57:03.645Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite-solar-linear-v58.svg": {
       "size": 78501,
-      "modified": "2025-10-05T13:57:03.596Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite-v58.svg": {
       "size": 192828,
-      "modified": "2025-10-05T13:57:04.025Z"
+      "modified": "2025-10-07T06:15:03.756Z"
     },
     "icons/sprite.svg": {
       "size": 365707,
-      "modified": "2025-09-13T10:15:53.974Z"
+      "modified": "2025-10-07T06:15:03.772Z"
     },
     "index.d.ts": {
       "size": 421,
-      "modified": "2025-09-13T10:15:53.974Z"
+      "modified": "2025-10-07T06:15:03.772Z"
     },
     "sounds/dingding.mp3": {
       "size": 13945,
-      "modified": "2025-09-13T10:15:53.975Z"
+      "modified": "2025-10-07T06:15:03.772Z"
     },
     "sounds/ping.wav": {
       "size": 234964,
-      "modified": "2025-09-13T10:15:53.976Z"
+      "modified": "2025-10-07T06:15:03.776Z"
     },
     "sounds/tick.mp3": {
       "size": 1938494,
-      "modified": "2025-09-13T10:15:53.988Z"
+      "modified": "2025-10-07T06:15:03.808Z"
     },
     "sounds/tick1.mp3": {
       "size": 524120,
-      "modified": "2025-09-13T10:15:53.996Z"
+      "modified": "2025-10-07T06:15:03.824Z"
     },
     "sounds/upchime.mp3": {
       "size": 51336,
-      "modified": "2025-09-13T10:15:53.996Z"
+      "modified": "2025-10-07T06:15:03.832Z"
     }
   },
-  "timestamp": "2025-10-05T15:02:12.860Z"
+  "timestamp": "2025-10-07T06:52:48.946Z"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/memotron": {
       "name": "memotron-app",
-      "version": "0.61.4",
+      "version": "0.62.0",
       "dependencies": {
         "@antv/g6": "^5.0.26",
         "@carbon/charts-svelte": "1.13.6",
@@ -138,7 +138,7 @@
     },
     "apps/nucleus": {
       "name": "nucleus-app",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@21n/actions": "*",
         "@21n/components": "*",
@@ -362,7 +362,7 @@
     },
     "apps/pointron": {
       "name": "pointron-app",
-      "version": "0.83.2",
+      "version": "0.83.3",
       "dependencies": {
         "@21n/actions": "*",
         "@21n/components": "*",


### PR DESCRIPTION
Fix test suite failures by handling relative URLs in `fetchJsonPlugin` and allowing Vitest to pass when no tests are found in certain apps.

The `fetchJsonPlugin` was attempting to fetch JSON from relative URLs in test environments where `VITE_STATIC_URL` was not configured, causing `node-fetch` to throw an "Only absolute URLs are supported" error. Additionally, the `nucleus` and `memotron` apps were causing test runs to fail because Vitest exits with code 1 when no test files are present, which is expected for these apps.

---
Linear Issue: [TIDY-301](https://linear.app/21n0/issue/TIDY-301/tidy-9-testing-oct-06-sai)

<a href="https://cursor.com/background-agent?bcId=bc-b025739d-9b3c-4e38-a798-ec5eccf3769f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b025739d-9b3c-4e38-a798-ec5eccf3769f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stabilizes the test suite by skipping JSON fetches in dev/test when URLs aren’t absolute and letting Vitest pass in apps without tests. Aligns with Linear TIDY-301 to improve Tidy 9 testing.

- **Bug Fixes**
  - fetchJsonPlugin: skip fetch when URL is missing or not http.
  - Added Vitest configs for memotron and nucleus with passWithNoTests: true.

- **Dependencies**
  - Version bumps: memotron 0.62.0, nucleus 0.3.4, pointron 0.83.3.

<!-- End of auto-generated description by cubic. -->

