### PR TITLE
feat: TIDY-248_TIDY-323

### DIFF
--- a/apps/memotron/package.json
+++ b/apps/memotron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memotron-app",
   "version": "0.62.0",
-  "build": 3,
+  "build": 4,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5002",

--- a/apps/nucleus/package.json
+++ b/apps/nucleus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nucleus-app",
   "version": "0.3.4",
-  "build": 3,
+  "build": 4,
   "private": true,
   "scripts": {
     "dev": "vite dev --port 5050",

--- a/apps/pointron/package.json
+++ b/apps/pointron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pointron-app",
   "version": "0.83.3",
-  "build": 3,
+  "build": 4,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5001",

--- a/client/app.css
+++ b/client/app.css
@@ -18,8 +18,26 @@
   @apply overflow-x-auto-raw no-scrollbar;
 }
 
+.overflow-auto-scrollbar {
+  @apply overflow-auto-raw styledscroll;
+}
+
+.overflow-y-auto-scrollbar {
+  @apply overflow-y-auto-raw styledscroll;
+}
+
 :root {
   overflow: hidden;
+}
+
+  /**
+* user-select: none is used to provide native experience for touch devices
+*/
+:root {
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
 li.md-list-item::before {
@@ -37,9 +55,9 @@ blockquote {
     } */
 
   /* Hide scrollbar for IOS webview and other scenarios */
-  ::-webkit-scrollbar {
+  /* ::-webkit-scrollbar {
     width: 0em;
-  }
+  } */
 
   .no-scrollbar {
     -webkit-overflow-scrolling: touch;
@@ -65,7 +83,7 @@ blockquote {
   } */
   .styledscroll::-webkit-scrollbar-thumb {
     border-radius: 9999px;
-    background-color: rgba(var(--colors-bgs3));
+    background-color: rgba(var(--colors-bgs4));
   }
 
   .styledscroll::-webkit-scrollbar-thumb:hover {
@@ -153,6 +171,13 @@ blockquote {
 
   .default-typeface {
     font-family: "Sen", "Hanken Grotesk", system-ui, sans-serif;
+  }
+
+  .selectable {
+    -webkit-user-select: text; /* Safari */
+    -moz-user-select: text; /* Firefox */
+    -ms-user-select: text; /* Internet Explorer/Edge */
+    user-select: text; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
   }
 }
 

--- a/client/components/library/LibraryRecordsPane.svelte
+++ b/client/components/library/LibraryRecordsPane.svelte
@@ -618,7 +618,7 @@
     />
   {/if}
   <div
-    class="flex flex-col gap-4 px-4 overflow-auto grow"
+    class="flex flex-col gap-4 px-4 overflow-auto-scrollbar grow"
     id="records-container"
   >
     <InlineSyncingFeedback {resource} />

--- a/client/components/markdown/content/CodeContent.svelte
+++ b/client/components/markdown/content/CodeContent.svelte
@@ -1,26 +1,21 @@
 <script lang="ts">
   import type { ICodeBlockBody } from "../md.type";
   import type { MdStoreType } from "../markdown.store";
-  import CodeContentUsingMonaco from "./CodeContentUsingMonaco.svelte";
+  // import CodeContentUsingMonaco from "./CodeContentUsingMonaco.svelte";
   import CodeContentUsingHighlight from "./CodeContentUsingHighlight.svelte";
-  
+
   export let mdStore: MdStoreType;
   export let body: ICodeBlockBody;
   export let useMonacoEditor: boolean = false;
 </script>
 
 {#if useMonacoEditor}
-  <CodeContentUsingMonaco
+  <!-- <CodeContentUsingMonaco
     {mdStore}
     {body}
     on:update
     on:delete
-  />
+  /> -->
 {:else}
-  <CodeContentUsingHighlight
-    {mdStore}
-    {body}
-    on:update
-    on:delete
-  />
+  <CodeContentUsingHighlight {mdStore} {body} on:update on:delete />
 {/if}

--- a/client/components/markdown/markdown.utils.ts
+++ b/client/components/markdown/markdown.utils.ts
@@ -140,13 +140,6 @@ export const inlineStylingPatterns = [
       "`",
       "<span class='bg-aps2 px-0.5 text-b2 font-mono'>$1</span>"
     )
-  },
-  {
-    regex: /\#([^\#]+)\#(?!#)/g,
-    replacement: encapsulateInlinePattern(
-      "#",
-      "<span class='bg-aps2 rounded-sm'>$1</span>"
-    )
   }
   // {
   //   regex: /#\[((?:\S|\s\S)+?)\]\(([^)]+?)\)/g,

--- a/client/components/record/resource.actions.ts
+++ b/client/components/record/resource.actions.ts
@@ -62,6 +62,20 @@ export class ResourceActions<T extends IMemotronItemBase> {
       }
     };
   }
+  copyExternalLink(): IContextMenuItem {
+    return {
+      label: "Copy source link",
+      value: "copyExternalLink",
+      icon: "copy",
+      callback: async () => {
+        const url = (this.resource as any)?.url;
+        if (url) {
+          await navigator.clipboard.writeText(url);
+          toasts.success("External link copied to clipboard");
+        }
+      }
+    };
+  }
   copyContents(): IContextMenuItem {
     return {
       label: "Copy contents",

--- a/client/components/tasks/TaskLibrary.svelte
+++ b/client/components/tasks/TaskLibrary.svelte
@@ -503,9 +503,12 @@
 
   {#if tasks && tasks.length > 0}
     <div
-      class={cn("flex flex-col gap-4 overflow-auto grow userdata", {
-        "px-4": accessPoint === ResourceAccessPoint.LIBRARY
-      })}
+      class={cn(
+        "flex flex-col gap-4 pr-1.5 overflow-auto-scrollbar grow userdata",
+        {
+          "px-4": accessPoint === ResourceAccessPoint.LIBRARY
+        }
+      )}
     >
       <!-- {#if selectedSubType !== TaskSubTypeForSwitcher.BY_MONTH}
       <AddNewTaskInline on:add={onAdd} bind:this={addNewTaskInlineRef} />

--- a/client/elements/input/SearchResultsPopover.svelte
+++ b/client/elements/input/SearchResultsPopover.svelte
@@ -201,7 +201,7 @@
     "bg-bgs1 rounded-md border border-brs2": isApplyPopoverStyling
   })}
 >
-  <div class="flex flex-col flex-grow items-center w-full">
+  <div class="flex flex-col overflow-y-auto-scrollbar items-center w-full">
     {#if isAlwaysShowSearchFeedback && isSearchInProgress}
       <span class="flex items-center gap-2 p-2">
         <Icon icon="svg-spinners:3-dots-fade" />

--- a/client/extensions/clipper/sidePanel/clips/ClipsPane.svelte
+++ b/client/extensions/clipper/sidePanel/clips/ClipsPane.svelte
@@ -120,10 +120,10 @@
       isSearchContext={true}
       mainText={isMemotronPage
         ? "Hello from the other side of Memotron👋."
-        : "No clips found."}
+        : "No bookmarks found."}
       subText={isMemotronPage
-        ? "Start highlighting to save clips about Memotron to your Memotron."
-        : "Start highlighting to create clips."}
+        ? "Start highlighting to save bookmarks about Memotron to your Memotron."
+        : "Start highlighting to create bookmarks."}
     />
   {/if}
 </main>

--- a/client/layout/layers/BaseLayer.svelte
+++ b/client/layout/layers/BaseLayer.svelte
@@ -45,7 +45,7 @@
   import view from "@21n/stores/view.store";
   let timer: any;
   let isMounted = false;
-  let lastOrientation: 'portrait' | 'landscape' | null = null;
+  let lastOrientation: "portrait" | "landscape" | null = null;
   const productConfig = resolveProductConfig();
 
   onMount(async () => {
@@ -265,19 +265,20 @@
   function updateOrientationClasses(): boolean {
     const html = document.documentElement;
     const isPortrait = window.innerHeight > window.innerWidth;
-    const currentOrientation = isPortrait ? 'portrait' : 'landscape';
-    
-    const hasOrientationChanged = lastOrientation !== null && lastOrientation !== currentOrientation;
+    const currentOrientation = isPortrait ? "portrait" : "landscape";
+
+    const hasOrientationChanged =
+      lastOrientation !== null && lastOrientation !== currentOrientation;
     lastOrientation = currentOrientation;
-    
+
     html.classList.remove("device-portrait", "device-landscape");
-    
+
     if (isPortrait) {
       html.classList.add("device-portrait");
     } else {
       html.classList.add("device-landscape");
     }
-    
+
     return hasOrientationChanged;
   }
 
@@ -560,15 +561,3 @@
     }
   }}
 />
-
-<style>
-  /**
-* user-select: none is used to provide native experience for touch devices
-*/
-  :global(body) {
-    -webkit-user-select: none; /* Safari */
-    -moz-user-select: none; /* Firefox */
-    -ms-user-select: none; /* Internet Explorer/Edge */
-    user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
-  }
-</style>

--- a/client/layout/topNav/tabs/TopBarResourceItem.svelte
+++ b/client/layout/topNav/tabs/TopBarResourceItem.svelte
@@ -27,6 +27,8 @@
   import Button from "$lib/client/elements/button/Button.svelte";
   import { AppSearchParam } from "$lib/client/types/appStore.type";
   import context from "$lib/client/stores/context.store";
+  import { ResourceActions } from "$lib/client/components/record/resource.actions";
+  import { resolveResourceStore } from "$lib/client/components/flux/resourceStores/store.resolver";
   const dispatch = createEventDispatcher();
   export let item: IRecordId;
   export let isInterimTab: boolean = false;
@@ -41,6 +43,7 @@
       items: [
         {
           value: "remove",
+          label: "Remove from tabs",
           icon: "cross",
           callback: async () => uiState.removeResourceFromTabs(item)
         }
@@ -56,7 +59,19 @@
   });
 
   function resolveContextMenu() {
-    return contextMenu;
+    const resourceStore = resolveResourceStore(resourceType);
+    if (!resource || !resourceStore) return contextMenu;
+    const resourceActions = new ResourceActions(resource, resourceStore, {
+      accessPoint: ResourceAccessPoint.SELF,
+      accessMode: ResourceAccessMode.TAB
+    });
+    return [
+      ...contextMenu,
+      {
+        group: "open",
+        items: [resourceActions.openAsSplit(), resourceActions.openAsFull()]
+      }
+    ];
   }
 
   function handleRearrange(displacement: number) {

--- a/client/products/memotron/common/linkbox/LinkItems.svelte
+++ b/client/products/memotron/common/linkbox/LinkItems.svelte
@@ -82,7 +82,7 @@
           }
         });
         if (linkResult && isValidArrayWithData(linkResult)) {
-          link = linkResult[0];
+          link = { links: linkResult, linkedTo: nodeId };
           expansionState = "node";
         } else {
           expansionState = "error";

--- a/client/products/memotron/graph/NodeGraphUsingG6.svelte
+++ b/client/products/memotron/graph/NodeGraphUsingG6.svelte
@@ -224,8 +224,8 @@
           labelBackground: true,
           labelPadding: [4, 12, 4, 12],
           labelBackgroundOpacity: 1,
-          labelFill: currentColors["bgs1"],
-          labelBackgroundFill: currentColors["ass1"],
+          labelFill: currentColors["aps1"],
+          labelBackgroundFill: currentColors["aps3"],
           padding: [16, 16, 16, 16],
           labelBackgroundRadius: 6
         }

