### PR TITLE
feat: TIDY-356

### DIFF
--- a/apps/memotron/package.json
+++ b/apps/memotron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memotron-app",
   "version": "0.62.0",
-  "build": 6,
+  "build": 7,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5002",

--- a/apps/nucleus/package.json
+++ b/apps/nucleus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nucleus-app",
   "version": "0.3.4",
-  "build": 6,
+  "build": 7,
   "private": true,
   "scripts": {
     "dev": "vite dev --port 5050",

--- a/client/components/markdown/content/TextContent.svelte
+++ b/client/components/markdown/content/TextContent.svelte
@@ -342,7 +342,6 @@
     type: "keyup" | "keydown" = "keydown"
   ) {
     if (!$mdStore.params?.canUseSlashShortcut) return false;
-
     const hasColon = text.includes(":");
 
     if (type === "keydown" && event.key === ":") {
@@ -365,7 +364,6 @@
         const spaceIndex = afterColon.search(/\s/);
         emojiSearchQuery =
           spaceIndex === -1 ? afterColon : afterColon.substring(0, spaceIndex);
-
         if (emojiSearchQuery.trim()) {
           if (!isRenderEmojiPicker) {
             showPopover("emojiPicker");
@@ -386,7 +384,7 @@
       emojiPickerRef?.key(event.key);
       event.preventDefault();
     }
-    return hasColon || isRenderEmojiPicker;
+    return isRenderEmojiPicker;
   }
 
   function handleKeyDown(

--- a/client/products/memotron/node/base/NonMediaNode.svelte
+++ b/client/products/memotron/node/base/NonMediaNode.svelte
@@ -184,13 +184,17 @@
 >
   {#if $node}
     {#if selectedView === NodeView.CONTENT}
+      {@const isRenderCover =
+        $node.contentType === NodeType.NODULAR_MARKDOWN &&
+        cover &&
+        !$node.focusedBlock}
       {#key refreshId}
         <div
-          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4 otop:pt-12", {
-            "flex px-4 justify-center": !isWidened,
+          class={cn("h-full w-full flex mo:gap-0 cw:gap-0 gap-4", {
+            "px-4 otop:pt-12": !isRenderCover,
+            "justify-center": !isWidened,
             "dp:grid dp:grid-cols-[1fr_auto_1fr] dp:gap-2":
               !isWidened && !isConstrainedWidth,
-            "flex px-4": isWidened,
             "px-0": isConstrainedWidth && rightPane !== NodeRightPaneType.NONE
           })}
         >
@@ -203,9 +207,9 @@
                 "dp:min-w-[50rem]": !isWidened && !isConstrainedWidth
               })}
             >
-              {#if $node.contentType === NodeType.NODULAR_MARKDOWN && cover && !$node.focusedBlock}
+              {#if isRenderCover}
                 <div
-                  class="relative flex w-full h-72 justify-center items-center"
+                  class="relative flex w-full cw:h-32 h-72 justify-center items-center"
                   use:hoverable={{
                     onHover: (e) => {
                       isCoverPickerHovered = e;
@@ -264,7 +268,12 @@
                 </div>
               {:else}
                 <main
-                  class="relative flex flex-col gap-6 mo:pr-0 h-full w-full overflow-auto"
+                  class={cn(
+                    "relative flex flex-col gap-6 mo:pr-0 h-full w-full overflow-auto",
+                    {
+                      "cw:px-4": isRenderCover
+                    }
+                  )}
                   on:scroll={onScroll}
                 >
                   {#if !$node.focusedBlock}

--- a/client/products/memotron/node/content/web/social/SocialPostContent.svelte
+++ b/client/products/memotron/node/content/web/social/SocialPostContent.svelte
@@ -171,7 +171,10 @@
         label={resolveOpenInButtonLabel()}
         isUnderlined={true}
         size={Size.sm}
-        on:click
+        on:click={() => {
+          if (!node.url) return;
+          appStore.openLink(node.url);
+        }}
       />
     </div>
   </div>

--- a/extensions/memotron-share/src/routes/[...route]/+page.svelte
+++ b/extensions/memotron-share/src/routes/[...route]/+page.svelte
@@ -35,6 +35,7 @@
           const parsed = JSON.parse(event.data.payload);
           addToDebugLog(`Parsed data: ${JSON.stringify(parsed)}`);
           if (parsed.type === "SHARED_CONTENT") {
+            if (data) return;
             await processShareData(parsed);
           }
         }
@@ -298,7 +299,7 @@
       {:else}
         <EmptyStatusView
           isLoadingState={true}
-          subText="Logged in. Reading data..."
+          loadingText="Logged in. Reading data..."
         />
       {/if}
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Refine cover rendering logic in NonMediaNode, add social link opening behavior, tighten emoji picker key handling, guard against duplicate share processing, update status view prop, and bump build versions

New Features:
- Enable social post links to open via appStore.openLink on click

Bug Fixes:
- Prevent duplicate processing of shared content by early returning when data exists
- Rename EmptyStatusView prop to loadingText to match component API
- Limit emoji keyup handling to when the emoji picker is active

Enhancements:
- Introduce isRenderCover flag in NonMediaNode to conditionally adjust layout, padding, and sizing for nodular markdown covers
- Adjust cover preview height for cw breakpoints and add conditional padding when rendering cover

Build:
- Bump build number to 7 for memotron-app and nucleus-app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link navigation functionality for social posts.

* **Bug Fixes**
  * Refined emoji picker shortcut behavior for improved handling.
  * Enhanced loading state messaging in shared content.
  * Added protection against duplicate data processing.

* **Chores**
  * Updated build versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->