### PR TITLE
Fix kv stores not loading on reload

### DIFF
--- a/client/components/flux/resourceStores/kv.store.ts
+++ b/client/components/flux/resourceStores/kv.store.ts
@@ -73,7 +73,7 @@ export class KeyValueStore<T>
    */
   loader(data: T) {
     // console.log({ context: "kv.store loader", id: this.id, data });
-    if (!data.id) return;
+    if (!data || typeof data !== 'object') return;
     this.isInitialized = true;
     this.__set({ ...data });
   }

--- a/client/products/pointron/pointron.store.ts
+++ b/client/products/pointron/pointron.store.ts
@@ -152,7 +152,7 @@ class PointronPreferencesStore extends KeyValueStore<IPointronPreferences> {
     super(Resource.pointronPreferences, seedLocalPreferences);
   }
   loader(data: IPointronPreferences) {
-    if (!data.id) return;
+    if (!data || typeof data !== 'object') return;
     if (!data.uiStates) data.uiStates = seedLocalPreferences.uiStates;
     if (!data.presets) data.presets = generateSeedPresets();
     //m.horizonCharts = defaultHorizonChartConfiguration;


### PR DESCRIPTION
Update KV store loaders to correctly validate data, fixing an issue where stores failed to load on reload due to an incorrect `id` field check.

Previously, the `loader` method in `KeyValueStore` and `PointronPreferencesStore` checked for `data.id`. However, KV store data retrieved from the database often doesn't include an `id` field within the data object itself, causing the loader to return early and prevent state restoration.

---
Linear Issue: [TIDY-311](https://linear.app/21n0/issue/TIDY-311/kv-stores-not-loading-properly-on-reload)

<a href="https://cursor.com/background-agent?bcId=bc-704160cd-4e43-4bb7-9b85-831852a70e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-704160cd-4e43-4bb7-9b85-831852a70e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes KV stores not restoring state on app reload by validating loader input as an object instead of requiring data.id. Addresses Linear TIDY-311 so focus sessions and recently used commands load previously saved data.

<!-- End of auto-generated description by cubic. -->

