### PR TITLE
Bug fixes and improvements

### DIFF
--- a/apps/memotron/package.json
+++ b/apps/memotron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memotron-app",
   "version": "0.62.0",
-  "build": 6,
+  "build": 7,
   "private": true,
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 5002",

--- a/apps/nucleus/package.json
+++ b/apps/nucleus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nucleus-app",
   "version": "0.3.4",
-  "build": 6,
+  "build": 7,
   "private": true,
   "scripts": {
     "dev": "vite dev --port 5050",

--- a/client/components/markdown/content/TextContent.svelte
+++ b/client/components/markdown/content/TextContent.svelte
@@ -342,7 +342,6 @@
     type: "keyup" | "keydown" = "keydown"
   ) {
     if (!$mdStore.params?.canUseSlashShortcut) return false;
-
     const hasColon = text.includes(":");
 
     if (type === "keydown" && event.key === ":") {
@@ -365,7 +364,6 @@
         const spaceIndex = afterColon.search(/\s/);
         emojiSearchQuery =
           spaceIndex === -1 ? afterColon : afterColon.substring(0, spaceIndex);
-
         if (emojiSearchQuery.trim()) {
           if (!isRenderEmojiPicker) {
             showPopover("emojiPicker");
@@ -386,7 +384,7 @@
       emojiPickerRef?.key(event.key);
       event.preventDefault();
     }
-    return hasColon || isRenderEmojiPicker;
+    return isRenderEmojiPicker;
   }
 
   function handleKeyDown(

--- a/client/products/memotron/node/base/NonMediaNode.svelte
+++ b/client/products/memotron/node/base/NonMediaNode.svelte
@@ -184,13 +184,17 @@
 >
   {#if $node}
     {#if selectedView === NodeView.CONTENT}
+      {@const isRenderCover =
+        $node.contentType === NodeType.NODULAR_MARKDOWN &&
+        cover &&
+        !$node.focusedBlock}
       {#key refreshId}
         <div
-          class={cn("h-full w-full mo:gap-0 cw:gap-0 gap-4 otop:pt-12", {
-            "flex px-4 justify-center": !isWidened,
+          class={cn("h-full w-full flex mo:gap-0 cw:gap-0 gap-4", {
+            "px-4 otop:pt-12": !isRenderCover,
+            "justify-center": !isWidened,
             "dp:grid dp:grid-cols-[1fr_auto_1fr] dp:gap-2":
               !isWidened && !isConstrainedWidth,
-            "flex px-4": isWidened,
             "px-0": isConstrainedWidth && rightPane !== NodeRightPaneType.NONE
           })}
         >
@@ -203,9 +207,9 @@
                 "dp:min-w-[50rem]": !isWidened && !isConstrainedWidth
               })}
             >
-              {#if $node.contentType === NodeType.NODULAR_MARKDOWN && cover && !$node.focusedBlock}
+              {#if isRenderCover}
                 <div
-                  class="relative flex w-full h-72 justify-center items-center"
+                  class="relative flex w-full cw:h-32 h-72 justify-center items-center"
                   use:hoverable={{
                     onHover: (e) => {
                       isCoverPickerHovered = e;
@@ -264,7 +268,12 @@
                 </div>
               {:else}
                 <main
-                  class="relative flex flex-col gap-6 mo:pr-0 h-full w-full overflow-auto"
+                  class={cn(
+                    "relative flex flex-col gap-6 mo:pr-0 h-full w-full overflow-auto",
+                    {
+                      "cw:px-4": isRenderCover
+                    }
+                  )}
                   on:scroll={onScroll}
                 >
                   {#if !$node.focusedBlock}

--- a/client/products/memotron/node/content/web/social/SocialPostContent.svelte
+++ b/client/products/memotron/node/content/web/social/SocialPostContent.svelte
@@ -171,7 +171,10 @@
         label={resolveOpenInButtonLabel()}
         isUnderlined={true}
         size={Size.sm}
-        on:click
+        on:click={() => {
+          if (!node.url) return;
+          appStore.openLink(node.url);
+        }}
       />
     </div>
   </div>

--- a/extensions/memotron-share/src/routes/[...route]/+page.svelte
+++ b/extensions/memotron-share/src/routes/[...route]/+page.svelte
@@ -35,6 +35,7 @@
           const parsed = JSON.parse(event.data.payload);
           addToDebugLog(`Parsed data: ${JSON.stringify(parsed)}`);
           if (parsed.type === "SHARED_CONTENT") {
+            if (data) return;
             await processShareData(parsed);
           }
         }
@@ -298,7 +299,7 @@
       {:else}
         <EmptyStatusView
           isLoadingState={true}
-          subText="Logged in. Reading data..."
+          loadingText="Logged in. Reading data..."
         />
       {/if}
     </div>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed emoji picker return logic in TextContent component

- Improved cover rendering conditions with extracted variable

- Fixed social post link opening with null check

- Corrected share page loading state prop name

- Bumped build versions for both apps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TextContent<br/>Emoji Picker"] -->|"Fixed return logic"| B["Bug Fix"]
  C["NonMediaNode<br/>Cover Rendering"] -->|"Extracted isRenderCover"| D["Enhancement"]
  E["SocialPostContent<br/>Link Handler"] -->|"Added null check"| F["Bug Fix"]
  G["Share Page<br/>Loading State"] -->|"Fixed prop name"| H["Bug Fix"]
  I["Package Versions"] -->|"Build 6→7"| J["Version Bump"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TextContent.svelte</strong><dd><code>Fixed emoji picker return logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/components/markdown/content/TextContent.svelte

<ul><li>Removed unnecessary blank line in <code>handleEmojiShortcut</code> function<br> <li> Fixed return statement logic to return only <code>isRenderEmojiPicker</code> <br>instead of <code>hasColon || isRenderEmojiPicker</code><br> <li> Cleaned up whitespace formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-a1ab9df68d20c11419c9524dade49eeb223b124ce5a87246899cac1a07280333">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SocialPostContent.svelte</strong><dd><code>Added null check for link opening</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/products/memotron/node/content/web/social/SocialPostContent.svelte

<ul><li>Added null check for <code>node.url</code> before calling <code>appStore.openLink()</code><br> <li> Converted empty click handler to proper function with safety guard</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-4e78645914e5c858225e9b6260307a1943ca99a1825acaf58c3943cda56010f6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+page.svelte</strong><dd><code>Fixed share data processing and loading text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/memotron-share/src/routes/[...route]/+page.svelte

<ul><li>Added early return guard to prevent duplicate processing of shared <br>content<br> <li> Changed <code>subText</code> prop to <code>loadingText</code> in EmptyStatusView component</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-f0559a6a8bd66adbd22eaadb941f369b0a59c6ddf84adaf5b6fe2ee675afcf0f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NonMediaNode.svelte</strong><dd><code>Improved cover rendering with extracted variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/products/memotron/node/base/NonMediaNode.svelte

<ul><li>Extracted cover rendering condition into <code>isRenderCover</code> variable for <br>better readability<br> <li> Updated class binding logic to use extracted variable<br> <li> Added responsive height class <code>cw:h-32</code> to cover element<br> <li> Added conditional padding class <code>cw:px-4</code> to main content area based on <br>cover rendering<br> <li> Reorganized flex and padding classes for cleaner structure</ul>


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-84719f237bb3cdeb8bfb22faef22c65ad813b668ec1d7d42ca01c8568b71550f">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bumped memotron app build version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/memotron/package.json

- Incremented build version from 6 to 7


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-47aab8931d844baa95318b96022476f62c4f216a151586fbf639bc260c0e07c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bumped nucleus app build version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/nucleus/package.json

- Incremented build version from 6 to 7


</details>


  </td>
  <td><a href="https://github.com/21nOrg/tidigit/pull/422/files#diff-e0edc99bba388334d54e36ae58be7c73e8b30676cc8e941488a58e9da3ca2633">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