--- a/client/products/memotron/linking/LinkTagger.svelte
+++ b/client/products/memotron/linking/LinkTagger.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import TextSearchInput from "$lib/client/elements/input/TextSearchInput.svelte";
   import { InputStyle } from "$lib/client/types/input.type";
   import { createEventDispatcher } from "svelte";
@@ -7,6 +6,7 @@
   import type { INodeLinkThumb } from "../node/node.type";
   import type { IRecordId } from "$lib/client/types/data.type";
   import { logger } from "$lib/client/components/debug/logger.client";
+  import { LinkType } from "./link.type";
   const dispatch = createEventDispatcher();
 
   export let link: INodeLinkThumb;
@@ -19,7 +19,11 @@
 
   async function processSelect(id: IRecordId) {
     link.tags = [...(link.tags || []), id];
-    const result = await linker.modify(link.id, {
+    const linkId =
+      link.links?.find((x) => x.linkType === LinkType.DIRECT)?.id ??
+      link.links?.[0].id;
+    if (!linkId) return;
+    const result = await linker.modify(linkId, {
       tags: link.tags
     });
     logger.log({ at: "processSelect", result });

--- a/client/products/memotron/linking/LinkTags.svelte
+++ b/client/products/memotron/linking/LinkTags.svelte
@@ -9,15 +9,27 @@
   import { resourceInList } from "$lib/client/components/flux/resourceStores/resource.utils";
   const dispatch = createEventDispatcher();
   export let link: INodeLinkThumb;
-  $: _tags = $linkTagStore
-    ?.filter((x) => link.tags?.some(resourceInList(x)))
-    ?.map(linkTagLabelMapper);
+  $: _tags =
+    $linkTagStore
+      ?.filter((x) => link.tags?.some(resourceInList(x)))
+      ?.map(linkTagLabelMapper) ?? [];
 
   async function onRemove(tagId: IRecordId) {
     link.tags = link.tags?.filter((x) => x.toString() !== tagId.toString());
-    await linker.modify(link.id, {
-      tags: link.tags
-    });
+    const linksWithThisTag = link.links?.filter((x) =>
+      x.tags?.some(resourceInList(tagId))
+    );
+    if (linksWithThisTag && linksWithThisTag.length > 0) {
+      link.links = link.links?.map((x) => ({
+        ...x,
+        tags: x.tags?.filter((y) => y.toString() !== tagId.toString())
+      }));
+      linksWithThisTag.forEach(async (x) => {
+        await linker.modify(x.id, {
+          tags: x.tags?.filter((y) => y.toString() !== tagId.toString())
+        });
+      });
+    }
   }
   function onTagClick(tagId: IRecordId, e: MouseEvent) {
     dispatch("tagClick", tagId);

--- a/client/products/memotron/linking/link.utils.ts
+++ b/client/products/memotron/linking/link.utils.ts
@@ -1,4 +1,4 @@
-import type { ILinkTag } from "./link.type";
+import { LinkType, type ILinkTag } from "./link.type";
 
 export function linkTagLabelMapper(tag: ILinkTag) {
   const label = tag.group
@@ -7,5 +7,39 @@ export function linkTagLabelMapper(tag: ILinkTag) {
   return {
     ...tag,
     label
+  };
+}
+
+export function resolveLinkTypeConfig(
+  linkType: LinkType,
+  direction: "incoming" | "outgoing" | undefined
+) {
+  if (linkType === LinkType.DIRECT) {
+    return {
+      icon: "ph:arrows-left-right-light",
+      label: "Direct link"
+    };
+  } else if (linkType === LinkType.MENTION) {
+    if (direction === "incoming") {
+      return {
+        icon: "incoming",
+        label: "Incoming mention"
+      };
+    } else if (direction === "outgoing") {
+      return {
+        icon: "outgoing",
+        label: "Outgoing mention"
+      };
+    } else {
+      return {
+        icon: "at",
+        label: "Mention"
+      };
+    }
+  }
+  return {
+    icon: "link",
+    label: "Link",
+    description: "Link to another node"
   };
 }

--- a/client/products/memotron/memotron.actions.ts
+++ b/client/products/memotron/memotron.actions.ts
@@ -36,6 +36,7 @@ import CaptureSettings from "./capture/CaptureSettings.svelte";
 import LinkTagsControlPanel from "./linking/LinkTagsControlPanel.svelte";
 import LibraryPanelContentResolver from "$lib/client/components/library/LibraryPanelContentResolver.svelte";
 import PreviewImageUploader from "./node/PreviewImageUploader.svelte";
+import NodeSettings from "./node/NodeSettings.svelte";
 
 export const memotronActions: IAction[] = [
   {
@@ -340,6 +341,20 @@ export const memotronActions: IAction[] = [
       title: "Capture Settings",
       layout: {
         size: Size.lg,
+        orientation: Orientation.Vertical,
+        isShowCantileverClose: true
+      }
+    }
+  },
+  {
+    action: MemotronAction.NODE_SETTINGS,
+    label: "Node Settings",
+    type: ActionType.MODAL,
+    component: NodeSettings,
+    modalParams: {
+      title: "Node Settings",
+      layout: {
+        size: Size.md,
         orientation: Orientation.Vertical,
         isShowCantileverClose: true
       }

--- a/client/products/memotron/memotronAction.enum.ts
+++ b/client/products/memotron/memotronAction.enum.ts
@@ -35,5 +35,6 @@ export enum MemotronAction {
   EDIT_CAPTURE_SHORTCUTS = "edit-capture-shortcuts",
   CAPTURE_SETTINGS = "capture-settings",
   RELATIONS_AS_SETTINGS = "relations-as-settings",
-  ACTIVATE_LINK_BOX = "ACTIVATE_LINK_BOX"
+  ACTIVATE_LINK_BOX = "ACTIVATE_LINK_BOX",
+  NODE_SETTINGS = "node-settings"
 }

--- a/client/products/memotron/node/NodeSettings.svelte
+++ b/client/products/memotron/node/NodeSettings.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import SwitchInput from "$lib/client/elements/toggle/SwitchInput.svelte";
+  import { Size } from "$lib/client/types/size.enum";
+  import { InputStyle } from "$lib/client/types/input.type";
+  import { preferences } from "$lib/client/stores/preferences/preferences.store";
+  import { Preference, PreferencesScope } from "$lib/client/stores/preferences/preferences.type";
+  import { appStore } from "$lib/client/stores/app.store";
+  import { derived } from "svelte/store";
+
+  const hideHighlightColors = derived(
+    [preferences, appStore],
+    ([$preferences, $appStore]) => {
+      const key = `${$appStore.product}-${Preference.HIDE_HIGHLIGHT_COLORS}`;
+      return ($preferences[key] as boolean) ?? false;
+    }
+  );
+
+  function handleToggleChange(event: CustomEvent<boolean>) {
+    preferences.save(Preference.HIDE_HIGHLIGHT_COLORS, event.detail, {
+      scope: PreferencesScope.PRODUCT
+    });
+  }
+</script>
+
+<div class="flex flex-col gap-6 h-full w-full">
+  <SwitchInput
+    checked={$hideHighlightColors}
+    size={Size.md}
+    style={InputStyle.PLAIN}
+    isExpanded={true}
+    label={{
+      label: "Don't show text highlight colors",
+      tooltip: {
+        body: "When enabled, text highlights from Kindle and web clips will not display their colors."
+      }
+    }}
+    on:change={handleToggleChange}
+  />
+</div>

--- a/client/products/memotron/node/birdView/NodeBirdView.svelte
+++ b/client/products/memotron/node/birdView/NodeBirdView.svelte
@@ -145,7 +145,6 @@
    */
   async function refreshGraphData(links: any[], depth: number) {
     try {
-      console.log({ links });
       if (!links) return;
       await loadLinkedNodesData(links);
       if (isAutoGrouping) {
@@ -205,7 +204,7 @@
           return {
             source: $node.id.toString(),
             target: l.linkedTo.toString(),
-            id: l.id,
+            id: l.links?.[0]?.id,
             linkType: l.linkType
           };
         });

--- a/client/products/memotron/node/content/MediaContent.svelte
+++ b/client/products/memotron/node/content/MediaContent.svelte
@@ -20,7 +20,7 @@
   export let isConstrainedWidth: boolean = false;
   export let rightPane: NodeRightPaneType | undefined =
     $node?.contentType === NodeType.PDF && !isConstrainedWidth
-      ? NodeRightPaneType.TRACES
+      ? NodeRightPaneType.BOOKMARKS
       : undefined;
   let renderingDetails: any;
   let contentRef: MediaContentResolver;

--- a/client/products/memotron/node/content/web/TextClipPreview.svelte
+++ b/client/products/memotron/node/content/web/TextClipPreview.svelte
@@ -7,11 +7,35 @@
   } from "$lib/client/products/memotron/node/node.type";
   import { cn, convertToRGBA } from "$lib/client/utils/ui.utils";
   import { truncateString } from "$lib/shared/utils/text.utils";
+  import Button from "$lib/client/elements/button/Button.svelte";
+  import { ButtonStyle } from "$lib/client/types/button.type";
+  import { Size } from "$lib/client/types/size.enum";
+  import { toasts } from "$lib/client/stores/notification.store";
+  import { preferences } from "$lib/client/stores/preferences/preferences.store";
+  import {
+    Preference,
+    PreferencesScope
+  } from "$lib/client/stores/preferences/preferences.type";
+  import { appStore } from "$lib/client/stores/app.store";
+  import { derived } from "svelte/store";
+  import { Arrangement } from "$lib/client/types/direction.enum";
   export let node: INode;
   export let contentPreview: string;
   export let truncateLength: number | undefined = undefined;
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.SELF;
-  let textHightlightColor = resolveTextHighlightColor(node);
+  export let arrangement: Arrangement = Arrangement.LIST;
+
+  const hideHighlightColors = derived(
+    [preferences, appStore],
+    ([$preferences, $appStore]) => {
+      const key = `${$appStore.product}-${Preference.HIDE_HIGHLIGHT_COLORS}`;
+      return ($preferences[key] as boolean) ?? false;
+    }
+  );
+
+  $: textHightlightColor = $hideHighlightColors
+    ? undefined
+    : resolveTextHighlightColor(node);
 
   function getKindleHighlightRGBA(color: string, opacity: number) {
     const colorMap = {
@@ -42,25 +66,51 @@
       return undefined;
     }
   }
+
+  async function copyTextContent() {
+    const text = node.text || node.mdText || contentPreview || "";
+    if (text) {
+      await navigator.clipboard.writeText(text);
+      toasts.success("Text copied to clipboard");
+    }
+  }
 </script>
 
-<div
-  class={cn("rounded-md text-wrap text-left userdata", {
-    "m-4 p-4 bg--bgs2": accessPoint === ResourceAccessPoint.SELF,
-    "line-clamp-3":
-      accessPoint !== ResourceAccessPoint.SELF &&
-      accessPoint !== ResourceAccessPoint.NODE_TRACES,
-    "line-clamp-5": accessPoint === ResourceAccessPoint.NODE_TRACES
-  })}
->
-  <span
-    class={cn("relative", {
-      "text-b2": accessPoint === ResourceAccessPoint.SELF
+<div class="flex flex-col gap-2">
+  <div
+    class={cn("rounded-md text-wrap text-left userdata selectable", {
+      "m-4 p-4 bg--bgs2": accessPoint === ResourceAccessPoint.SELF,
+      "line-clamp-3":
+        accessPoint !== ResourceAccessPoint.SELF &&
+        accessPoint !== ResourceAccessPoint.NODE_TRACES &&
+        arrangement === Arrangement.LIST,
+      "line-clamp-5": accessPoint === ResourceAccessPoint.NODE_TRACES
     })}
-    style="background-color: {textHightlightColor
-      ? textHightlightColor
-      : 'transparent'};"
   >
-    {truncateString(contentPreview, truncateLength)}
-  </span>
+    <span
+      class={cn("relative", {
+        "text-b2": accessPoint === ResourceAccessPoint.SELF,
+        "text-fgs3":
+          accessPoint !== ResourceAccessPoint.SELF &&
+          !textHightlightColor &&
+          arrangement !== Arrangement.LIST
+      })}
+      style="background-color: {textHightlightColor
+        ? textHightlightColor
+        : 'transparent'};"
+    >
+      {truncateString(contentPreview, truncateLength)}
+    </span>
+  </div>
+  {#if accessPoint === ResourceAccessPoint.SELF}
+    <div class="flex justify-center items-center w-full gap-4 pb-4">
+      <Button
+        style={ButtonStyle.PLAIN}
+        label="Copy text content"
+        isUnderlined={true}
+        size={Size.sm}
+        on:click={copyTextContent}
+      />
+    </div>
+  {/if}
 </div>

--- a/client/products/memotron/node/content/web/social/SocialPostContent.svelte
+++ b/client/products/memotron/node/content/web/social/SocialPostContent.svelte
@@ -21,6 +21,7 @@
   import { ButtonStyle } from "$lib/client/types/button.type";
   import { properCase } from "$lib/shared/utils/text.utils";
   import { resolveContentPreview } from "../../../node.utils";
+  import { toasts } from "$lib/client/stores/notification.store";
 
   export let node: INode;
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.SELF;
@@ -83,16 +84,21 @@
     else suffix = properCase(node.contentType.split("_POST")[0]);
     return `Open on ${suffix}`;
   }
+
+  async function copyTextContent() {
+    const text = resolveContentPreview(node);
+    if (text) {
+      await navigator.clipboard.writeText(text);
+      toasts.success("Text copied to clipboard");
+    }
+  }
 </script>
 
 {#if oembedHtml}
   {@html oembedHtml}
 {:else if shouldShowWidget() && node.url && !error}
-  <button
+  <div
     class="relative w-full h-full px-4 flex flex-col justify-center items-center overflow-y-auto"
-    on:click={() => {
-      if (node.url) appStore.openLink(node.url);
-    }}
   >
     <div class="absolute inset-0 flex justify-center items-center z-0 mb-12">
       <Icon icon="svg-spinners:3-dots-fade" size={Size.lg} />
@@ -105,8 +111,7 @@
       {/if}
       {#if node.contentType === NodeType.TWEET}
         <TweetPreviewUsingWidget tweetUrl={node.url} />
-      {:else if node.contentType === NodeType.INSTAGRAM_POST ||
-        node.contentType === NodeType.INSTAGRAM_REEL}
+      {:else if node.contentType === NodeType.INSTAGRAM_POST || node.contentType === NodeType.INSTAGRAM_REEL}
         <InstagramPostWidget postUrl={node.url} />
       {:else if node.contentType === NodeType.LINKEDIN_POST}
         <LinkedInPostWidget postUrl={node.url} />
@@ -134,7 +139,9 @@
         />
       {/if}
     </div>
-    <div class="flex justify-center items-center w-full gap-4 pt-4 pb-8">
+    <div
+      class="flex cw:flex-col justify-center items-center w-full gap-4 pt-4 pb-8"
+    >
       {#if hasPermanentCopy}
         <Button
           style={ButtonStyle.PLAIN}
@@ -147,6 +154,18 @@
           }}
         />
       {/if}
+      {#if hasPermanentCopy}
+        <Button
+          style={ButtonStyle.PLAIN}
+          label="Copy text content"
+          isUnderlined={true}
+          size={Size.sm}
+          on:click={(e) => {
+            e.stopPropagation();
+            copyTextContent();
+          }}
+        />
+      {/if}
       <Button
         style={ButtonStyle.PLAIN}
         label={resolveOpenInButtonLabel()}
@@ -155,7 +174,7 @@
         on:click
       />
     </div>
-  </button>
+  </div>
 {:else}
   <SocialPostContentFallback {node} />
 {/if}

--- a/client/products/memotron/node/content/web/social/SocialPostContentFallback.svelte
+++ b/client/products/memotron/node/content/web/social/SocialPostContentFallback.svelte
@@ -15,6 +15,10 @@
   import { Persistence } from "$lib/client/persistence/persistence";
   import { InfoTextType } from "$lib/client/types/text.type";
   import { parse } from "$lib/shared/utils/json.utils";
+  import Button from "$lib/client/elements/button/Button.svelte";
+  import { ButtonStyle } from "$lib/client/types/button.type";
+  import { Size } from "$lib/client/types/size.enum";
+  import { toasts } from "$lib/client/stores/notification.store";
 
   export let node: INode;
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.SELF;
@@ -134,6 +138,13 @@
     }
     return "Unknown";
   }
+
+  async function copyTextContent() {
+    if (contentPreview) {
+      await navigator.clipboard.writeText(contentPreview);
+      toasts.success("Text copied to clipboard");
+    }
+  }
 </script>
 
 <div
@@ -174,4 +185,18 @@
       {getPostedAtTime()}
     </div>
   </button>
+  {#if contentPreview}
+    <div class="flex justify-center items-center w-full gap-4">
+      <Button
+        style={ButtonStyle.PLAIN}
+        label="Copy text content"
+        isUnderlined={true}
+        size={Size.sm}
+        on:click={(e) => {
+          e.stopPropagation();
+          copyTextContent();
+        }}
+      />
+    </div>
+  {/if}
 </div>

--- a/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
+++ b/client/products/memotron/node/floatingBar/MediaNodeFloatingBar.svelte
@@ -176,7 +176,7 @@
                 e.detail === NodeRightPaneType.PROPERTIES ||
                 e.detail === NodeRightPaneType.SIDENOTES ||
                 e.detail === NodeRightPaneType.LINKS ||
-                e.detail === NodeRightPaneType.TRACES
+                e.detail === NodeRightPaneType.BOOKMARKS
               ) {
                 bottomAction = e.detail;
               }

--- a/client/products/memotron/node/links/LinkItem.svelte
+++ b/client/products/memotron/node/links/LinkItem.svelte
@@ -10,12 +10,26 @@
   import Toggle from "$lib/client/elements/toggle/Toggle.svelte";
   import LinkTags from "../../linking/LinkTags.svelte";
   import NodeThumbnail from "../thumbnail/NodeThumbnail.svelte";
+  import LinkTypeIndicator from "./LinkTypeIndicator.svelte";
+  import { LinkType } from "$lib/client/products/memotron/linking/link.type";
+  import { createEventDispatcher } from "svelte";
+  const dispatch = createEventDispatcher();
   export let accessPointId: IRecordId;
   export let link: INodeLinkThumb;
   export let item: INode;
   export let accessPoint: ResourceAccessPoint = ResourceAccessPoint.NODE_LINKS;
   export let accessPointContext: string | undefined = undefined;
   let isShowLinkTagger = false;
+
+  function propagateLinkTypeClick(
+    linkType: LinkType,
+    direction: "incoming" | "outgoing"
+  ) {
+    return (e: Event) => {
+      e.stopPropagation();
+      dispatch("linkTypeSelect", { linkType, direction });
+    };
+  }
 </script>
 
 <!-- TODO - add parent breadcrumbs  and avatar in below component - moving from LinkSuggestionItem.svelte -->
@@ -29,18 +43,36 @@
     on:action
     isAlwaysShowContextMenuOnTouchDevice={true}
   >
-    <span slot="right" class="flex bg-bgs2 rounded-md border border-brs3">
-      <Toggle icon="relation" bind:on={isShowLinkTagger} />
+    <span slot="right" class="flex items-center gap-2">
+      <span class="flex bg-bgs2 rounded-md border border-brs3">
+        <Toggle icon="relation" bind:on={isShowLinkTagger} />
+      </span>
     </span>
     <span
       slot="bottom"
       class={cn("flex flex-col gap-2", {
-        "pt-2": (link.tags && link.tags.length > 0) || isShowLinkTagger
+        "pt-3": (link.tags && link.tags.length > 0) || isShowLinkTagger
       })}
     >
-      {#if link.tags && link.tags.length > 0}
-        <LinkTags bind:link on:tagClick />
-      {/if}
+      <span class="flex gap-2">
+        {#if link.links && link.links.length > 0}
+          <span class="flex gap-1">
+            {#each link.links as linkType}
+              <LinkTypeIndicator
+                linkType={linkType.linkType}
+                direction={linkType.direction}
+                on:click={propagateLinkTypeClick(
+                  linkType.linkType,
+                  linkType.direction
+                )}
+              />
+            {/each}
+          </span>
+        {/if}
+        {#if link.tags && link.tags.length > 0}
+          <LinkTags bind:link on:tagClick />
+        {/if}
+      </span>
       {#if isShowLinkTagger}
         <div class="w-full py-2">
           <LinkTagger bind:link />

--- a/client/products/memotron/node/links/LinkThumbnailItems.svelte
+++ b/client/products/memotron/node/links/LinkThumbnailItems.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class="flex flex-col gap-3 w-full">
-  {#each links as item (item.link.id)}
+  {#each links as item (item.link.linkedTo)}
     <LinkItem
       link={item.link}
       item={item.node}
@@ -25,6 +25,7 @@
       on:click={(e) => {
         dispatch("click", { event: e, id: item.node.id });
       }}
+      on:linkTypeSelect
       on:action
       on:tagClick
     />

--- a/client/products/memotron/node/links/LinkTypeIndicator.svelte
+++ b/client/products/memotron/node/links/LinkTypeIndicator.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Icon from "$lib/client/elements/Icon.svelte";
+  import { LinkType } from "$lib/client/products/memotron/linking/link.type";
+  import { cn } from "$lib/client/utils/ui.utils";
+  import { Size } from "$lib/client/types/size.enum";
+  import { tooltip } from "$lib/client/actions/popover.action";
+  import { resolveLinkTypeConfig } from "$lib/client/products/memotron/linking/link.utils";
+
+  export let linkType: LinkType;
+  export let direction: "incoming" | "outgoing" | undefined = undefined;
+
+  $: linkConfig = resolveLinkTypeConfig(linkType, direction);
+</script>
+
+<button
+  class={cn(
+    "flex items-center justify-center gap-1 h-6 w-6 rounded-md border text-b4 font-medium hover:bg-bgs2"
+  )}
+  use:tooltip={{
+    text: linkConfig.label
+  }}
+  on:click
+>
+  <Icon icon={linkConfig.icon} size={Size.sm} />
+</button>

--- a/client/products/memotron/node/links/NodeLinksPane.svelte
+++ b/client/products/memotron/node/links/NodeLinksPane.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import LinkThumbnailItems from "./LinkThumbnailItems.svelte";
-  import OptionSelector from "$lib/client/elements/select/OptionSelector.svelte";
   import { Size } from "$lib/client/types/size.enum";
   import EmptyStatusView from "$lib/client/elements/feedback/EmptyStatusView.svelte";
   import ErrorStatusPane from "$lib/client/elements/feedback/ErrorStatusPane.svelte";
@@ -31,16 +30,11 @@
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import { logger } from "$lib/client/components/debug/logger.client";
   import type { IRecordId } from "$lib/client/types/data.type";
-  import Toggle from "$lib/client/elements/toggle/Toggle.svelte";
   import LinkTagFilter from "./LinkTagFilter.svelte";
-  import ComingSoonView from "$lib/client/elements/ComingSoonView.svelte";
   import {
     resourceInList,
     isSameResource
   } from "$lib/client/components/flux/resourceStores/resource.utils";
-  import PanelSwitcher from "$lib/client/elements/switcher/PanelSwitcher.svelte";
-  import { PanelSwitcherStyle } from "$lib/client/types/switcher.enum";
-  import { activeResourceFilterV2 } from "$lib/client/utils/utils";
   import { BulkEditor } from "../../../../components/record/record.store";
   import { toasts } from "$lib/client/stores/notification.store";
   import { deepCopy, isValidArrayWithData } from "$lib/shared/utils/obj.utils";
@@ -50,6 +44,8 @@
   } from "$lib/client/components/error/error.type";
   import { ResourceError } from "$lib/client/components/error/errors";
   import { LoadingAnimationType } from "$lib/client/types/feedback.type";
+  import Tag from "$lib/client/elements/text/Tag.svelte";
+  import { resolveLinkTypeConfig } from "$lib/client/products/memotron/linking/link.utils";
   export let node: IActiveNodeStore;
   $: multiSelectContext = {
     resource: Resource.node,
@@ -62,7 +58,9 @@
   let outgoingMentions: { link: INodeLinkThumb; node: INode }[] = [];
   let filtered: { link: INodeLinkThumb; node: INode }[] = [];
 
-  let selectedLinkType: LinkType = LinkType.DIRECT;
+  let selectedLinkType:
+    | { linkType: LinkType; direction: "incoming" | "outgoing" | undefined }
+    | undefined = undefined;
   let selectedLinkTags: IRecordId[] = [];
   let fetchError: string | undefined = undefined;
   let linkStatus: { message: string; type: AlertType } = {
@@ -71,11 +69,9 @@
   };
   let previousFocus: IRecordId;
   let searchQuery: string = "";
-  let isShowLinkTagFilters = false;
-  let isShowLinkSuggestions = false;
   let dev_linkTagFilter: "and" | "or" = "and";
-  let selectedMentionDirection: "incoming" | "outgoing" = "incoming";
   let isRefreshing = false;
+  let availableLinkTags: IRecordId[] = [];
 
   onMount(() => {
     const unsubscribe = node.subscribe(async (x) => {
@@ -216,10 +212,14 @@
       outgoingMentions = result.map((x: any) => ({
         link: {
           linkedTo: x.out,
-          linkType: LinkType.MENTION,
-          id: x.id,
-          tags: x.tags,
-          direction: "outgoing"
+          links: [
+            {
+              linkType: LinkType.MENTION,
+              id: x.id,
+              direction: "outgoing"
+            }
+          ],
+          tags: x.tags
         },
         node: nodes.find((y: any) => isSameResource(y.id, x.out))
       }));
@@ -231,19 +231,25 @@
   }
 
   async function applyFilters() {
-    if (
-      selectedLinkType === LinkType.MENTION &&
-      selectedMentionDirection === "outgoing"
-    ) {
-      filtered = await refreshOutgoingMentions();
-    } else {
-      filtered = all.filter((x) => x.link.linkType === selectedLinkType);
-      if (selectedLinkType === LinkType.MENTION) {
-        filtered = filtered.filter(
-          (x) => x.link.direction === selectedMentionDirection
-        );
-      }
-    }
+    const outgoing = await refreshOutgoingMentions();
+    const combined = [...all, ...outgoing].filter(
+      (item, index, self) =>
+        index ===
+        self.findIndex(
+          (t) => t.link.linkedTo.toString() === item.link.linkedTo.toString()
+        )
+    );
+
+    filtered = combined;
+
+    const allTags = new Set<IRecordId>();
+    combined.forEach((item) => {
+      item.link.tags?.forEach((tag) => {
+        allTags.add(tag);
+      });
+    });
+    availableLinkTags = Array.from(allTags);
+
     if (selectedLinkTags.length > 0) {
       if (dev_linkTagFilter === "or") {
         filtered = filtered.filter((x) =>
@@ -254,6 +260,15 @@
           selectedLinkTags.every((y) => x.link.tags?.some(resourceInList(y)))
         );
       }
+    }
+    if (selectedLinkType) {
+      filtered = filtered.filter((x) =>
+        x.link.links?.some(
+          (y) =>
+            y.linkType === selectedLinkType.linkType &&
+            y.direction === selectedLinkType.direction
+        )
+      );
     }
   }
 
@@ -283,7 +298,12 @@
     if (!e.detail) return;
     if (selectedLinkTags.some(resourceInList(e.detail))) return;
     selectedLinkTags = [...selectedLinkTags, e.detail];
-    isShowLinkTagFilters = true;
+    applyFilters();
+  }
+
+  function onLinkTypeSelect(e: CustomEvent) {
+    if (!e.detail) return;
+    selectedLinkType = e.detail;
     applyFilters();
   }
 
@@ -338,104 +358,47 @@
     </div> -->
   </div>
   <div class="flex flex-col gap-4 w-full flex-grow">
-    <div class="flex gap-4 items-center justify-between">
-      <!-- <OptionSelector
-        size={Size.sm}
-        bind:selected={selectedLinkType}
-        on:select={applyFilters}
-        options={[
-          {
-            value: LinkType.DIRECT,
-            label: "Direct",
-            icon: "arrow-right-left"
-          },
-          {
-            label: "Mentioned",
-            value: LinkType.MENTION,
-            icon: "at-symbol"
-          }
-        ]}
-      /> -->
-      <PanelSwitcher
-        items={[
-          {
-            value: LinkType.DIRECT,
-            label: "Direct",
-            icon: "ph:arrows-left-right-light",
-            badge: all.filter((x) => x.link.linkType === LinkType.DIRECT).length
-          },
-          {
-            label: "Mentions",
-            value: LinkType.MENTION,
-            icon: "at",
-            badge: all.filter((x) => x.link.linkType === LinkType.MENTION)
-              .length
-          }
-        ]}
-        size={Size.sm}
-        bind:value={selectedLinkType}
-        on:switch={applyFilters}
-        isExpandToFullWidth={true}
-        style={PanelSwitcherStyle.BAR}
-      >
-        <slot name="right" slot="right">
-          <div class="flex items-center">
-            <!-- <Toggle
-              icon="lightbulb"
-              tooltip="Link suggestions"
-              bind:on={isShowLinkSuggestions}
-            /> -->
-            <Toggle
-              icon="relation"
-              tooltip="Relations"
-              bind:on={isShowLinkTagFilters}
-              count={selectedLinkTags.length > 0
-                ? selectedLinkTags.length
-                : undefined}
-            />
-          </div>
-        </slot>
-      </PanelSwitcher>
-    </div>
-    {#if selectedLinkType === LinkType.MENTION}
-      <OptionSelector
-        size={Size.sm}
-        bind:selected={selectedMentionDirection}
-        on:select={applyFilters}
-        options={[
-          {
-            value: "incoming",
-            label: "Incoming",
-            icon: "incoming"
-          },
-          {
-            label: "Outgoing",
-            value: "outgoing",
-            icon: "outgoing"
-          }
-        ]}
+    {#if selectedLinkType}
+      {@const config = resolveLinkTypeConfig(
+        selectedLinkType.linkType,
+        selectedLinkType.direction
+      )}
+      <Tag
+        label={config.label}
+        icon={config.icon}
+        size={Size.md}
+        isActive={true}
+        isRemovable={true}
+        on:remove={() => {
+          selectedLinkType = undefined;
+          applyFilters();
+        }}
+        on:click={(e) => {
+          selectedLinkType = undefined;
+          applyFilters();
+        }}
       />
     {/if}
-    {#if isShowLinkTagFilters}
-      <LinkTagFilter
-        links={filtered.map((x) => x.link)}
-        bind:selected={selectedLinkTags}
-        on:change={applyFilters}
-      />
+    {#if availableLinkTags.length > 0}
+      <div class="flex flex-col gap-3">
+        <LinkTagFilter
+          links={filtered.map((x) => x.link)}
+          bind:selected={selectedLinkTags}
+          on:change={applyFilters}
+        />
+      </div>
     {/if}
     {#if fetchError}
       <ErrorStatusPane error={fetchError} />
-    {:else if isShowLinkSuggestions}
-      <ComingSoonView mainText="Link suggestions" subText="Coming soon..." />
     {:else if filtered.length > 0 && !isRefreshing}
       <div class="flex flex-col flex-grow w-full">
         <LinkThumbnailItems
           links={filtered}
           accessPointId={node.id}
-          accessPointContext={selectedLinkType}
           on:click={onClick}
           on:action={onAction}
           on:tagClick={onTagClick}
+          on:linkTypeSelect={onLinkTypeSelect}
         />
         <ScrollViewBottomSpacer />
       </div>
@@ -444,12 +407,8 @@
         isSearchContext={true}
         isLoadingState={isRefreshing}
         loadingAnimation={LoadingAnimationType.FOCUS_ITEMS_PULSE}
-        mainText={selectedLinkType === LinkType.SUGGESTION
-          ? "No suggestions found."
-          : "No links found."}
-        subText={selectedLinkType === LinkType.SUGGESTION
-          ? "Come back later to see link suggestions"
-          : "Try different filters or add links."}
+        mainText="No links found."
+        subText="Try different filters or add links."
       />
     {/if}
   </div>
@@ -457,7 +416,6 @@
     <BottomFloat class="!mb-3" zIndex="z-30">
       <BulkEditBar
         context={multiSelectContext}
-        subContext={selectedLinkType}
         on:selectAll={onSelectAll}
         on:action={onBulkAction}
       />

--- a/client/products/memotron/node/node.store.ts
+++ b/client/products/memotron/node/node.store.ts
@@ -11,6 +11,7 @@ import {
   headingNodeTypes,
   mediaNodeTypeList,
   rootNodeTypeList,
+  socialPostNodeTypeList,
   type INodeCapture
 } from "$lib/client/products/memotron/node/node.type";
 import { ResourceStore } from "$lib/client/components/flux/resourceStores/resource.store";
@@ -46,7 +47,8 @@ import { isValidString } from "$lib/shared/utils/text.utils";
 import {
   resourceInList,
   isSameResource,
-  isRecordId
+  isRecordId,
+  removeDuplicatesFilter
 } from "$lib/client/components/flux/resourceStores/resource.utils";
 
 import context from "$lib/client/stores/context.store";
@@ -409,14 +411,28 @@ export class ActiveNodeStore extends CollectibleStore<
       );
       console.timeEnd("ActiveNodeStore.afterInit - links");
       if (linksResult && isValidArrayWithData(linksResult)) {
-        const links: INodeLinkThumb[] = linksResult.map((x: ILink) => {
+        let uniqueLinkIds = new Set();
+        linksResult.forEach((x: ILink) => {
           const id = x.in.toString() === this.id ? x.out : x.in;
+          uniqueLinkIds.add(id);
+        });
+        const links: INodeLinkThumb[] = Array.from(uniqueLinkIds).map((id) => {
+          const allLinks = linksResult.filter(
+            (y) => y.out === id || y.in === id
+          );
           return {
             linkedTo: id,
-            linkType: x.linkType,
-            id: x.id,
-            tags: x.tags,
-            direction: x.in.toString() === this.id ? "outgoing" : "incoming"
+            links: allLinks.map((y) => ({
+              id: y.id,
+              linkType: y.linkType,
+              direction: y.in.toString() === this.id ? "outgoing" : "incoming",
+              tags: y.tags
+            })),
+            tags: allLinks
+              .map((y) => y.tags)
+              .flat()
+              .filter(Boolean)
+              .filter(removeDuplicatesFilter)
           } as INodeLinkThumb;
         });
         this.update((n) => {
@@ -769,6 +785,19 @@ class NodeActions {
     }
   };
 
+  copyHighlightText = {
+    value: "copyHighlightText",
+    label: "Copy content",
+    icon: "copy",
+    callback: async () => {
+      const text = this.node.text || this.node.mdText || "";
+      if (text) {
+        await navigator.clipboard.writeText(text);
+        toasts.success("Highlight text copied to clipboard");
+      }
+    }
+  };
+
   sideNotesPane() {
     return {
       value: NodeRightPaneType.SIDENOTES,
@@ -796,10 +825,10 @@ class NodeActions {
 
   tracesPane() {
     return {
-      value: NodeRightPaneType.TRACES,
+      value: NodeRightPaneType.BOOKMARKS,
       icon: "bookmark",
-      label: "Show traces",
-      tooltip: "Show traces",
+      label: "Show bookmarks",
+      tooltip: "Show bookmarks",
       count:
         "clips" in this.node &&
         this.node.clips &&
@@ -904,19 +933,32 @@ export function resolveNodeContextMenu(
   }
   let mediaShareAndExportGroup = {
     group: "shareAndExport",
-    items: [resourceActions.copyLink()]
+    items: [
+      resourceActions.copyLink(),
+      ...(node.url ? [resourceActions.copyExternalLink()] : [])
+    ]
   };
   if (
     [...mediaNodeTypeList, NodeType.WEB_SCREENSHOT].includes(node.contentType)
   ) {
     mediaShareAndExportGroup.items.unshift(nodeActions.download);
   }
+  const isTextBookmarkOrSocialPost =
+    node.contentType === NodeType.WEB_TEXT_BOOKMARK ||
+    node.contentType === NodeType.KINDLE_HIGHLIGHT ||
+    socialPostNodeTypeList.has(node.contentType);
+  if (isTextBookmarkOrSocialPost) {
+    mediaShareAndExportGroup.items.unshift(nodeActions.copyHighlightText);
+  }
   if (
     (accessPoint === ResourceAccessPoint.NODE_LINKS ||
       accessPoint === ResourceAccessPoint.DEFAULT_RIGHT_PANE_LINKS) &&
     params?.accessPointId
   ) {
-    let baseItems = [resourceActions.copyLink()];
+    let baseItems = [
+      resourceActions.copyLink(),
+      ...(node.url ? [resourceActions.copyExternalLink()] : [])
+    ];
     if (accessPoint === ResourceAccessPoint.NODE_LINKS) {
       baseItems.unshift(
         resourceActions.select(accessPoint, params?.accessPointId)
@@ -932,15 +974,19 @@ export function resolveNodeContextMenu(
       },
       ...commonGroups
     ];
-  } else if (accessPoint != ResourceAccessPoint.SELF) {
+  } else if (accessPoint !== ResourceAccessPoint.SELF) {
     let primaryItems = [
       resourceActions.select(accessPoint, params?.accessPointId),
       resourceActions.star(),
       resourceActions.addToCollection(),
       resourceActions.link(),
       resourceActions.edit(accessPoint),
-      resourceActions.copyLink()
+      resourceActions.copyLink(),
+      ...(node.url ? [resourceActions.copyExternalLink()] : [])
     ];
+    if (isTextBookmarkOrSocialPost) {
+      primaryItems.splice(5, 0, nodeActions.copyHighlightText);
+    }
     if (
       accessPoint === ResourceAccessPoint.COLLECTION &&
       params?.accessPointId
@@ -950,7 +996,8 @@ export function resolveNodeContextMenu(
         resourceActions.select(accessPoint, params?.accessPointId),
         resourceActions.star(),
         resourceActions.edit(accessPoint),
-        resourceActions.copyLink()
+        resourceActions.copyLink(),
+        ...(node.url ? [resourceActions.copyExternalLink()] : [])
       ];
     }
     return [
@@ -1047,7 +1094,11 @@ export function resolveNodeContextMenu(
     },
     {
       group: "shareAndExport",
-      items: [resourceActions.copyLink(), resourceActions.copyContents()]
+      items: [
+        resourceActions.copyLink(),
+        ...(node.url ? [resourceActions.copyExternalLink()] : []),
+        resourceActions.copyContents()
+      ]
     },
     ...commonGroups
   ];

--- a/client/products/memotron/node/node.type.ts
+++ b/client/products/memotron/node/node.type.ts
@@ -341,7 +341,7 @@ export enum NodeRightPaneType {
   NONE = "NONE",
   OUTLINE = "OUTLINE",
   PROPERTIES = "PROPERTIES",
-  TRACES = "TRACES",
+  BOOKMARKS = "BOOKMARKS",
   SIDENOTES = "SIDENOTES",
   METADATA = "METADATA",
   LINKS = "LINKS",
@@ -365,9 +365,13 @@ type INodeLinkBase = {
 };
 
 export type INodeLinkThumb = ILinkBase & {
-  id: IRecordId;
   linkedTo: IRecordId;
-  direction: "incoming" | "outgoing";
+  links?: {
+    id: IRecordId;
+    linkType: LinkType;
+    direction: "incoming" | "outgoing";
+    tags?: IRecordId[];
+  }[];
 };
 
 export type LinkThumbnail = ILink & {
@@ -1172,7 +1176,10 @@ export const canHaveTraces = [
 
 export type IVideoBookmarkCapture = INodeHasUrl &
   INodeHasText & {
-    contentType: NodeType.YOUTUBE_BOOKMARK | NodeType.VIDEO_BOOKMARK | NodeType.WEB_VIDEO_BOOKMARK;
+    contentType:
+      | NodeType.YOUTUBE_BOOKMARK
+      | NodeType.VIDEO_BOOKMARK
+      | NodeType.WEB_VIDEO_BOOKMARK;
     body: IVideoBookmarkBody;
     metadata: IVideoBookmarkMetadata;
   };

--- a/client/products/memotron/node/rightPanel/NodeRightPane.svelte
+++ b/client/products/memotron/node/rightPanel/NodeRightPane.svelte
@@ -29,7 +29,7 @@
 
   if (canHaveTraces.includes($node?.contentType ?? NodeType.UNKNOWN)) {
     verticalSwitcherItems.push({
-      value: NodeRightPaneType.TRACES,
+      value: NodeRightPaneType.BOOKMARKS,
       icon: "bookmark"
     });
   }

--- a/client/products/memotron/node/rightPanel/NodeRightPaneContent.svelte
+++ b/client/products/memotron/node/rightPanel/NodeRightPaneContent.svelte
@@ -53,7 +53,7 @@
     <NodeLinksPane {node} />
   {:else if pane === NodeRightPaneType.PROPERTIES}
     <PropertiesPane item={node} resource={Resource.node} />
-  {:else if pane === NodeRightPaneType.TRACES}
+  {:else if pane === NodeRightPaneType.BOOKMARKS}
     <NodeTracesPane {node} />
   {:else if pane === NodeRightPaneType.HISTORY}
     <NodeHistoryPane {node} />

--- a/client/products/memotron/node/rightPanel/RightPaneOverviewMetricCard.svelte
+++ b/client/products/memotron/node/rightPanel/RightPaneOverviewMetricCard.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <button
-  class="flex items-center gap-1 hover:bg-bgs2 border border-transparent hover:border-brs3 rounded-md px-4 py-1 default-typeface"
+  class="flex items-center gap-1 hover:bg-bgs2 rounded-md px-4 h-full default-typeface"
   on:click
 >
   <Icon {icon} size={Size.sm} />

--- a/client/products/memotron/node/rightPanel/WebNodeDefaultRightPane.svelte
+++ b/client/products/memotron/node/rightPanel/WebNodeDefaultRightPane.svelte
@@ -72,9 +72,7 @@
   <Text content="Overview" style={TextStyle.PANEL_HEADING_SMALL} />
 
   {#if canHaveTraces.includes($node.contentType)}
-    <div
-      class="flex flex-row justify-around items-center w-full border border-brs3 rounded-md px-2 py-0.5"
-    >
+    <div class="grid grid-cols-2 w-full border border-brs3 rounded-md h-10">
       <RightPaneOverviewMetricCard
         label="Links"
         icon="link"
@@ -82,10 +80,10 @@
         on:click={() => (pane = NodeRightPaneType.LINKS)}
       />
       <RightPaneOverviewMetricCard
-        label="Clips"
+        label="Bookmarks"
         icon="bookmark"
         value={$node.clips?.length || 0}
-        on:click={() => (pane = NodeRightPaneType.TRACES)}
+        on:click={() => (pane = NodeRightPaneType.BOOKMARKS)}
       />
     </div>
   {/if}
@@ -94,7 +92,7 @@
     <div class="flex flex-col gap-4 items-start w-full h-1/3 min-h-0">
       <span class="flex flex-row justify-between items-center w-full">
         <span class="flex flex-row gap-1 items-center">
-          <Text content="Clips" style={TextStyle.SECTION_HEADING} />
+          <Text content="Bookmarks" style={TextStyle.SECTION_HEADING} />
           <Badge text={$node.clips?.length || 0} size={Size.sm} />
         </span>
         {#if $node.clips?.length > 2}
@@ -104,7 +102,7 @@
               icon="proceed"
               label="View all"
               style={ButtonStyle.PLAIN}
-              on:click={() => (pane = NodeRightPaneType.TRACES)}
+              on:click={() => (pane = NodeRightPaneType.BOOKMARKS)}
             />
           </span>
         {/if}
@@ -115,10 +113,8 @@
           accessPoint={ResourceAccessPoint.NODE_TRACES}
           resource={Resource.node}
           size={Size.sm}
-          isPreventDefault={
-            $node.contentType === NodeType.YOUTUBE_VIDEO ||
-            $node.contentType === NodeType.YOUTUBE_SHORT
-          }
+          isPreventDefault={$node.contentType === NodeType.YOUTUBE_VIDEO ||
+            $node.contentType === NodeType.YOUTUBE_SHORT}
           on:click={(e) => {
             if (
               $node.contentType !== NodeType.YOUTUBE_VIDEO &&

--- a/client/products/memotron/node/thumbnail/NodeThumbnail.svelte
+++ b/client/products/memotron/node/thumbnail/NodeThumbnail.svelte
@@ -71,7 +71,8 @@
   $: isFullExpand =
     isTextClip ||
     socialPostNodeTypeList.has(item.contentType) ||
-    accessPoint === ResourceAccessPoint.NODE_TRACES;
+    (accessPoint === ResourceAccessPoint.NODE_TRACES &&
+      item.contentType !== NodeType.YOUTUBE_BOOKMARK);
   $: isShouldContainImage = resolveIfImageShouldContain(item.contentType);
 
   $: isLinkContext =
@@ -132,17 +133,18 @@
           !isApplyCustomColor,
         "bg-bgs2 px-2":
           !isApplyCustomColor &&
-          (accessPoint === ResourceAccessPoint.LIBRARY ||
-            accessPoint === ResourceAccessPoint.NODE_LINKS ||
-            accessPoint === ResourceAccessPoint.DEFAULT_RIGHT_PANE_LINKS),
-        "p-2": isLinkContext
+          (accessPoint === ResourceAccessPoint.LIBRARY || isLinkContext),
+        "pb-2": isLinkContext,
+        "pt-2": isLinkContext && (isFullExpand || filePreview || urlPreview)
       })}
     >
       <button
         class={cn(
           "flex w-full items-center border- rounded--md truncate",
           !isFullExpand && {
-            "h-16": !visibleProps || visibleProps.length === 0
+            "h-16":
+              (!isLinkContext || isFullExpand) &&
+              (!visibleProps || visibleProps.length === 0)
             // "bg-ccs5 hover:bg-ccs4 border-ccs2": isApplyCustomColor,
             // "bg-bgs2 border-brs3 hover:border-fgs4": !isApplyCustomColor
           }
@@ -208,7 +210,12 @@
                     contentType={item.contentType}
                   />
                 {:else if isTextClip && contentPreview}
-                  <TextClipPreview node={item} {contentPreview} {accessPoint} />
+                  <TextClipPreview
+                    node={item}
+                    {contentPreview}
+                    {accessPoint}
+                    {arrangement}
+                  />
                 {:else if contentPreview}
                   <span class="text-fgs3 userdata">
                     {@html renderMdAsHtml(contentPreview)}
@@ -233,14 +240,16 @@
                 {accessPoint}
               />
             {/key}
-            <div class="text-b4 text-fgs3 default-typeface">
-              {#if accessPoint === ResourceAccessPoint.CALENDAR}
-                {formatTime($userPreferences, item.createdAt)}
-              {:else}
-                {formatDatetime($userPreferences, item.createdAt)}
-              {/if}
-            </div>
-            {#if visibleProps.length > 0}
+            {#if !isLinkContext}
+              <div class="text-b4 text-fgs3 default-typeface">
+                {#if accessPoint === ResourceAccessPoint.CALENDAR}
+                  {formatTime($userPreferences, item.createdAt)}
+                {:else}
+                  {formatDatetime($userPreferences, item.createdAt)}
+                {/if}
+              </div>
+            {/if}
+            {#if visibleProps.length > 0 && !isLinkContext}
               <div class="py-1">
                 <NodeThumbnailProperties
                   values={item.properties}
@@ -306,7 +315,12 @@
           {:else}
             <div class="h-full overflow-clip text-b2">
               {#if isTextClip && contentPreview}
-                <TextClipPreview node={item} {contentPreview} {accessPoint} />
+                <TextClipPreview
+                  node={item}
+                  {contentPreview}
+                  {accessPoint}
+                  {arrangement}
+                />
               {:else if item.contentType === NodeType.AUDIO && _url}
                 <NodeThumbnailAudioPreview url={_url} />
               {:else if contentPreview}
@@ -388,7 +402,12 @@
         class="h-auto p-2 overflow-clip text-wrap max-h-48 text-left text-b3"
       >
         {#if isTextClip}
-          <TextClipPreview node={item} {contentPreview} {accessPoint} />
+          <TextClipPreview
+            node={item}
+            {contentPreview}
+            {accessPoint}
+            {arrangement}
+          />
         {:else if socialPostNodeTypeList.has(item.contentType)}
           <span class="text-fgs3">
             <NodeThumbnailSocialPostPreview

--- a/client/products/memotron/node/traces/NodeTracesPane.svelte
+++ b/client/products/memotron/node/traces/NodeTracesPane.svelte
@@ -20,12 +20,24 @@
   import ScrollViewBottomSpacer from "$lib/client/layout/scrollView/ScrollViewBottomSpacer.svelte";
   import NodeTasksPane from "./NodeTasksPane.svelte";
   import { resolveNodeIcon } from "../node.utils";
+  import { preferences } from "$lib/client/stores/preferences/preferences.store";
+  import { Preference } from "$lib/client/stores/preferences/preferences.type";
+  import { appStore } from "$lib/client/stores/app.store";
+  import { derived } from "svelte/store";
   const contentContext = getContext<any>("content");
 
   export let node: IActiveNodeStore | null = null;
   $: pdfAnnotations = $node?.pdfAnnotations ?? [];
   let options = resolveOptions($node?.contentType);
   let selectedType: string | undefined = undefined;
+
+  const hideHighlightColors = derived(
+    [preferences, appStore],
+    ([$preferences, $appStore]) => {
+      const key = `${$appStore.product}-${Preference.HIDE_HIGHLIGHT_COLORS}`;
+      return ($preferences[key] as boolean) ?? false;
+    }
+  );
 
   function resolveOptions(contentType: NodeType | undefined) {
     const tasks = {
@@ -39,20 +51,15 @@
       icon: "chat-two"
     };
 
-    if (contentType === NodeType.PDF) {
+    if (
+      contentType === NodeType.PDF ||
+      contentType === NodeType.WEB_PAGE ||
+      contentType === NodeType.KINDLE_BOOK
+    ) {
       return [
         {
           value: "clips",
-          label: "Highlights",
-          icon: "bookmark"
-        }
-        // tasks
-      ];
-    } else if (contentType === NodeType.WEB_PAGE) {
-      return [
-        {
-          value: "clips",
-          label: "Clips",
+          label: "Bookmarks",
           icon: "bookmark"
         }
         // tasks
@@ -73,17 +80,8 @@
       return [
         {
           value: "clips",
-          label: "Clips",
+          label: "Bookmarks",
           icon: "youtube"
-        }
-        // tasks
-      ];
-    } else if (contentType === NodeType.KINDLE_BOOK) {
-      return [
-        {
-          value: "clips",
-          label: "Highlights",
-          icon: "bookmark"
         }
         // tasks
       ];
@@ -93,7 +91,7 @@
   }
 </script>
 
-{#if options}
+{#if options && options.length > 1}
   <OptionSelector {options} size={Size.sm} bind:selected={selectedType} />
 {/if}
 
@@ -154,16 +152,19 @@
               </div>
             </div>
           {:else}
-            {@const color = highlightStore.resolveColor(trace.color)}
+            {@const color = $hideHighlightColors
+              ? undefined
+              : highlightStore.resolveColor(trace.color)}
             <div
               class="w-full min-h-fit p-2 rounded-md text-fgs2"
-              style="text-decoration: 2px {trace.annotType?.toLowerCase()} {trace.annotType !==
-              AnnotationType.HIGHLIGHT
+              style="text-decoration: 2px {trace.annotType?.toLowerCase()} {!$hideHighlightColors &&
+              trace.annotType !== AnnotationType.HIGHLIGHT
                 ? color
                 : ''}; "
             >
               <span
-                style={trace.annotType === AnnotationType.HIGHLIGHT
+                style={!$hideHighlightColors &&
+                trace.annotType === AnnotationType.HIGHLIGHT
                   ? `background-color: ${hexToRGBA(color, 0.2)};`
                   : ""}
               >
@@ -196,7 +197,7 @@
       />
     {/if}
   </div>
-{:else if canHaveTraces.includes($node?.contentType ?? NodeType.UNKNOWN) && selectedType === "clips"}
+{:else if canHaveTraces.includes($node?.contentType ?? NodeType.UNKNOWN) && (selectedType === "clips" || !selectedType)}
   {#if $node?.clips && $node?.clips?.length > 0}
     <div class="h-full w-full overflow-y-auto">
       <Resources
@@ -204,10 +205,8 @@
         accessPoint={ResourceAccessPoint.NODE_TRACES}
         resource={Resource.node}
         size={Size.sm}
-        isPreventDefault={
-          $node.contentType === NodeType.YOUTUBE_VIDEO ||
-          $node.contentType === NodeType.YOUTUBE_SHORT
-        }
+        isPreventDefault={$node.contentType === NodeType.YOUTUBE_VIDEO ||
+          $node.contentType === NodeType.YOUTUBE_SHORT}
         on:click={(e) => {
           if (!e?.detail) return;
           if (
@@ -225,8 +224,8 @@
     </div>
   {:else}
     <EmptyStatusView
-      mainText="No clips found"
-      subText="This page doesn't have any clips yet"
+      mainText="No bookmarks found"
+      subText="This page doesn't have any bookmarks yet"
     />
   {/if}
 {:else if selectedType === "tasks"}
@@ -237,5 +236,5 @@
     subText="Commenting will be available soon"
   />
 {:else}
-  <EmptyStatusView size={Size.sm} mainText="No traces found" />
+  <EmptyStatusView size={Size.sm} mainText="No bookmarks found" />
 {/if}

--- a/client/products/memotron/pdfAnnotator/PdfViewer.svelte
+++ b/client/products/memotron/pdfAnnotator/PdfViewer.svelte
@@ -14,6 +14,7 @@
   import { generateSimpleRandomId } from "$lib/shared/utils/crypto.utils";
   import { fileEmbedChannel } from "$lib/client/components/files/fileEmbedChannel.store";
   import { OperatingSystem } from "$lib/client/types/context.type";
+  import { pdfCache } from "$lib/client/utils/pdfCache.utils";
 
   // pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorker;
   // pdfjs.GlobalWorkerOptions.workerSrc =
@@ -64,6 +65,8 @@
   let load_error_messge: string | null = null;
   let _prev_gap_top = "8px";
   let _prev_gap_bottom = "8px";
+  let loadingProgress = 0;
+  let isLoading = false;
 
   //Init button handlers (some require hydration on mount)
   let onPasswordSubmit: () => void;
@@ -155,19 +158,66 @@
     );
 
     const { pdf_viewer, pdf_link_service } = await init_promise;
-    // Loading document.
     try {
       if (isDataViaEmbed) {
         if (!dataViaEmbed) return;
         pdfData = fileEmbedChannel.base64ToUint8Array(dataViaEmbed);
       } else {
-        const arrayBuffer = await fetch(url.toString()).then((response) =>
-          response.arrayBuffer()
-        );
-        pdfData = new Uint8Array(arrayBuffer);
+        const cachedData = await pdfCache.get(url.toString());
+        
+        if (cachedData) {
+          pdfData = cachedData;
+        } else {
+          isLoading = true;
+          loadingProgress = 0;
+          const response = await fetch(url.toString());
+          if (!response.ok) {
+            throw new Error(
+              `Failed to fetch PDF: ${response.status} ${response.statusText}`
+            );
+          }
+          const ct = response.headers.get("content-type") || "";
+          if (!ct.toLowerCase().includes("application/pdf")) {
+            throw new Error("Fetched content is not a PDF");
+          }
+
+          const contentLength = response.headers.get("content-length");
+          if (contentLength && response.body) {
+            const total = parseInt(contentLength, 10);
+            let loaded = 0;
+            const reader = response.body.getReader();
+            const chunks: Uint8Array[] = [];
+
+            while (true) {
+              const { done, value } = await reader.read();
+
+              if (done) break;
+
+              chunks.push(value);
+              loaded += value.length;
+              loadingProgress = Math.round((loaded / total) * 100);
+            }
+
+            const allChunks = new Uint8Array(loaded);
+            let position = 0;
+            for (const chunk of chunks) {
+              allChunks.set(chunk, position);
+              position += chunk.length;
+            }
+
+            pdfData = allChunks;
+          } else {
+            const arrayBuffer = await response.arrayBuffer();
+            pdfData = new Uint8Array(arrayBuffer);
+          }
+
+          await pdfCache.set(url.toString(), pdfData);
+          isLoading = false;
+        }
       }
     } catch (error) {
       console.error("Error loading PDF:", error);
+      isLoading = false;
       load_error_messge = "Error loading PDF. Please try again.";
       return;
     }
@@ -190,8 +240,12 @@
         });
       })
       .catch(function (error) {
-        password_error = true;
-        load_error_messge = error.message;
+        const name = (error && (error.name || error.toString())) || "";
+        const message =
+          error && error.message ? error.message : String(error || "");
+        const isPwd = typeof name === "string" && name.includes("Password");
+        password_error = isPwd;
+        load_error_messge = message;
       });
 
     onZoomIn = () => {
@@ -257,7 +311,7 @@
         {/if}
         <p>{load_error_messge}</p>
       </div>
-    {:else}<!-- svelte-ignore a11y-click-events-have-key-events -->
+    {:else}
       <!-- <div class="spdfbanner">
         <span class="toolbarbutton" on:click={onZoomIn}>
           <img
@@ -305,6 +359,14 @@
         </span>
       </div> -->
       <!-- <div class="spdfinner"> -->
+      {#if isLoading}
+        <div
+          class="bg-bgs1 absolute inset-0 z-50 flex flex-col items-center justify-center w-full h-full gap-4"
+        >
+          <div class="text-fg1 text-sm">Loading PDF...</div>
+          <div class="text-fg2 text-xs">{loadingProgress}%</div>
+        </div>
+      {/if}
       <div id="viewerContainer" bind:this={container}>
         <div id="viewer" class="pdfViewer" />
         <!-- <slot /> -->

--- a/client/products/product.config.ts
+++ b/client/products/product.config.ts
@@ -151,6 +151,7 @@ export const products: Record<Product, IAppConfigBase> = {
           Action.APPEARANCE_SETTINGS,
           "analytics-settings",
           "session-settings",
+          MemotronAction.NODE_SETTINGS,
           Action.DATETIME_SETTINGS,
           Action.SHORTCUTS,
           Action.ACCESSIBILITY
@@ -214,6 +215,7 @@ export const products: Record<Product, IAppConfigBase> = {
         children: [
           Action.MODE_OF_INTERACTION,
           Action.APPEARANCE_SETTINGS,
+          MemotronAction.NODE_SETTINGS,
           Action.DATETIME_SETTINGS,
           Action.SHORTCUTS,
           Action.ACCESSIBILITY

--- a/client/static/assets-manifest.json
+++ b/client/static/assets-manifest.json
@@ -4,7 +4,7 @@
   "assets": {
     ".turbo/turbo-build.log": {
       "size": 0,
-      "modified": "2025-10-11T16:41:59.664Z"
+      "modified": "2025-10-12T17:16:50.126Z"
     },
     "README.md": {
       "size": 2095,
@@ -99,5 +99,5 @@
       "modified": "2025-10-09T09:34:35.538Z"
     }
   },
-  "timestamp": "2025-10-11T16:41:59.965Z"
+  "timestamp": "2025-10-12T17:16:50.355Z"
 }

--- a/client/stores/account.store.ts
+++ b/client/stores/account.store.ts
@@ -445,7 +445,7 @@ class AccountStore extends ObservableStore<UserAccount> {
       logger.log({ at: "uploadFileV2", id, contentType, fileName });
       fileName = fileName
         .replace(/\s+/g, "_")
-        .replace(/[()@#$%&*!?<>{}[\]\\\/\^~`+=;:]/g, "_");
+        .replace(/[()@#$%&*!?<>{}[\]\\\/\^~`+=;:,'"|]/g, "_");
 
       // Convert HEIC files to PNG
       const isHeicFile = fileName.toLowerCase().endsWith(".heic");

--- a/client/stores/preferences/preferences.type.ts
+++ b/client/stores/preferences/preferences.type.ts
@@ -9,6 +9,7 @@ export interface IPreferencesStore {
   [Preference.IMPORT_HISTORY]?: ImportHistoryItem[];
   [Preference.CALENDAR_TILE_INDICATORS_MONTH]?: boolean;
   [Preference.CALENDAR_TILE_INDICATORS_YEAR]?: boolean;
+  [Preference.HIDE_HIGHLIGHT_COLORS]?: boolean;
   [key: string]: unknown;
 }
 
@@ -20,7 +21,8 @@ export enum Preference {
   NOTES_TEMPLATE = "notesTemplate",
   IMPORT_HISTORY = "importHistory",
   CALENDAR_TILE_INDICATORS_MONTH = "calendarTileIndicatorsMonth",
-  CALENDAR_TILE_INDICATORS_YEAR = "calendarTileIndicatorsYear"
+  CALENDAR_TILE_INDICATORS_YEAR = "calendarTileIndicatorsYear",
+  HIDE_HIGHLIGHT_COLORS = "hideHighlightColors"
 }
 
 export enum PreferencesScope {

--- a/client/utils/pdfCache.utils.ts
+++ b/client/utils/pdfCache.utils.ts
@@ -1,0 +1,232 @@
+import { logger } from "$lib/client/components/debug/logger.client";
+
+const CACHE_NAME = "pdf-cache-v1";
+const CACHE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface ICacheMetadata {
+  timestamp: number;
+  size: number;
+}
+
+class PdfCache {
+  private isSupported: boolean;
+
+  constructor() {
+    this.isSupported = typeof caches !== "undefined";
+    if (!this.isSupported) {
+      logger.warn({
+        at: "PdfCache.constructor",
+        message: "Cache API not supported in this browser"
+      });
+    }
+  }
+
+  private getCacheKey(url: string): Request {
+    return new Request(url, { method: "GET" });
+  }
+
+  private getMetadataKey(url: string): Request {
+    const metadataUrl = new URL(url);
+    metadataUrl.searchParams.set('_cache_metadata', 'true');
+    return new Request(metadataUrl.toString(), { method: "GET" });
+  }
+
+  private async getMetadata(url: string): Promise<ICacheMetadata | null> {
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const response = await cache.match(this.getMetadataKey(url));
+      
+      if (!response) return null;
+      
+      return await response.json();
+    } catch (error) {
+      logger.error({ at: "PdfCache.getMetadata", error });
+      return null;
+    }
+  }
+
+  private async setMetadata(url: string, metadata: ICacheMetadata): Promise<void> {
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const response = new Response(JSON.stringify(metadata), {
+        headers: { "Content-Type": "application/json" }
+      });
+      
+      await cache.put(this.getMetadataKey(url), response);
+    } catch (error) {
+      logger.error({ at: "PdfCache.setMetadata", error });
+    }
+  }
+
+  async get(url: string): Promise<Uint8Array | null> {
+    if (!this.isSupported) return null;
+
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const cacheKey = this.getCacheKey(url);
+      const response = await cache.match(cacheKey);
+
+      if (!response) {
+        logger.log({ at: "PdfCache.get", message: "Cache miss", url });
+        return null;
+      }
+
+      const metadata = await this.getMetadata(url);
+      if (metadata) {
+        const age = Date.now() - metadata.timestamp;
+        if (age > CACHE_EXPIRY_MS) {
+          logger.log({ at: "PdfCache.get", message: "Cache expired", url, age });
+          await this.delete(url);
+          return null;
+        }
+
+        logger.log({
+          at: "PdfCache.get",
+          message: "Cache hit",
+          url,
+          size: metadata.size,
+          age: Math.round(age / 1000 / 60) + " minutes"
+        });
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    } catch (error) {
+      logger.error({ at: "PdfCache.get", error, url });
+      return null;
+    }
+  }
+
+  async set(url: string, data: Uint8Array): Promise<void> {
+    if (!this.isSupported) return;
+
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const cacheKey = this.getCacheKey(url);
+      
+      const response = new Response(data, {
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Length": data.length.toString()
+        }
+      });
+
+      await cache.put(cacheKey, response);
+      
+      await this.setMetadata(url, {
+        timestamp: Date.now(),
+        size: data.length
+      });
+
+      logger.log({
+        at: "PdfCache.set",
+        message: "PDF cached",
+        url,
+        size: data.length
+      });
+
+      await this.cleanupOldEntries();
+    } catch (error) {
+      logger.error({ at: "PdfCache.set", error, url });
+    }
+  }
+
+  async delete(url: string): Promise<void> {
+    if (!this.isSupported) return;
+
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      await cache.delete(this.getCacheKey(url));
+      await cache.delete(this.getMetadataKey(url));
+      logger.log({ at: "PdfCache.delete", message: "Cache entry deleted", url });
+    } catch (error) {
+      logger.error({ at: "PdfCache.delete", error, url });
+    }
+  }
+
+  async clear(): Promise<void> {
+    if (!this.isSupported) return;
+
+    try {
+      await caches.delete(CACHE_NAME);
+      logger.info({ at: "PdfCache.clear", message: "All cache entries cleared" });
+    } catch (error) {
+      logger.error({ at: "PdfCache.clear", error });
+    }
+  }
+
+  async getStats(): Promise<{
+    count: number;
+    totalSize: number;
+    oldestEntry: number | null;
+  }> {
+    if (!this.isSupported) {
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const requests = await cache.keys();
+
+      const pdfRequests = requests.filter(req => 
+        !req.url.includes('_cache_metadata=true')
+      );
+
+      let totalSize = 0;
+      let oldestTimestamp: number | null = null;
+
+      for (const req of pdfRequests) {
+        const metadata = await this.getMetadata(req.url);
+        
+        if (metadata) {
+          totalSize += metadata.size;
+          if (!oldestTimestamp || metadata.timestamp < oldestTimestamp) {
+            oldestTimestamp = metadata.timestamp;
+          }
+        }
+      }
+
+      return {
+        count: pdfRequests.length,
+        totalSize,
+        oldestEntry: oldestTimestamp
+      };
+    } catch (error) {
+      logger.error({ at: "PdfCache.getStats", error });
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+  }
+
+  private async cleanupOldEntries(): Promise<void> {
+    if (!this.isSupported) return;
+
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const requests = await cache.keys();
+      const now = Date.now();
+      let deletedCount = 0;
+
+      for (const req of requests) {
+        if (!req.url.includes('_cache_metadata=true')) {
+          const metadata = await this.getMetadata(req.url);
+
+          if (metadata && now - metadata.timestamp > CACHE_EXPIRY_MS) {
+            await this.delete(req.url);
+            deletedCount++;
+          }
+        }
+      }
+
+      if (deletedCount > 0) {
+        logger.info({
+          at: "PdfCache.cleanupOldEntries",
+          message: `Cleaned up ${deletedCount} expired entries`
+        });
+      }
+    } catch (error) {
+      logger.error({ at: "PdfCache.cleanupOldEntries", error });
+    }
+  }
+}
+
+export const pdfCache = new PdfCache();


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced PDF caching with progress tracking and metadata management

- Improved link management with multi-link support and type indicators

- Added text content copying for bookmarks and social posts

- Renamed "Clips/Traces" to "Bookmarks" throughout the application

- Added user preference to hide text highlight colors

- Fixed scrollbar styling and user selection behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pdfCache["PDF Cache System"] --> progress["Loading Progress"]
  pdfCache --> metadata["Cache Metadata"]
  links["Link Management"] --> multiLink["Multi-Link Support"]
  links --> indicators["Link Type Indicators"]
  ui["UI Enhancements"] --> bookmarks["Clips → Bookmarks"]
  ui --> copyText["Copy Text Content"]
  ui --> scrollbars["Styled Scrollbars"]
  preferences["User Preferences"] --> hideColors["Hide Highlight Colors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>31 files</summary><table>
<tr>
  <td><strong>pdfCache.utils.ts</strong><dd><code>New PDF caching utility with metadata and expiry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-224bcf025f4062e48b374f34aa420ea0978b100c73bcba1a9b2bbb57ca6f8a85">+232/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PdfViewer.svelte</strong><dd><code>Added loading progress and cache integration for PDFs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-23a5d5d12dd14c334d6c9e09859140768837941e15dc8688460dc490c311f130">+70/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>node.store.ts</strong><dd><code>Refactored link storage to support multiple link types</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-027bd7295d678b58adda6fbb34146d11ee3a124918e5ba2b41c7a4881af2e0ff">+66/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LinkItem.svelte</strong><dd><code>Added link type indicators and improved tag display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-f4f5a6318c0e4892406ab2295dca2656d928e556686846aae47c3c5dcb2cc13d">+38/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LinkTypeIndicator.svelte</strong><dd><code>New component for displaying link type badges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-21ef27c77350a231eb3c30f5e52981a0a825620057772cd434312871f0289133">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeLinksPane.svelte</strong><dd><code>Enhanced link filtering with type and tag support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-bffa4766264927a4e3cb752f24b9b51036933d7595d2a48f66f01725fb45340e">+78/-120</a></td>

</tr>

<tr>
  <td><strong>link.utils.ts</strong><dd><code>Added link type configuration resolver utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-a2f17c3c89e1ad2becb404e6367dcf175ebe5be3914d73e0acc1edf8bd266711">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TextClipPreview.svelte</strong><dd><code>Added copy text button and highlight color preference</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-b306be85c43bf9b940344c7c5ed6cb5a41e1bccddb123a29398bb78ff9bc4a69">+68/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SocialPostContent.svelte</strong><dd><code>Added copy text functionality for social posts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-4e78645914e5c858225e9b6260307a1943ca99a1825acaf58c3943cda56010f6">+27/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeTracesPane.svelte</strong><dd><code>Renamed clips to bookmarks and added color preference</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-85ab8a76d8e7cf81d34b1ce50ad3c4838b83590e3a4feab61e8a73fcedf9d898">+33/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>NodeSettings.svelte</strong><dd><code>New settings component for hiding highlight colors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-547b565fb4ef0cf4ea09d6705aaa80608ad9acfd0d121a223a7352863476925d">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>preferences.type.ts</strong><dd><code>Added hide highlight colors preference type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-ed65b61ccc76e4ebae4794a4634ebae2a78115893b6957ab2632163e90603762">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>node.type.ts</strong><dd><code>Updated link types and renamed traces to bookmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-4c5e1e5aaf85cedac67b6a48bde35ec45c9abb83894ae5b05697ee59027c3461">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.css</strong><dd><code>Added styled scrollbar classes and selectable text utility</code></dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-79ffe9c64c617971af80cdaf7bc01243e7c8632c0e42a973f65791dc808f3f89">+28/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LibraryRecordsPane.svelte</strong><dd><code>Applied styled scrollbar to records container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-d3f3ca9ebd10f6eaf8e0e1103be78b1720632fe6f0bcc6bd7415eeda1188d36b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskLibrary.svelte</strong><dd><code>Applied styled scrollbar to task list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-5ad37c1b52636580d769c96fc9f5a3335d2cc6124a8b22f43d1993c5631361df">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SearchResultsPopover.svelte</strong><dd><code>Applied styled scrollbar to search results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-f49eb477d5ba7b9c2fc86d957c3161e418b14cd1ac14c66d6345941e6cbe4d2d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeThumbnail.svelte</strong><dd><code>Improved text clip preview layout and styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-b773283dec11de3e00da3b65240c28696bfb4ffb79cff97fb10fb88b4919dd50">+36/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>WebNodeDefaultRightPane.svelte</strong><dd><code>Updated clips label to bookmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-cc926c5b63ab6f2386d735d3dcc3adf1eb4583bf78755d1d24002b16e9101e11">+7/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resource.actions.ts</strong><dd><code>Added copy external link action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-dc8f7122463e00ce48a72b1ecfeb1c89799adcc2e6c979097c23476c0c907674">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeGraphUsingG6.svelte</strong><dd><code>Updated combo label colors for better visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-79b130a86fa46557231cdc1f44f0cd3ea9bde76ef591fd6e030e40035c3156e3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TopBarResourceItem.svelte</strong><dd><code>Added context menu actions for tab items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-4cb0e99b24dc090f7ac573f4a7151722ed458c728a5ca4be7d0f72b09467a0ff">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MediaContent.svelte</strong><dd><code>Changed default right pane from traces to bookmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-27e102a36ab22d625ff78673253529d859556a5599a2a934e2d412b6fb21d7d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MediaNodeFloatingBar.svelte</strong><dd><code>Updated action handling for bookmarks pane</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-8e0310050bac2cefea2e45c7f0bb34950138da13aed1a2934bc82b96c7fd96be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeRightPane.svelte</strong><dd><code>Renamed traces to bookmarks in right pane</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-e6ec5d8cd1f7cc083f1ada8c9e6da47849fcf029cb8b6f4537a7e0e6a59dc34d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeRightPaneContent.svelte</strong><dd><code>Updated pane type from traces to bookmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-30812ff5e210d5d8c08f4ce57afb665a7babec234819681a6983f78e9b61795d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RightPaneOverviewMetricCard.svelte</strong><dd><code>Adjusted card styling for better layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-81eae807b27d9ca48944034839d16fa8c258066ed59b2077a14f6af5b1edb3ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ClipsPane.svelte</strong><dd><code>Updated clips terminology to bookmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-3dde9429e316aea28ead6004ca3fa454728875b647daf33f64884db70e3032d7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>memotron.actions.ts</strong><dd><code>Added node settings action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-d5e06474a0970d61664656e40ed1b1b72d937d9e37f8863c9dcfde09050ec2fb">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>memotronAction.enum.ts</strong><dd><code>Added node settings action enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-26d2c0d29c25ccf4ecd81fede898557689971213bbf83629b170b5cce8605fbf">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>product.config.ts</strong><dd><code>Added node settings to settings menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-aaeeadb1844e0d133ff10d7317ac8c92a7d08cbf260ddaac7d847e31cf992e87">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>BaseLayer.svelte</strong><dd><code>Moved user-select CSS to global scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-80156b373b6b3d04540271bb2c8a9ed71dc4ffdfe4b1dc3f1786fcb38d395f81">+8/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LinkTagger.svelte</strong><dd><code>Fixed tag modification for multi-link support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-93767bf9cc3eaad5e07e7a76bb1b031ab69034979fb260cc121e312cfa87d0cd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LinkTags.svelte</strong><dd><code>Updated tag removal for multi-link structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-c9c938e0b16e68bbec5d340b153ac6c60e20b927f5656c4e85cdbade7fa7dd71">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LinkItems.svelte</strong><dd><code>Updated link result structure for node links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-985a77540cb661bed4c23c711e1584a9cd7a8cbd1e6abb6601b1a6700de4112e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account.store.ts</strong><dd><code>Enhanced filename sanitization for file uploads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-0133246180c7fb347066ad5f3b7f49acabbc429f5c785ab5ba3754a455c69079">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodeBirdView.svelte</strong><dd><code>Updated edge ID resolution for multi-link support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-ce284e6fab7577ad1602eeca8e9bf40a839d1792c839e2f7fca3edb582229c9a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LinkThumbnailItems.svelte</strong><dd><code>Changed key from link ID to linkedTo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-c088f1de4dd04307f29b68ad4fdc3afc075ed6a19db2e5aa1a446fe28ed27e8d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>CodeContent.svelte</strong><dd><code>Commented out Monaco editor option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-6e42f60399a9ba44c1d399b1f0eb4fd6785d0cdf11b7bfe52e13bc06566825ed">+5/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>markdown.utils.ts</strong><dd><code>Removed custom inline styling pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-66d6a0843e90b51e056321888ff6fdb34d531f8ef38f0570e3cc36f5810178c1">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Incremented build number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-47aab8931d844baa95318b96022476f62c4f216a151586fbf639bc260c0e07c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Incremented build number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-e0edc99bba388334d54e36ae58be7c73e8b30676cc8e941488a58e9da3ca2633">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Incremented build number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-843cbc90701f03221c165a344c1dcc9cf57eba1776fa8f9e62738b09ce033a76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assets-manifest.json</strong><dd><code>Updated asset manifest timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-69a8958b39d1e362ece6032a327696bf3d28079c239cd802f35a0a2496ed2fed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SocialPostContentFallback.svelte</strong></td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/389/files#diff-1daa5990dd3f76bd562f820533f3d2b43d7946e9c6cb831fea1609dcc999a3a5">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Node Settings modal with option to hide highlight colors.
  - Context menu: Copy source link; Open in Split/Full; Copy highlight/text content.
  - PDF viewer caching with progress overlay and improved error handling.

- Improvements
  - “Clips” renamed to “Bookmarks” across UI; PDF default right pane set to Bookmarks.
  - Enhanced link browsing with type indicators and streamlined filters.
  - Text selection re-enabled; improved scrollbars; broader filename sanitization.

- Chores
  - Build number bumps for multiple apps; assets manifest timestamp updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->