### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ client/cx/contemporaries/glasp-*
 
 # Generated static assets manifest
 client/static/assets-manifest.json
+
+.plasmo

--- a/apps/memotron/package.json
+++ b/apps/memotron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memotron-app",
   "version": "0.62.0",
-  "build": 5,
+  "build": 6,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5002",

--- a/apps/nucleus/package.json
+++ b/apps/nucleus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nucleus-app",
   "version": "0.3.4",
-  "build": 5,
+  "build": 6,
   "private": true,
   "scripts": {
     "dev": "vite dev --port 5050",

--- a/apps/pointron/package.json
+++ b/apps/pointron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pointron-app",
   "version": "0.83.3",
-  "build": 5,
+  "build": 6,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5001",

--- a/client/components/calendar/column/MemotronTempCalendarColumn.svelte
+++ b/client/components/calendar/column/MemotronTempCalendarColumn.svelte
@@ -18,6 +18,7 @@
   import { Size } from "$lib/client/types/size.enum";
   import { debouncer } from "$lib/client/utils/utils";
   import { generateSimpleRandomId } from "$lib/shared/utils/crypto.utils";
+  import { resolveCalendarNotesId } from "../calendar.utils";
 
   export let date: Date;
   export let scale: TimeScaleUnit;
@@ -60,6 +61,12 @@
   };
 
   setContext("calendar-content", calendarContentContext);
+
+  function openNotesInFullScreen() {
+    const id = resolveCalendarNotesId(date, scale);
+    if (!id) return;
+    appStore.openResource(id, ResourceAccessMode.FULL);
+  }
 </script>
 
 <div
@@ -82,15 +89,22 @@
       <span class="text-b2 text-fgs3">| Notes </span>
       <InlineFeedbackText {feedback} size={Size.sm} />
     </div>
-    <Button
-      icon="history"
-      tooltip="History"
-      on:click={() => {
-        appStore.openResource(Action.HISTORY, ResourceAccessMode.POP, {
-          searchParams: { [AppSearchParam.DATE]: date.toISOString() }
-        });
-      }}
-    />
+    <div class="flex items-center">
+      <Button
+        icon="fullscreen"
+        tooltip="Open notes in full screen"
+        on:click={openNotesInFullScreen}
+      />
+      <Button
+        icon="history"
+        tooltip="History"
+        on:click={() => {
+          appStore.openResource(Action.HISTORY, ResourceAccessMode.POP, {
+            searchParams: { [AppSearchParam.DATE]: date.toISOString() }
+          });
+        }}
+      />
+    </div>
   </div>
   <div class="px-1 flex-grow">
     <CalendarNotesPanel {date} {scale} {mdId} />

--- a/client/components/collection/CreateCollection.svelte
+++ b/client/components/collection/CreateCollection.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
-  import Button from "$lib/client/elements/button/Button.svelte";
   import TextInput from "$lib/client/elements/input/TextInput.svelte";
   import OptionSelector from "$lib/client/elements/select/OptionSelector.svelte";
   import Text from "$lib/client/elements/text/Text.svelte";
   import { Orientation } from "$lib/client/types/direction.enum";
   import { Size } from "$lib/client/types/size.enum";
   import { TextStyle } from "$lib/client/types/text.enum";
-  import { collectionLayoutOptions, collectionStore } from "./collection.store";
+  import { collectionStore } from "./collection.store";
   import Toggle from "$lib/client/elements/toggle/Toggle.svelte";
   import { OptionSelectorStyle } from "$lib/client/types/select.type";
-  import InlineInfoBanner from "$lib/client/elements/text/InlineInfoBanner.svelte";
   import FormControlLabel from "$lib/client/elements/text/formLabel/FormControlLabel.svelte";
   import {
     CollectionLayout,
@@ -21,7 +19,6 @@
   import { propertyEditorStore } from "./properties/property.store";
   import { onMount } from "svelte";
   import ModalFooter from "$lib/client/components/modal/ModalFooter.svelte";
-  import { ButtonVariant } from "$lib/client/types/button.type";
   import {
     resolveResourceIcon,
     resourceAction
@@ -31,15 +28,11 @@
     ResourceActionType
   } from "$lib/client/components/flux/resourceStores/resource.type";
   import { logger } from "$lib/client/components/debug/logger.client";
-  import Divider from "$lib/client/elements/Divider.svelte";
   import {
     resolveCollectionResource,
     resolveCollectionTypeIcon,
     resolveCollectionTypeLabel
   } from "./collection.utils";
-  import CoverPicker from "$lib/client/elements/coverPicker/CoverPicker.svelte";
-  import { hoverable } from "$lib/client/actions/hover.action";
-  import CoverRenderer from "$lib/client/elements/coverPicker/CoverRenderer.svelte";
   import TypeExtensionAndPropertiesEditor from "./TypeExtensionAndPropertiesEditor.svelte";
   import { appStore } from "$lib/client/stores/app.store";
   import view from "$lib/client/stores/view.store";
@@ -52,18 +45,17 @@
   let title: string;
   let description: string;
   let isStarred: boolean = false;
-  let selectedType: CollectionType = CollectionType.UNTYPED;
+  let selectedType: CollectionType = CollectionType.TYPED;
   let selectedView: CollectionLayout = CollectionLayout.BOARD;
   let isCaptureShortcutEnabled: boolean = true;
   let properties: IProperty[] = [];
   let avatar: any;
   let coverPhoto: any;
-  let isShowCoverPicker: boolean = false;
-  let isCoverPickerHovered: boolean = false;
   let collectibleResources: Resource[] = resolveCollectionResource(
     $appStore.product
   );
   let resource: Resource = collectibleResources[0];
+  const dev_isShowTypeSelector: boolean = false;
 
   const formLabelConfig = {
     orientation: Orientation.Vertical
@@ -75,10 +67,10 @@
 
   function generateInfo(selectedType: CollectionType) {
     switch (selectedType) {
-      case CollectionType.TYPED:
+      case CollectionType.SYNCED:
         return {
           content:
-            "Use typed collections to store **structured data**. You can define the properties of the data you want to store and customize avatar, content templates etc.",
+            "Use synced collections to sync data from external sources or apps.",
           action: {
             label: "Learn more",
             action: $appStore?.appData?.urls?.kbTypedCollections
@@ -91,14 +83,6 @@
           action: {
             label: "Learn more",
             action: $appStore?.appData?.urls?.kbQueryCollections
-          }
-        };
-      default:
-        return {
-          content: "Use simple collections to store any **unstructured data.**",
-          action: {
-            label: "Learn more",
-            action: $appStore?.appData?.urls?.kbSimpleCollections
           }
         };
     }
@@ -153,86 +137,32 @@
 </script>
 
 <div class="flex w-full h-full items-start">
-  {#if !$view.isConstrainedWidth && !$view.isPortrait}
-    <button
-      class="relative flex flex-col items-center justify-center w-48 h-full"
-      use:hoverable={{
-        onHover: (e) => {
-          isCoverPickerHovered = e;
-        }
-      }}
-      on:click={() => {
-        isShowCoverPicker = true;
-      }}
+  <div
+    class="flex flex-col h-full gap-4 flex-1 items-center justify-between overflow-auto"
+  >
+    <ModalContentPadded
+      class="flex flex-col gap-8 w-full flex-grow overflow-auto mt-4"
     >
-      {#if coverPhoto}
-        {#key coverPhoto}
-          <CoverRenderer cover={coverPhoto} class="rounded-l-md" />
-          {#if isCoverPickerHovered && !isShowCoverPicker}
-            <div
-              class="absolute top-0 left-0 w-full h-full flex flex-col gap-6 items-center justify-center bg-bgs2 bg-opacity-70 rounded-l-md"
-            >
-              <span class="text-fgs1">Click to replace</span>
-              <Button
-                icon="trash"
-                label="Remove"
-                type={ButtonVariant.DANGER}
-                size={Size.sm}
-                on:click={(e) => {
-                  coverPhoto = undefined;
-                  e?.detail?.stopPropagation();
-                }}
-              />
-            </div>
-          {/if}
-        {/key}
-      {:else}
-        <span class="text-fgs3 text-b2"> + add cover photo </span>
-      {/if}
-    </button>
-    <Divider orientation={Orientation.Vertical} />
-  {/if}
-  {#if isShowCoverPicker}
-    <div class="h-full flex-1">
-      <CoverPicker
-        value={coverPhoto}
-        on:close={() => {
-          isShowCoverPicker = false;
-        }}
-        on:change={(e) => {
-          coverPhoto = e.detail;
-        }}
-        on:select={(e) => {
-          coverPhoto = e.detail;
-        }}
-      />
-    </div>
-  {:else}
-    <div
-      class="flex flex-col h-full gap-4 flex-1 items-center justify-between overflow-auto"
-    >
-      <ModalContentPadded
-        class="flex flex-col gap-8 w-full flex-grow overflow-auto mt-4"
-      >
-        <div class="flex items-center justify-between w-full gap-2">
-          <Text content="Create collection" style={TextStyle.PANEL_HEADING} />
-          <span use:tooltip={{ text: "Star collection" }}>
-            <Toggle icon="star" bind:on={isStarred} />
-          </span>
-        </div>
+      <div class="flex items-center justify-between w-full gap-2">
+        <Text content="Create collection" style={TextStyle.PANEL_HEADING} />
+        <span use:tooltip={{ text: "Star collection" }}>
+          <Toggle icon="star" bind:on={isStarred} />
+        </span>
+      </div>
+      {#if dev_isShowTypeSelector}
         <div class="flex flex-col w-full gap-6">
           <OptionSelector
             options={[
-              CollectionType.UNTYPED,
               CollectionType.TYPED,
-              CollectionType.QUERY
+              CollectionType.QUERY,
+              CollectionType.SYNCED
             ].map((type) => ({
               label: resolveCollectionTypeLabel(type),
               value: type,
               icon: resolveCollectionTypeIcon(type),
-              isDisabled: type === CollectionType.QUERY,
-              badge: type === CollectionType.QUERY ? "planned" : undefined,
-              tooltip: generateInfo(type).content
+              isDisabled: type === CollectionType.SYNCED,
+              badge: type === CollectionType.SYNCED ? "planned" : undefined,
+              tooltip: generateInfo(type)?.content
             }))}
             style={$view.isConstrainedWidth
               ? OptionSelectorStyle.OUTLINE
@@ -247,57 +177,59 @@
           />
           <!-- <InlineInfoBanner {...generateInfo(selectedType)} /> -->
         </div>
-        {#if collectibleResources.length > 1}
-          <OptionSelector
-            options={collectibleResources.map((resource) => ({
-              value: resource,
-              label: `${resource}s`,
-              icon: resolveResourceIcon(resource)
-            }))}
-            style={OptionSelectorStyle.CHECK_CIRCLE}
-            size={Size.sm}
-            bind:selected={resource}
-            labelProps={{
-              ...formLabelConfig,
-              label: "Resource to collect"
-            }}
-          />
-        {/if}
-        <div class="flex flex-col gap-2">
-          <FormControlLabel
-            props={{
-              label:
-                selectedType === CollectionType.TYPED
-                  ? "Avatar and title"
-                  : "Title"
-            }}
-          />
-          <div class="flex gap-2">
-            {#if selectedType === CollectionType.TYPED}
-              <span class="w-12 h-full">
-                <Avatar bind:avatar isInEditMode={true} />
-              </span>
-            {/if}
-            <TextInput
-              bind:value={title}
-              width="grow"
-              placeholder="Name of the collection"
-            />
-          </div>
-        </div>
-        <TextArea
-          bind:value={description}
-          placeholder="Description (Optional)"
-          rows={3}
-          label={{ label: "Description", orientation: Orientation.Vertical }}
+      {/if}
+
+      {#if collectibleResources.length > 1}
+        <OptionSelector
+          options={collectibleResources.map((resource) => ({
+            value: resource,
+            label: `${resource}s`,
+            icon: resolveResourceIcon(resource)
+          }))}
+          style={OptionSelectorStyle.CHECK_CIRCLE}
+          size={Size.sm}
+          bind:selected={resource}
+          labelProps={{
+            ...formLabelConfig,
+            label: "Resource to collect"
+          }}
         />
-        {#if selectedType === CollectionType.TYPED}
-          <TypeExtensionAndPropertiesEditor
-            bind:isCaptureShortcutEnabled
-            {resource}
+      {/if}
+      <div class="flex flex-col gap-2">
+        <FormControlLabel
+          props={{
+            label:
+              selectedType === CollectionType.TYPED
+                ? "Avatar and title"
+                : "Title"
+          }}
+        />
+        <div class="flex gap-2">
+          {#if selectedType === CollectionType.TYPED}
+            <span class="w-12 h-full">
+              <Avatar bind:avatar isInEditMode={true} />
+            </span>
+          {/if}
+          <TextInput
+            bind:value={title}
+            width="grow"
+            placeholder="Name of the collection"
           />
-        {/if}
-        <!-- <OptionSelector
+        </div>
+      </div>
+      <TextArea
+        bind:value={description}
+        placeholder="Description (Optional)"
+        rows={3}
+        label={{ label: "Description", orientation: Orientation.Vertical }}
+      />
+      {#if selectedType === CollectionType.TYPED}
+        <TypeExtensionAndPropertiesEditor
+          bind:isCaptureShortcutEnabled
+          {resource}
+        />
+      {/if}
+      <!-- <OptionSelector
           options={collectionLayoutOptions}
           iconOrientation={Orientation.Vertical}
           size={$view.isConstrainedWidth ? Size.sm : Size.md}
@@ -312,17 +244,16 @@
           }}
           bind:selected={selectedView}
         /> -->
-      </ModalContentPadded>
-      <ModalFooter
-        action={resourceAction(Resource.collection, ResourceActionType.CREATE)}
-        primaryAction={{
-          label: "Save",
-          callback: onSave
-        }}
-        secondaryAction={{
-          label: "Discard"
-        }}
-      />
-    </div>
-  {/if}
+    </ModalContentPadded>
+    <ModalFooter
+      action={resourceAction(Resource.collection, ResourceActionType.CREATE)}
+      primaryAction={{
+        label: "Save",
+        callback: onSave
+      }}
+      secondaryAction={{
+        label: "Discard"
+      }}
+    />
+  </div>
 </div>

--- a/client/components/collection/collection.store.ts
+++ b/client/components/collection/collection.store.ts
@@ -62,7 +62,7 @@ import { UIState } from "$lib/client/stores/uiState/uiState.type";
 import view from "$lib/client/stores/view.store";
 
 const defaults: Partial<ICollection> = {
-  type: CollectionType.UNTYPED,
+  type: CollectionType.TYPED,
   typeToExtend: "",
   resource: Resource.node
 };
@@ -265,7 +265,6 @@ class CollectionStore extends ResourceStore<ICollection, ICollectionCapture> {
   > {
     const data = await this.selectMany({
       filters: {
-        type: CollectionType.TYPED,
         isCaptureShortcutEnabled: true
       }
     });
@@ -658,20 +657,6 @@ export function resolveCollectionContextMenu(
           //   callback: async () => {}
           // },
           resourceActions.copyLink(),
-          {
-            value: "convert",
-            icon: "convert",
-            label: "Convert as Simple",
-            callback: async () => {
-              const result = await collectionStore.modify(collection.id, {
-                type: CollectionType.UNTYPED
-              });
-              if (result) {
-                toasts.success("Collection converted to simple");
-              }
-              return result;
-            }
-          },
           ...(!collection.resource || collection.resource === Resource.node
             ? [captureToggle]
             : []),

--- a/client/components/collection/collection.type.ts
+++ b/client/components/collection/collection.type.ts
@@ -16,9 +16,16 @@ import type { Resource } from "../flux/resourceStores/resource.enum";
 import type { IGoalThumb } from "../goals/goal.type";
 
 export enum CollectionType {
+  /**
+   * All collection will have the ability for properties, templates etc. Therefore the older version "TYPED" collection is deprecated and is now "DEFAULT"
+   */
   TYPED = "TYPED",
+  /**
+   * @deprecated
+   */
   UNTYPED = "UNTYPED",
-  QUERY = "QUERY"
+  QUERY = "QUERY",
+  SYNCED = "SYNCED"
 }
 
 export enum CollectionLayout {

--- a/client/components/collection/collection.utils.ts
+++ b/client/components/collection/collection.utils.ts
@@ -30,6 +30,8 @@ export function resolveCollectionTypeIcon(type: CollectionType) {
       return "cube";
     case CollectionType.QUERY:
       return "ph:database-light";
+    case CollectionType.SYNCED:
+      return "sync";
   }
 }
 
@@ -41,6 +43,8 @@ export function resolveCollectionTypeLabel(type: CollectionType) {
       return "Typed";
     case CollectionType.QUERY:
       return "Query";
+    case CollectionType.SYNCED:
+      return "Synced";
   }
 }
 

--- a/client/components/collection/properties/PropertiesEditor.svelte
+++ b/client/components/collection/properties/PropertiesEditor.svelte
@@ -297,10 +297,10 @@
       <div class="flex flex-col items-start w-full gap-3">
         <SwitchInput
           label={{
-            label: "Extend an existing Type collection",
+            label: "Extend an existing collection",
             orientation: Orientation.Horizontal,
             tooltip: {
-              body: "You can extend an existing type by adding additional properties on top. Editing the properties on base type will reflect in all extended types.",
+              body: "You can extend an existing collection by adding additional properties on top. Editing the properties on base collection will reflect in all extended collections.",
               actionText: "Learn more about advanced filter query",
               action: "/kb/advanced-filter-query"
             }

--- a/client/components/goals/Goal.svelte
+++ b/client/components/goals/Goal.svelte
@@ -40,6 +40,7 @@
   let containerWidth = 0;
   let goal: IActiveGoalStore = ActiveGoalStore.resolve(id);
   let isReady = false;
+  const dev_isEnableLinks = false;
   $: isActiveResource =
     !$goal?.isArchived && !$goal?.trashInformation && !$goal?.isParentInactive;
   $: isConstrainedWidth =
@@ -138,7 +139,7 @@
         icon: "shapes"
       });
     }
-    if ($appStore.product === Product.NUCLEUS) {
+    if ($appStore.product === Product.NUCLEUS && dev_isEnableLinks) {
       items.push({
         label: "Links",
         value: "links",

--- a/client/components/markdown/content/TextContent.svelte
+++ b/client/components/markdown/content/TextContent.svelte
@@ -342,13 +342,10 @@
     type: "keyup" | "keydown" = "keydown"
   ) {
     if (!$mdStore.params?.canUseSlashShortcut) return false;
-    
+
     const hasColon = text.includes(":");
-    
-    if (
-      type === "keydown" &&
-      event.key === ":"
-    ) {
+
+    if (type === "keydown" && event.key === ":") {
       logger.log({
         at: "handleEmojiShortcut - triggered",
         key: event.key
@@ -356,10 +353,7 @@
       return true;
     } else if (!hasColon && !isRenderEmojiPicker) {
       return false;
-    } else if (
-      type === "keyup" &&
-      (event.key === "Escape" || !hasColon)
-    ) {
+    } else if (type === "keyup" && (event.key === "Escape" || !hasColon)) {
       if (isRenderEmojiPicker) {
         hidePopover("emojiPicker");
       }
@@ -369,8 +363,9 @@
         // Extract query from colon until next space or end of text
         const afterColon = text.substring(colonIndex + 1);
         const spaceIndex = afterColon.search(/\s/);
-        emojiSearchQuery = spaceIndex === -1 ? afterColon : afterColon.substring(0, spaceIndex);
-        
+        emojiSearchQuery =
+          spaceIndex === -1 ? afterColon : afterColon.substring(0, spaceIndex);
+
         if (emojiSearchQuery.trim()) {
           if (!isRenderEmojiPicker) {
             showPopover("emojiPicker");
@@ -381,7 +376,7 @@
           }
         }
       }
-    }else if (
+    } else if (
       type === "keydown" &&
       isRenderEmojiPicker &&
       (event.key === "ArrowDown" ||
@@ -855,13 +850,17 @@
   options={{
     isPlaceAtCaret: $view.isConstrainedWidth ? false : true,
     offsetInPx: 10,
-    id: isRenderEmojiPicker ? "emojiPickerPopover" : (isRenderMentionSearch ? "mentionSearchPopover" : "blockBrowserPopover"),
+    id: isRenderEmojiPicker
+      ? "emojiPickerPopover"
+      : isRenderMentionSearch
+        ? "mentionSearchPopover"
+        : "blockBrowserPopover",
     class: cn({
       "w-72": blockSearchQuery,
       "w-[30rem]": !blockSearchQuery
     })
   }}
-  triggerClass="w-full"
+  triggerClass="w-full cursor-text"
   isPreventDefault={true}
 >
   <div class="relative w-full flex justify-start">

--- a/client/layout/paint/Panel.svelte
+++ b/client/layout/paint/Panel.svelte
@@ -47,6 +47,8 @@
   onMount(() => {
     const unsubscribe = appEvents.subscribe((e) => {
       if (e.event === GlobalEvent.APP_MENU_SWITCHED) {
+        const currentPath = window?.location?.pathname?.replace("/", "");
+        if (currentPath !== e.value) return;
         isCollapsed = !isCollapsed;
         isExplicitlyCollapsed = false;
       }

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -97,7 +97,7 @@
     {#if pinnedItems.length === 0 && !isInterimTab}
       <div class="flex items-center justify-center">
         <button
-          class="flex items-center justify-between w-96 bg-bgs3 hover:bg-bgs4 rounded-md px-3 py-1 mx-3 text-b2 text-fgs2"
+          class="flex items-center justify-between w-96 h-full border-x border-brs3 hover:bg-bgs3 px-3 mx-3 text-b2 text-fgs2"
           transition:fly={{
             duration: 300,
             x: 40

--- a/client/products/memotron/capture/EditCaptureShortcuts.svelte
+++ b/client/products/memotron/capture/EditCaptureShortcuts.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { collectionStore } from "$lib/client/components/collection/collection.store";
-  import { CollectionType } from "$lib/client/components/collection/collection.type";
   import { Resource } from "$lib/client/components/flux/resourceStores/resource.enum";
   import type { ICollectionThumb } from "$lib/client/components/collection/collection.type";
   import EmptyStatusView from "$lib/client/elements/feedback/EmptyStatusView.svelte";
@@ -8,23 +7,18 @@
   import { appStore } from "$lib/client/stores/app.store";
   import { resourceAction } from "$lib/client/components/flux/resourceStores/resource.utils";
   import { ResourceActionType } from "$lib/client/components/flux/resourceStores/resource.type";
-  import Button from "$lib/client/elements/button/Button.svelte";
-  import modalEvent from "$lib/client/components/modal/modal.store";
-  import { MemotronAction } from "../memotronAction.enum";
   import ScrollViewBottomSpacer from "$lib/client/layout/scrollView/ScrollViewBottomSpacer.svelte";
-  import { ButtonStyle } from "$lib/client/types/button.type";
-  import view from "$lib/client/stores/view.store";
-  import { resolveProductConfig } from "../../product.config";
   import CollectionThumbnailLabel from "$lib/client/components/collection/thumbnail/CollectionThumbnailLabel.svelte";
-  import { AppSearchParam } from "$lib/client/types/appStore.type";
+  import InlineSearchBar from "$lib/client/elements/InlineSearchBar.svelte";
+  import { InputStyle } from "$lib/client/types/input.type";
 
   let collections: ICollectionThumb[] = [];
-
+  let filteredCollections: ICollectionThumb[] = [];
+  let query: string = "";
   async function loadCollections() {
     const data = await collectionStore.selectMany(
       {
         filters: {
-          type: CollectionType.TYPED,
           resource: Resource.node
         }
       },
@@ -33,6 +27,7 @@
       }
     );
     collections = data || [];
+    filteredCollections = collections;
   }
 
   async function toggleShortcut(collectionId: string, isEnabled: boolean) {
@@ -45,8 +40,25 @@
           ? { ...collection, isCaptureShortcutEnabled: isEnabled }
           : collection
       );
+      filteredCollections = filteredCollections.map((collection) =>
+        collection.id === collectionId
+          ? { ...collection, isCaptureShortcutEnabled: isEnabled }
+          : collection
+      );
     } catch (error) {
       console.error("Error updating capture shortcut:", error);
+    }
+  }
+
+  function onSearch(event: CustomEvent<string>) {
+    query = event.detail;
+    if (query) {
+      filteredCollections = collections.filter(
+        (collection) =>
+          collection.label?.toLowerCase().includes(query.toLowerCase()) ?? false
+      );
+    } else {
+      filteredCollections = collections;
     }
   }
 </script>
@@ -58,13 +70,13 @@
     </div>
   {:then}
     <div class="text-b2 text-fgs3">
-      Enable typed collections to appear as quick capture options in the capture
+      Enable collections to appear as quick capture options in the capture
       screen.
     </div>
     <div class="flex flex-col gap-2 w-full flex-grow">
       {#if collections.length === 0}
         <EmptyStatusView
-          mainText="No typed collections found. Please create a new collection."
+          mainText="No collections found. Please create a new collection."
           actionText="Create new collection"
           on:click={() => {
             appStore.runAction(
@@ -73,7 +85,12 @@
           }}
         />
       {:else}
-        {#each collections as collection (collection.id)}
+        <InlineSearchBar
+          bind:query
+          on:search={onSearch}
+          style={InputStyle.FILLED}
+        />
+        {#each filteredCollections as collection (collection.id)}
           <div
             class="flex justify-between items-center p-3 rounded-lg bg-bgs2 border border-brs3 w-full"
           >
@@ -89,30 +106,6 @@
             />
           </div>
         {/each}
-        <div class="flex justify-center w-full pt-2">
-          <Button
-            label="See all collections"
-            style={ButtonStyle.PLAIN}
-            isUnderlined={true}
-            on:click={() => {
-              modalEvent.hide(MemotronAction.EDIT_CAPTURE_SHORTCUTS);
-              modalEvent.hide(MemotronAction.CAPTURE_SETTINGS);
-              if ($view.isPortrait) {
-                appStore.runAction(ResourceActionType.BROWSE, {
-                  componentParams: {
-                    resource: Resource.collection,
-                    [AppSearchParam.RETURN_TO]:
-                      resolveProductConfig().homePathPt
-                  }
-                });
-              } else {
-                appStore.runAction(
-                  resourceAction(Resource.collection, ResourceActionType.BROWSE)
-                );
-              }
-            }}
-          />
-        </div>
         <ScrollViewBottomSpacer />
       {/if}
     </div>

--- a/client/products/memotron/capture/TypeSelector.svelte
+++ b/client/products/memotron/capture/TypeSelector.svelte
@@ -38,10 +38,14 @@
       icon: "upload",
       value: CaptureMethod.UPLOAD
     },
-    !$context.isEmbed && {
-      icon: "clipboard",
-      value: CaptureMethod.PASTE
-    }
+    ...(!$context.isEmbed
+      ? [
+          {
+            icon: "clipboard",
+            value: CaptureMethod.PASTE
+          }
+        ]
+      : [])
   ];
 
   async function refreshTypes() {

--- a/client/products/memotron/node/base/NonMediaNode.svelte
+++ b/client/products/memotron/node/base/NonMediaNode.svelte
@@ -128,7 +128,8 @@
   }
 
   function onRightPaneSwitch() {
-    if ($node.accessMode !== ResourceAccessMode.INLINE) return;
+    if ($node.accessMode !== ResourceAccessMode.INLINE || isConstrainedWidth)
+      return;
     if (isRightPanelCollapsed) {
       dispatchCustomEvent(GlobalEvent.EXPAND_PANEL, {});
     } else {

--- a/client/products/memotron/node/links/LinkItem.svelte
+++ b/client/products/memotron/node/links/LinkItem.svelte
@@ -51,7 +51,10 @@
     <span
       slot="bottom"
       class={cn("flex flex-col gap-2", {
-        "pt-3": (link.tags && link.tags.length > 0) || isShowLinkTagger
+        "pt-3":
+          (link.tags && link.tags.length > 0) ||
+          (link.links && link.links.length > 0) ||
+          isShowLinkTagger
       })}
     >
       <span class="flex gap-2">
@@ -75,7 +78,7 @@
       </span>
       {#if isShowLinkTagger}
         <div class="w-full py-2">
-          <LinkTagger bind:link />
+          <LinkTagger bind:link on:tag />
         </div>
       {/if}
     </span>

--- a/client/products/memotron/node/links/LinkThumbnailItems.svelte
+++ b/client/products/memotron/node/links/LinkThumbnailItems.svelte
@@ -28,6 +28,7 @@
       on:linkTypeSelect
       on:action
       on:tagClick
+      on:tag
     />
   {/each}
 </div>

--- a/client/products/memotron/node/links/NodeLinksPane.svelte
+++ b/client/products/memotron/node/links/NodeLinksPane.svelte
@@ -123,8 +123,12 @@
       linkStatus.type = AlertType.SUCCESS;
       const link: INodeLinkThumb = {
         linkedTo: e.detail.item.id,
-        linkType: LinkType.DIRECT,
-        id: result[0]?.id ?? ""
+        links: [
+          {
+            linkType: LinkType.DIRECT,
+            id: result[0]?.id ?? ""
+          }
+        ]
       };
       _links = [...(_links ?? []), link];
       $node.links = [...($node.links ?? []), link];
@@ -363,21 +367,23 @@
         selectedLinkType.linkType,
         selectedLinkType.direction
       )}
-      <Tag
-        label={config.label}
-        icon={config.icon}
-        size={Size.md}
-        isActive={true}
-        isRemovable={true}
-        on:remove={() => {
-          selectedLinkType = undefined;
-          applyFilters();
-        }}
-        on:click={(e) => {
-          selectedLinkType = undefined;
-          applyFilters();
-        }}
-      />
+      <div>
+        <Tag
+          label={config.label}
+          icon={config.icon}
+          size={Size.md}
+          isActive={true}
+          isRemovable={true}
+          on:remove={() => {
+            selectedLinkType = undefined;
+            applyFilters();
+          }}
+          on:click={(e) => {
+            selectedLinkType = undefined;
+            applyFilters();
+          }}
+        />
+      </div>
     {/if}
     {#if availableLinkTags.length > 0}
       <div class="flex flex-col gap-3">
@@ -398,6 +404,9 @@
           on:click={onClick}
           on:action={onAction}
           on:tagClick={onTagClick}
+          on:tag={() => {
+            applyFilters();
+          }}
           on:linkTypeSelect={onLinkTypeSelect}
         />
         <ScrollViewBottomSpacer />

--- a/client/products/memotron/node/node.store.ts
+++ b/client/products/memotron/node/node.store.ts
@@ -1014,7 +1014,9 @@ export function resolveNodeContextMenu(
         items: [
           resourceActions.star(),
           resourceActions.edit(accessPoint),
-          nodeActions.tracesPane(),
+          ...(canHaveTraces.includes(node.contentType)
+            ? [nodeActions.tracesPane()]
+            : []),
           nodeActions.linksPane(),
           nodeActions.sideNotesPane(),
           nodeStaticActions.propertiesPane,

--- a/client/products/memotron/node/node.type.ts
+++ b/client/products/memotron/node/node.type.ts
@@ -375,7 +375,7 @@ export type INodeLinkThumb = ILinkBase & {
   links?: {
     id: IRecordId;
     linkType: LinkType;
-    direction: "incoming" | "outgoing";
+    direction?: "incoming" | "outgoing";
     tags?: IRecordId[];
   }[];
 };

--- a/client/stores/actionMap.ts
+++ b/client/stores/actionMap.ts
@@ -581,8 +581,8 @@ export const globalActions: IAction[] = [
     type: ActionType.MODAL,
     modalParams: {
       layout: {
-        size: Size.lg,
-        orientation: Orientation.Horizontal,
+        size: Size.md,
+        orientation: Orientation.Vertical,
         ignoreSafeArea: true
       }
     }
@@ -755,8 +755,8 @@ export const globalActions: IAction[] = [
           icon: "offline",
           variant: ButtonVariant.SECONDARY,
           callback: async () => {
-             await context.toggleOfflineMode(true);
-              modalEvent.hide(Action.INACTIVE_PLAN);
+            await context.toggleOfflineMode(true);
+            modalEvent.hide(Action.INACTIVE_PLAN);
           }
         }
       }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Streamlined collection creation and capture shortcuts, improved linking and notes UX, and fixed several UI bugs across Memotron and core UI.

- **Bug Fixes**
  - Prevented panel collapse when switching app menus on other routes.
  - Right pane toggle now respects constrained width in non-media nodes.
  - Type selector no longer renders a falsey “Paste” option in embeds.
  - Stabilized emoji picker keyboard handling and cursor behavior in markdown.
  - Traces menu item shows only for content types that support it.
  - Calendar column adds a button to open notes in full screen.

- **Refactors**
  - Collections default to “Typed”; added “Synced” type (planned) and removed “Convert as Simple”.
  - Updated labels and tooltips to refer to extending collections, not “Type collections”.
  - Capture shortcuts now list node collections regardless of type and include inline search.
  - Link model updated to nest link data under links[], and tag events trigger filter refresh.

<!-- End of auto-generated description by cubic. -->

