### PR TITLE
conduct, openspec init, testing task spec generation

### DIFF
--- a/.claude/commands/conduct/change.md
+++ b/.claude/commands/conduct/change.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.claude/commands/conduct/feature.md
+++ b/.claude/commands/conduct/feature.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/.claude/commands/openspec/apply.md
+++ b/.claude/commands/openspec/apply.md
@@ -1,0 +1,23 @@
+---
+name: OpenSpec: Apply
+description: Implement an approved OpenSpec change and keep tasks in sync.
+category: OpenSpec
+tags: [openspec, apply]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.claude/commands/openspec/archive.md
+++ b/.claude/commands/openspec/archive.md
@@ -1,0 +1,21 @@
+---
+name: OpenSpec: Archive
+description: Archive a deployed OpenSpec change and update specs.
+category: OpenSpec
+tags: [openspec, archive]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Identify the requested change ID (via the prompt or `openspec list`).
+2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
+3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.claude/commands/openspec/proposal.md
+++ b/.claude/commands/openspec/proposal.md
@@ -1,0 +1,27 @@
+---
+name: OpenSpec: Proposal
+description: Scaffold a new OpenSpec change and validate strictly.
+category: OpenSpec
+tags: [openspec, change]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/.cursor/commands/change.md
+++ b/.cursor/commands/change.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.cursor/commands/feature.md
+++ b/.cursor/commands/feature.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/.cursor/commands/openspec-apply.md
+++ b/.cursor/commands/openspec-apply.md
@@ -1,0 +1,23 @@
+---
+name: /openspec-apply
+id: openspec-apply
+category: OpenSpec
+description: Implement an approved OpenSpec change and keep tasks in sync.
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.cursor/commands/openspec-archive.md
+++ b/.cursor/commands/openspec-archive.md
@@ -1,0 +1,21 @@
+---
+name: /openspec-archive
+id: openspec-archive
+category: OpenSpec
+description: Archive a deployed OpenSpec change and update specs.
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Identify the requested change ID (via the prompt or `openspec list`).
+2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
+3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.cursor/commands/openspec-proposal.md
+++ b/.cursor/commands/openspec-proposal.md
@@ -1,0 +1,27 @@
+---
+name: /openspec-proposal
+id: openspec-proposal
+category: OpenSpec
+description: Scaffold a new OpenSpec change and validate strictly.
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/.cursor/plans/testing-e869b0d1.plan.md
+++ b/.cursor/plans/testing-e869b0d1.plan.md
@@ -1,0 +1,49 @@
+<!-- e869b0d1-43ed-497e-b2a7-052e57f1c6fa f42b497b-c943-47ad-8cad-ca5a534166fe -->
+# Testing Robustness Roadmap
+
+## Current Gaps
+
+- Existing suites are limited to alias linting (`tests/unit/eslint/alias-imports.spec.ts`) and a few shared/server helpers (`shared/utils/**/*.test.ts`, `server/utils.test.ts`), leaving most client, server, and integration logic untested.
+- No unified test runner for workspaces; coverage and regression gates are absent, and Turbo’s `test` task fails when sub-apps lack tests.
+
+## Phase 1 — Foundation & Tooling
+
+- Audit test entry points across workspaces, consolidate under a root Vitest config (e.g., `tests/vitest.config.ts`), and wire Turbo `test` to execute targeted suites via `test.setup.ts`.
+- Add shared test utilities (mocks, fixtures) in `tests/fixtures` and `tests/utils` for server (SurrealDB/Dynamo mocks) and client (Svelte rendering helpers).
+- Configure coverage reporting with Istanbul + HTML/LCOV output, and store baselines for comparison.
+
+## Phase 2 — Critical Server & Shared Coverage
+
+- Expand unit tests for `server/utils.ts`, `server/common/*`, and database providers (`server/database/providers/*.ts`) using deterministic fixtures and property-based checks (fast-check) for parsing/state helpers.
+- Introduce mutation/fuzz tests for serialization logic in `shared/utils` and schema definitions in `shared/dbo`, mirroring SQLite’s random tester philosophy.
+
+## Phase 3 — Client Utilities, Components & Store Testing
+
+- Co-locate Vitest suites beside every utility in `client/utils` (e.g., `client/utils/foo.test.ts`) to guarantee function-level coverage, backed by reusable mock helpers.
+- Add Svelte Testing Library setup (e.g., `tests/client/setup.ts`) to exercise `client/components`, `client/stores`, and product-specific flows under `client/products/*` with mocked appStore/product context.
+- Cover accessibility regressions with axe-core integration and snapshot-like DOM assertions for critical UI primitives (`client/elements/Button.svelte`, routing shells in `client/layout`).
+
+## Phase 4 — Integration & End-to-End Flows
+
+- Build integration suites that boot minimal SvelteKit servers for each app (`apps/{nucleus,memotron,pointron}`) and validate routing/state sync; reuse `tests/integration` for server-client contracts.
+- Introduce Playwright-driven smoke tests scoped to a dedicated workspace (e.g., `apps/e2e-playwright`) with one project per app, shared fixtures, and reusable auth/data helpers.
+- Wire the Playwright workspace into Turbo via a `test:e2e` task that depends on app builds, configure `webServer` entries to reuse existing `npm run dev:<product>` commands, and standardize trace/video artifacts.
+- Record golden responses for API endpoints in `server/index.ts` alongside Playwright regression baselines.
+
+## Phase 5 — Continuous Quality Gates
+
+- Enforce coverage thresholds per package via Vitest config, fail Turbo tasks when coverage dips below target, and publish reports in CI.
+- Add nightly long-haul fuzz/soak jobs (randomized workspace mutations, concurrent sync simulations) comparable to SQLite’s “torture tests.”
+
+## Phase 6 — Developer Experience & Governance
+
+- Update `CONTRIBUTING.md` and `WARP.md` with testing expectations, quick-start commands, and verification checklists.
+- Automate CI via GitHub Actions (or existing pipeline) to run unit, integration, and fuzz jobs on matrix of Node versions, ensuring reproducibility.
+
+### To-dos
+
+- [ ] Create consolidated Vitest config, shared fixtures, and coverage reporting infrastructure.
+- [ ] Write deterministic and property-based tests for server/common utilities and shared schema helpers.
+- [ ] Introduce Svelte Testing Library setup and cover critical components and stores.
+- [ ] Implement app-level integration tests and Playwright smoke suites.
+- [ ] Enforce coverage thresholds, add fuzz/soak jobs, and integrate CI governance updates.

--- a/.factory/commands/change.md
+++ b/.factory/commands/change.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.factory/commands/feature.md
+++ b/.factory/commands/feature.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/.factory/commands/openspec-apply.md
+++ b/.factory/commands/openspec-apply.md
@@ -1,0 +1,23 @@
+---
+description: Implement an approved OpenSpec change and keep tasks in sync.
+argument-hint: change-id
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+
+$ARGUMENTS
+<!-- OPENSPEC:END -->

--- a/.factory/commands/openspec-archive.md
+++ b/.factory/commands/openspec-archive.md
@@ -1,0 +1,21 @@
+---
+description: Archive a deployed OpenSpec change and update specs.
+argument-hint: change-id
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Identify the requested change ID (via the prompt or `openspec list`).
+2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
+3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+
+$ARGUMENTS
+<!-- OPENSPEC:END -->

--- a/.factory/commands/openspec-proposal.md
+++ b/.factory/commands/openspec-proposal.md
@@ -1,0 +1,27 @@
+---
+description: Scaffold a new OpenSpec change and validate strictly.
+argument-hint: request or feature description
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+
+$ARGUMENTS
+<!-- OPENSPEC:END -->

--- a/.github/prompts/conduct-change.prompt.md
+++ b/.github/prompts/conduct-change.prompt.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.github/prompts/conduct-feature.prompt.md
+++ b/.github/prompts/conduct-feature.prompt.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/.github/prompts/openspec-apply.prompt.md
+++ b/.github/prompts/openspec-apply.prompt.md
@@ -1,0 +1,22 @@
+---
+description: Implement an approved OpenSpec change and keep tasks in sync.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.github/prompts/openspec-archive.prompt.md
+++ b/.github/prompts/openspec-archive.prompt.md
@@ -1,0 +1,20 @@
+---
+description: Archive a deployed OpenSpec change and update specs.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Identify the requested change ID (via the prompt or `openspec list`).
+2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
+3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.github/prompts/openspec-proposal.prompt.md
+++ b/.github/prompts/openspec-proposal.prompt.md
@@ -1,0 +1,26 @@
+---
+description: Scaffold a new OpenSpec change and validate strictly.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/.opencode/command/change.md
+++ b/.opencode/command/change.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.opencode/command/feature.md
+++ b/.opencode/command/feature.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/.opencode/command/openspec-apply.md
+++ b/.opencode/command/openspec-apply.md
@@ -1,0 +1,21 @@
+---
+agent: build
+description: Implement an approved OpenSpec change and keep tasks in sync.
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.opencode/command/openspec-archive.md
+++ b/.opencode/command/openspec-archive.md
@@ -1,0 +1,19 @@
+---
+agent: build
+description: Archive a deployed OpenSpec change and update specs.
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Identify the requested change ID (via the prompt or `openspec list`).
+2. Run `openspec archive <id> --yes` to let the CLI move the change and apply spec updates without prompts (use `--skip-specs` only for tooling-only work).
+3. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+4. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.opencode/command/openspec-proposal.md
+++ b/.opencode/command/openspec-proposal.md
@@ -1,0 +1,29 @@
+---
+agent: build
+description: Scaffold a new OpenSpec change and validate strictly.
+---
+The user has requested the following change proposal. Use the openspec instructions to create their change proposal.
+<UserRequest>
+  $ARGUMENTS
+</UserRequest>
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/.warp/commands/conduct/change.md
+++ b/.warp/commands/conduct/change.md
@@ -1,0 +1,63 @@
+---
+description: Create a new change specification and increment parent feature version
+argument-hint: change name and optional target feature
+---
+
+# conduct-change
+Creates a new change specification and increments parent feature version.
+
+**Usage:**
+```
+conduct-change <change-name> [target-feature]
+```
+
+**Steps:**
+1. Determine target:
+   - If target-feature provided: search for feature in hierarchy
+   - Otherwise: use root `conduct/changes/`
+
+2. Create change file:
+   ```
+   <target>/changes/<change-name>.spec.md
+   ```
+
+3. Populate <change-name>.spec.md with change template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new spec version to document the change
+
+5. Add to track.json changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "<relative-path>",
+     "parentFeature": "<feature-name-or-root>",
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every change
+- Keep specs up to date with implementation
+- Link to issue trackers when available

--- a/.warp/commands/conduct/feature.md
+++ b/.warp/commands/conduct/feature.md
@@ -1,0 +1,70 @@
+---
+description: Create a new feature with proper directory structure and spec template
+argument-hint: feature name and optional parent feature
+---
+
+# conduct-feature
+Creates a new feature with the proper directory structure and spec template.
+
+**Usage:**
+```
+conduct-feature <feature-name> [parent-feature]
+```
+
+**Steps:**
+1. Determine target path:
+   - If parent-feature provided: search for it in hierarchy and create under `features/`
+   - Otherwise: create in `conduct/features/`
+
+2. Create directory structure:
+   ```
+   <target-path>/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Populate spec.v0.md with feature template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. If creating nested feature, increment parent spec version:
+   - Copy latest `spec.vN.md` to `spec.v(N+1).md` in parent feature folder
+   - Update the new spec version to document the new nested feature
+
+5. Add to track.json features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "<relative-path>",
+     "version": 0,
+     "created": "<current-date>",
+     "issueTrackers": { "github": "" }
+   }
+   ```
+
+**Notes:**
+- Always follow the templates in AGENTS.md
+- Update track.json for every feature
+- Link to issue trackers when available

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,23 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 <!-- OPENSPEC:END -->
 
-# AGENTS.md
+<!-- CONDUCT:START -->
+# Conduct Instructions
 
-See the [Tidigit Constitution](.specify/memory/constitution.md) for the authoritative onboarding checklist and operational policies.
+These instructions are for AI assistants working in this project.
+
+Always open `@/conduct/AGENTS.md` when the request:
+- Mentions features, changes, or specifications
+- Introduces new capabilities or significant modifications
+- Requires understanding the project structure and conventions
+- Needs guidance on creating or updating specs
+
+Use `@/conduct/AGENTS.md` to learn:
+- How to create features and changes
+- Spec format and conventions
+- Project structure and guidelines
+- Issue tracker integration
+
+Keep this managed block so 'conduct init' can refresh the instructions.
+
+<!-- CONDUCT:END -->

--- a/WARP.md
+++ b/WARP.md
@@ -152,3 +152,22 @@ When asked to fix pull request review comments by providing a PR number:
 - Be thorough and methodical in issue identification
 - Double-check that no critical issues are missed
 - Provide clear summary of what was fixed
+
+
+# Conduct Instructions
+
+These instructions are for Warp AI when working in this project.
+
+When the request mentions features, changes, or specifications:
+- Use `conduct-feature` command to create new features
+- Use `conduct-change` command to create new changes
+- Read `.warp/commands/conduct/feature.md` for feature creation guidance
+- Read `.warp/commands/conduct/change.md` for change creation guidance
+
+The Warp commands handle:
+- Creating proper directory structure
+- Generating spec templates
+- Updating track.json
+- Managing versions
+
+Keep this file so 'conduct init' can refresh the instructions.

--- a/conduct/AGENTS.md
+++ b/conduct/AGENTS.md
@@ -1,0 +1,212 @@
+# Conduct Agent Instructions
+
+## Overview
+This repository uses Conduct for specification and change management. This file provides instructions for AI coding agents to work effectively with the Conduct structure.
+
+## Directory Structure
+```
+conduct/
+├── spec.v0.md          # Root project specification
+├── track.json          # Feature and change tracking with issue tracker mappings
+├── AGENTS.md           # This file - instructions for AI agents
+├── features/           # Feature specifications (can be nested)
+│   └── feature-name/
+│       ├── spec.v0.md  # Feature specification (versioned)
+│       ├── features/   # Nested sub-features
+│       └── changes/    # Changes to this feature
+└── changes/            # Root-level changes
+```
+
+## Issue Trackers
+This project uses the following issue tracking systems:
+- GitHub Issues (21nOrg/tidigit/issues)
+
+All features and changes should be linked to issues in track.json.
+
+## Creating New Features
+
+### Using CLI (if available)
+If you have the Conduct CLI installed, the easiest way is to use it directly. However, if CLI commands are not available in your environment, follow the manual instructions below.
+
+### Manual Feature Creation
+1. Choose the appropriate location:
+   - For root-level features: `conduct/features/`
+   - For nested features: `conduct/features/<parent-feature>/features/`
+
+2. Create feature directory structure:
+   ```
+   conduct/features/<feature-name>/
+   ├── spec.v0.md
+   ├── features/
+   └── changes/
+   ```
+
+3. Create `spec.v0.md` with the following template:
+   ```markdown
+   # Feature Name
+
+   ## Overview
+   <!-- Description of this feature -->
+
+   ## Requirements
+   ### Functional Requirements
+   <!-- What the feature must do -->
+
+   ### Non-functional Requirements
+   <!-- Performance, security, usability requirements -->
+
+   ## Implementation
+   ### Technical Approach
+   <!-- How the feature will be implemented -->
+
+   ### File Structure
+   <!-- Files and directories created -->
+
+   ## Dependencies
+   <!-- Related features or external dependencies -->
+   ```
+
+4. Add entry to `conduct/track.json` features array:
+   ```json
+   {
+     "name": "<feature-name>",
+     "path": "features/<feature-name>",
+     "version": 0,
+     "created": "YYYY-MM-DD",
+     "issueTrackers": {
+       "github": ""
+     }
+   }
+   ```
+
+## Creating Changes
+
+### Manual Change Creation
+1. Identify the target feature (or use root `conduct/changes/` for project-level changes)
+
+2. Create change file directly in the changes/ folder:
+   ```
+   conduct/[features/<feature-name>/]changes/<change-name>.spec.md
+   ```
+
+3. Create `<change-name>.spec.md` with the following template:
+   ```markdown
+   # Change Name
+
+   ## Change Description
+   <!-- What is being changed and why -->
+
+   ## Impact
+   <!-- What parts of the system are affected -->
+
+   ## Implementation Notes
+   <!-- Technical details of the change -->
+
+   ## Checklist
+   - [ ] Implementation complete
+   - [ ] Tests added/updated
+   - [ ] Documentation updated
+   - [ ] Parent spec updated
+   ```
+
+4. Increment the parent feature's spec version:
+   - Copy `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new version to reflect the change
+
+5. Add entry to `conduct/track.json` changes array:
+   ```json
+   {
+     "name": "<change-name>",
+     "path": "[features/<feature-name>/]changes/<change-name>",
+     "parentFeature": "<feature-name>",
+     "created": "YYYY-MM-DD",
+     "issueTrackers": {
+       "github": ""
+     }
+   }
+   ```
+
+## Updating Existing Features
+
+When making changes to an existing feature:
+
+1. **Increment the spec version**:
+   - Copy the latest `spec.vN.md` to `spec.v(N+1).md`
+   - Update the new version with your changes
+
+2. **Document what changed**:
+   - Add a comment or section at the top describing the update
+   - Keep previous versions for history
+
+3. **Update track.json**:
+   - Update the `version` field for the feature
+   - Add `updated` timestamp
+
+## Best Practices
+
+1. **Specification-First Development**:
+   - Always create or update specs before implementing changes
+   - Keep specs up to date as development progresses
+
+2. **Nested Features**:
+   - Use nested features for logical sub-components
+   - Keep the hierarchy shallow (2-3 levels max recommended)
+
+3. **Version Management**:
+   - Never delete old spec versions - they provide history
+   - Increment versions whenever significant changes are made
+   - Parent specs should be updated when child features/changes are added
+
+4. **Issue Tracker Integration**:
+   - Always link features and changes to issue tracker items
+   - Update track.json with issue IDs as soon as they're created
+   - Use empty string ("") when issue is not yet created
+
+5. **Clarity and Detail**:
+   - Write specs that are clear and actionable
+   - Include code examples where helpful
+   - Document dependencies and impacts
+
+## Agent-Specific Commands
+
+Some AI coding agents may have custom commands available. Check for:
+- `.opencode` - Commands for OpenCode agent
+- `.factory` - Commands for Factory agent  
+- `.cursor` - Commands for Cursor agent
+- `.claude` - Commands for Claude agent
+
+If these files exist, they contain agent-specific shortcuts like:
+- `conduct-feature` - Quick feature creation
+- `conduct-change` - Quick change creation
+
+## Examples
+
+### Example: Creating a nested authentication feature
+```
+conduct/features/
+└── user-management/
+    ├── spec.v0.md
+    ├── features/
+    │   └── authentication/
+    │       ├── spec.v0.md
+    │       ├── features/
+    │       └── changes/
+    └── changes/
+```
+
+### Example: Adding a change to a feature
+```
+conduct/features/user-management/
+├── spec.v0.md
+├── spec.v1.md          # Incremented version
+├── features/
+└── changes/
+    └── add-password-reset.spec.md
+```
+
+## Getting Help
+
+- Review existing features and changes as examples
+- Check `conduct/spec.v0.md` for project-level context
+- Consult the Conduct CLI documentation if available
+- Follow the templates provided above strictly for consistency

--- a/conduct/features/rigorous-testing/spec.v0.md
+++ b/conduct/features/rigorous-testing/spec.v0.md
@@ -1,0 +1,50 @@
+# Rigorous Testing Initiative
+
+## Overview
+Establish a phased testing program that closes the repo’s critical coverage gaps, delivers unified tooling, and raises confidence across backend, client, and product code. The initiative follows the Testing Robustness Roadmap (`@testing-e869b0d1.plan.md`) and incorporates lessons from benchmarking high-maturity testing practices while avoiding anti-patterns identified in low-coverage audits.
+
+## Requirements
+### Functional Requirements
+- Deliver a consolidated Vitest workspace configuration with shared setup, fixtures, and Istanbul coverage reporting that works across all packages and Turbo tasks.
+- Provide reusable server and shared-layer test utilities (SurrealDB/Turso/Dynamo mocks, property-based helpers) and expand deterministic + fuzz coverage for `server/common`, `server/utils`, `shared/dbo`, and `shared/utils`.
+- Introduce client-side testing infrastructure (Svelte Testing Library, DOM helpers, axe-core) and co-located suites for `client/utils`, `client/stores`, `client/components`, and `client/products` critical flows.
+- Stand up integration suites that boot minimal SvelteKit servers for each app (`apps/{nucleus, memotron, pointron}`) and verify routing, state sync, and server-client contracts.
+- Create an `apps/e2e-playwright` workspace running Playwright smoke and regression tests with a Page Object Model, trace/video capture, and environment orchestration inspired by Huly Platform’s practice.
+- Enforce coverage thresholds per workspace, wire results into CI, and gate Turbo `test` tasks on minimum coverage; schedule nightly fuzz/soak jobs and persist artifacts.
+- Update contributor documentation (`CONTRIBUTING.md`, `WARP.md`) with testing expectations, quick-start flows, and verification checklists, reflecting governance guidelines.
+
+### Non-functional Requirements
+- Full test pipeline SHALL complete within 10 minutes on CI runners and remain parallelizable via Turbo caching and split Playwright projects.
+- Test suites MUST be deterministic, isolating data via disposable fixtures, seeded databases, or mocked services.
+- CI MUST upload coverage (LCOV + HTML), Playwright traces, and fuzz logs; artifacts retained for at least 14 days.
+- Tooling MUST support local development on macOS and Linux with Node 20+, Bun, and Docker-based optional services (SurrealDB, Dynamo emulator).
+
+## Implementation
+### Technical Approach
+- **Phase 1 – Foundation & Tooling:** Audit existing Vitest configs, converge on `tests/vitest.workspace.ts`, and centralize setup (`tests/test.setup.ts`). Add `tests/fixtures/**` and `tests/utils/**` with reusable mock builders; enable Istanbul coverage output (text, HTML, LCOV) and ensure Turbo recognizes `coverage/**` artifacts.
+- **Phase 2 – Server & Shared Coverage:** Extend deterministic unit and integration suites for `server/common/*`, `server/utils`, `server/database/providers/*`, and `shared/dbo`. Introduce fast-check powered property tests and mutation/fuzz tests targeting serialization paths, following roadmap guidance and avoiding Cap’s missing backend safeguards.
+- **Phase 3 – Client Utilities & Components:** Add Svelte Testing Library setup (`tests/client/setup.ts`), co-locate tests beside utilities/components, and integrate axe-core accessibility assertions. Implement snapshot-like DOM state verifications and interaction coverage to validate critical UI behaviors.
+- **Phase 4 – Integration & E2E:** Build integration harnesses that spin up lightweight SvelteKit servers per app, validate routing/state sync, and add Playwright smoke suites with Page Objects, multi-app projects, and standardized trace/video capture for observability.
+- **Phase 5 – Quality Gates:** Configure coverage thresholds in Vitest (`lines`, `branches`, `functions` >= 70 for critical packages), fail Turbo tasks on regressions, and run nightly fuzz/soak jobs (random workspace mutations, concurrent sync simulations) with artifact retention.
+- **Phase 6 – Developer Experience & Governance:** Update documentation, add CI workflows (`.github/workflows/tests.yml`, `tests-nightly.yml`), publish coverage to Codecov, and embed testing entry points in contributor guides to prevent governance gaps.
+
+### File Structure
+- `tests/vitest.workspace.ts` – Unified Vitest workspace configuration.
+- `tests/test.setup.ts` & `tests/client/setup.ts` – Global setup for server/client suites.
+- `tests/fixtures/**` – Shared fixtures, SurrealDB snapshots, Dynamo/Turso mocks.
+- `tests/utils/**` – Helper utilities, data builders, property-based generators.
+- `client/**/**.test.ts` & `client/**/**.spec.ts` – Co-located component, store, and utility tests.
+- `server/**/**.test.ts` expansions – Additional deterministic & fuzz suites.
+- `tests/integration/**` – SvelteKit integration harnesses per app.
+- `apps/e2e-playwright/` – Playwright workspace with projects, page objects, and traces output.
+- `.github/workflows/tests.yml` & `tests-nightly.yml` – CI pipelines for regular and fuzz testing.
+- Documentation updates in `CONTRIBUTING.md`, `WARP.md`, and testing playbooks within `tests/`.
+
+## Dependencies
+- Vitest 2.x workspace support, Istanbul coverage reporters, fast-check for property testing.
+- @testing-library/svelte, @testing-library/user-event, axe-core for accessibility checks.
+- Playwright (Chromium, Firefox, WebKit) with trace/video storage; optional Allure/HTML reporters.
+- Turbo monorepo orchestration, Node.js 20+, Bun, pnpm/npm compatibility.
+- Local service emulators: SurrealDB, DynamoDB local, Turso/libSQL; optional Docker compose for integration tests.
+- Codecov (or equivalent) for coverage publishing and GitHub Actions runners for CI integration.
+

--- a/conduct/spec.v0.md
+++ b/conduct/spec.v0.md
@@ -1,0 +1,16 @@
+# Project Specification
+
+## Overview
+<!-- High-level description of the project -->
+
+## Goals
+<!-- What this project aims to achieve -->
+
+## Technical Stack
+<!-- Technologies, frameworks, and tools used -->
+
+## Architecture
+<!-- System design and component structure -->
+
+## Development Phases
+<!-- Planned phases and milestones -->

--- a/conduct/track.json
+++ b/conduct/track.json
@@ -1,0 +1,23 @@
+{
+  "version": 0,
+  "issueTrackers": [
+    {
+      "name": "GitHub Issues",
+      "slug": "github",
+      "basePath": "21nOrg/tidigit/issues"
+    }
+  ],
+  "features": [
+    {
+      "name": "rigorous-testing",
+      "path": "features/rigorous-testing",
+      "version": 0,
+      "created": "2025-10-21",
+      "issueTrackers": {
+        "github": "",
+        "linear": "TIDY-318"
+      }
+    }
+  ],
+  "changes": []
+}

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,456 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## TL;DR Quick Checklist
+
+- Search existing work: `openspec spec list --long`, `openspec list` (use `rg` only for full-text search)
+- Decide scope: new capability vs modify existing capability
+- Pick a unique `change-id`: kebab-case, verb-led (`add-`, `update-`, `remove-`, `refactor-`)
+- Scaffold: `proposal.md`, `tasks.md`, `design.md` (only if needed), and delta specs per affected capability
+- Write deltas: use `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`; include at least one `#### Scenario:` per requirement
+- Validate: `openspec validate [change-id] --strict` and fix issues
+- Request approval: Do not start implementation until proposal is approved
+
+## Three-Stage Workflow
+
+### Stage 1: Creating Changes
+Create proposal when you need to:
+- Add features or functionality
+- Make breaking changes (API, schema)
+- Change architecture or patterns  
+- Optimize performance (changes behavior)
+- Update security patterns
+
+Triggers (examples):
+- "Help me create a change proposal"
+- "Help me plan a change"
+- "Help me create a proposal"
+- "I want to create a spec proposal"
+- "I want to create a spec"
+
+Loose matching guidance:
+- Contains one of: `proposal`, `change`, `spec`
+- With one of: `create`, `plan`, `make`, `start`, `help`
+
+Skip proposal for:
+- Bug fixes (restore intended behavior)
+- Typos, formatting, comments
+- Dependency updates (non-breaking)
+- Configuration changes
+- Tests for existing behavior
+
+**Workflow**
+1. Review `openspec/project.md`, `openspec list`, and `openspec list --specs` to understand current context.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, optional `design.md`, and spec deltas under `openspec/changes/<id>/`.
+3. Draft spec deltas using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement.
+4. Run `openspec validate <id> --strict` and resolve any issues before sharing the proposal.
+
+### Stage 2: Implementing Changes
+Track these steps as TODOs and complete them one by one.
+1. **Read proposal.md** - Understand what's being built
+2. **Read design.md** (if exists) - Review technical decisions
+3. **Read tasks.md** - Get implementation checklist
+4. **Implement tasks sequentially** - Complete in order
+5. **Confirm completion** - Ensure every item in `tasks.md` is finished before updating statuses
+6. **Update checklist** - After all work is done, set every task to `- [x]` so the list reflects reality
+7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
+
+### Stage 3: Archiving Changes
+After deployment, create separate PR to:
+- Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
+- Update `specs/` if capabilities changed
+- Use `openspec archive [change] --skip-specs --yes` for tooling-only changes
+- Run `openspec validate --strict` to confirm the archived change passes checks
+
+## Before Any Task
+
+**Context Checklist:**
+- [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] Check pending changes in `changes/` for conflicts
+- [ ] Read `openspec/project.md` for conventions
+- [ ] Run `openspec list` to see active changes
+- [ ] Run `openspec list --specs` to see existing capabilities
+
+**Before Creating Specs:**
+- Always check if capability already exists
+- Prefer modifying existing specs over creating duplicates
+- Use `openspec show [spec]` to review current state
+- If request is ambiguous, ask 1–2 clarifying questions before scaffolding
+
+### Search Guidance
+- Enumerate specs: `openspec spec list --long` (or `--json` for scripts)
+- Enumerate changes: `openspec list` (or `openspec change list --json` - deprecated but available)
+- Show details:
+  - Spec: `openspec show <spec-id> --type spec` (use `--json` for filters)
+  - Change: `openspec show <change-id> --json --deltas-only`
+- Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" openspec/specs`
+
+## Quick Start
+
+### CLI Commands
+
+```bash
+# Essential commands
+openspec list                  # List active changes
+openspec list --specs          # List specifications
+openspec show [item]           # Display change or spec
+openspec diff [change]         # Show spec differences
+openspec validate [item]       # Validate changes or specs
+openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
+
+# Project management
+openspec init [path]           # Initialize OpenSpec
+openspec update [path]         # Update instruction files
+
+# Interactive mode
+openspec show                  # Prompts for selection
+openspec validate              # Bulk validation mode
+
+# Debugging
+openspec show [change] --json --deltas-only
+openspec validate [change] --strict
+```
+
+### Command Flags
+
+- `--json` - Machine-readable output
+- `--type change|spec` - Disambiguate items
+- `--strict` - Comprehensive validation
+- `--no-interactive` - Disable prompts
+- `--skip-specs` - Archive without spec updates
+- `--yes`/`-y` - Skip confirmation prompts (non-interactive archive)
+
+## Directory Structure
+
+```
+openspec/
+├── project.md              # Project conventions
+├── specs/                  # Current truth - what IS built
+│   └── [capability]/       # Single focused capability
+│       ├── spec.md         # Requirements and scenarios
+│       └── design.md       # Technical patterns
+├── changes/                # Proposals - what SHOULD change
+│   ├── [change-name]/
+│   │   ├── proposal.md     # Why, what, impact
+│   │   ├── tasks.md        # Implementation checklist
+│   │   ├── design.md       # Technical decisions (optional; see criteria)
+│   │   └── specs/          # Delta changes
+│   │       └── [capability]/
+│   │           └── spec.md # ADDED/MODIFIED/REMOVED
+│   └── archive/            # Completed changes
+```
+
+## Creating Change Proposals
+
+### Decision Tree
+
+```
+New request?
+├─ Bug fix restoring spec behavior? → Fix directly
+├─ Typo/format/comment? → Fix directly  
+├─ New feature/capability? → Create proposal
+├─ Breaking change? → Create proposal
+├─ Architecture change? → Create proposal
+└─ Unclear? → Create proposal (safer)
+```
+
+### Proposal Structure
+
+1. **Create directory:** `changes/[change-id]/` (kebab-case, verb-led, unique)
+
+2. **Write proposal.md:**
+```markdown
+## Why
+[1-2 sentences on problem/opportunity]
+
+## What Changes
+- [Bullet list of changes]
+- [Mark breaking changes with **BREAKING**]
+
+## Impact
+- Affected specs: [list capabilities]
+- Affected code: [key files/systems]
+```
+
+3. **Create spec deltas:** `specs/[capability]/spec.md`
+```markdown
+## ADDED Requirements
+### Requirement: New Feature
+The system SHALL provide...
+
+#### Scenario: Success case
+- **WHEN** user performs action
+- **THEN** expected result
+
+## MODIFIED Requirements
+### Requirement: Existing Feature
+[Complete modified requirement]
+
+## REMOVED Requirements
+### Requirement: Old Feature
+**Reason**: [Why removing]
+**Migration**: [How to handle]
+```
+If multiple capabilities are affected, create multiple delta files under `changes/[change-id]/specs/<capability>/spec.md`—one per capability.
+
+4. **Create tasks.md:**
+```markdown
+## 1. Implementation
+- [ ] 1.1 Create database schema
+- [ ] 1.2 Implement API endpoint
+- [ ] 1.3 Add frontend component
+- [ ] 1.4 Write tests
+```
+
+5. **Create design.md when needed:**
+Create `design.md` if any of the following apply; otherwise omit it:
+- Cross-cutting change (multiple services/modules) or a new architectural pattern
+- New external dependency or significant data model changes
+- Security, performance, or migration complexity
+- Ambiguity that benefits from technical decisions before coding
+
+Minimal `design.md` skeleton:
+```markdown
+## Context
+[Background, constraints, stakeholders]
+
+## Goals / Non-Goals
+- Goals: [...]
+- Non-Goals: [...]
+
+## Decisions
+- Decision: [What and why]
+- Alternatives considered: [Options + rationale]
+
+## Risks / Trade-offs
+- [Risk] → Mitigation
+
+## Migration Plan
+[Steps, rollback]
+
+## Open Questions
+- [...]
+```
+
+## Spec File Format
+
+### Critical: Scenario Formatting
+
+**CORRECT** (use #### headers):
+```markdown
+#### Scenario: User login success
+- **WHEN** valid credentials provided
+- **THEN** return JWT token
+```
+
+**WRONG** (don't use bullets or bold):
+```markdown
+- **Scenario: User login**  ❌
+**Scenario**: User login     ❌
+### Scenario: User login      ❌
+```
+
+Every requirement MUST have at least one scenario.
+
+### Requirement Wording
+- Use SHALL/MUST for normative requirements (avoid should/may unless intentionally non-normative)
+
+### Delta Operations
+
+- `## ADDED Requirements` - New capabilities
+- `## MODIFIED Requirements` - Changed behavior
+- `## REMOVED Requirements` - Deprecated features
+- `## RENAMED Requirements` - Name changes
+
+Headers matched with `trim(header)` - whitespace ignored.
+
+#### When to use ADDED vs MODIFIED
+- ADDED: Introduces a new capability or sub-capability that can stand alone as a requirement. Prefer ADDED when the change is orthogonal (e.g., adding "Slash Command Configuration") rather than altering the semantics of an existing requirement.
+- MODIFIED: Changes the behavior, scope, or acceptance criteria of an existing requirement. Always paste the full, updated requirement content (header + all scenarios). The archiver will replace the entire requirement with what you provide here; partial deltas will drop previous details.
+- RENAMED: Use when only the name changes. If you also change behavior, use RENAMED (name) plus MODIFIED (content) referencing the new name.
+
+Common pitfall: Using MODIFIED to add a new concern without including the previous text. This causes loss of detail at archive time. If you aren’t explicitly changing the existing requirement, add a new requirement under ADDED instead.
+
+Authoring a MODIFIED requirement correctly:
+1) Locate the existing requirement in `openspec/specs/<capability>/spec.md`.
+2) Copy the entire requirement block (from `### Requirement: ...` through its scenarios).
+3) Paste it under `## MODIFIED Requirements` and edit to reflect the new behavior.
+4) Ensure the header text matches exactly (whitespace-insensitive) and keep at least one `#### Scenario:`.
+
+Example for RENAMED:
+```markdown
+## RENAMED Requirements
+- FROM: `### Requirement: Login`
+- TO: `### Requirement: User Authentication`
+```
+
+## Troubleshooting
+
+### Common Errors
+
+**"Change must have at least one delta"**
+- Check `changes/[name]/specs/` exists with .md files
+- Verify files have operation prefixes (## ADDED Requirements)
+
+**"Requirement must have at least one scenario"**
+- Check scenarios use `#### Scenario:` format (4 hashtags)
+- Don't use bullet points or bold for scenario headers
+
+**Silent scenario parsing failures**
+- Exact format required: `#### Scenario: Name`
+- Debug with: `openspec show [change] --json --deltas-only`
+
+### Validation Tips
+
+```bash
+# Always use strict mode for comprehensive checks
+openspec validate [change] --strict
+
+# Debug delta parsing
+openspec show [change] --json | jq '.deltas'
+
+# Check specific requirement
+openspec show [spec] --json -r 1
+```
+
+## Happy Path Script
+
+```bash
+# 1) Explore current state
+openspec spec list --long
+openspec list
+# Optional full-text search:
+# rg -n "Requirement:|Scenario:" openspec/specs
+# rg -n "^#|Requirement:" openspec/changes
+
+# 2) Choose change id and scaffold
+CHANGE=add-two-factor-auth
+mkdir -p openspec/changes/$CHANGE/{specs/auth}
+printf "## Why\n...\n\n## What Changes\n- ...\n\n## Impact\n- ...\n" > openspec/changes/$CHANGE/proposal.md
+printf "## 1. Implementation\n- [ ] 1.1 ...\n" > openspec/changes/$CHANGE/tasks.md
+
+# 3) Add deltas (example)
+cat > openspec/changes/$CHANGE/specs/auth/spec.md << 'EOF'
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+Users MUST provide a second factor during login.
+
+#### Scenario: OTP required
+- **WHEN** valid credentials are provided
+- **THEN** an OTP challenge is required
+EOF
+
+# 4) Validate
+openspec validate $CHANGE --strict
+```
+
+## Multi-Capability Example
+
+```
+openspec/changes/add-2fa-notify/
+├── proposal.md
+├── tasks.md
+└── specs/
+    ├── auth/
+    │   └── spec.md   # ADDED: Two-Factor Authentication
+    └── notifications/
+        └── spec.md   # ADDED: OTP email notification
+```
+
+auth/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+...
+```
+
+notifications/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: OTP Email Notification
+...
+```
+
+## Best Practices
+
+### Simplicity First
+- Default to <100 lines of new code
+- Single-file implementations until proven insufficient
+- Avoid frameworks without clear justification
+- Choose boring, proven patterns
+
+### Complexity Triggers
+Only add complexity with:
+- Performance data showing current solution too slow
+- Concrete scale requirements (>1000 users, >100MB data)
+- Multiple proven use cases requiring abstraction
+
+### Clear References
+- Use `file.ts:42` format for code locations
+- Reference specs as `specs/auth/spec.md`
+- Link related changes and PRs
+
+### Capability Naming
+- Use verb-noun: `user-auth`, `payment-capture`
+- Single purpose per capability
+- 10-minute understandability rule
+- Split if description needs "AND"
+
+### Change ID Naming
+- Use kebab-case, short and descriptive: `add-two-factor-auth`
+- Prefer verb-led prefixes: `add-`, `update-`, `remove-`, `refactor-`
+- Ensure uniqueness; if taken, append `-2`, `-3`, etc.
+
+## Tool Selection Guide
+
+| Task | Tool | Why |
+|------|------|-----|
+| Find files by pattern | Glob | Fast pattern matching |
+| Search code content | Grep | Optimized regex search |
+| Read specific files | Read | Direct file access |
+| Explore unknown scope | Task | Multi-step investigation |
+
+## Error Recovery
+
+### Change Conflicts
+1. Run `openspec list` to see active changes
+2. Check for overlapping specs
+3. Coordinate with change owners
+4. Consider combining proposals
+
+### Validation Failures
+1. Run with `--strict` flag
+2. Check JSON output for details
+3. Verify spec file format
+4. Ensure scenarios properly formatted
+
+### Missing Context
+1. Read project.md first
+2. Check related specs
+3. Review recent archives
+4. Ask for clarification
+
+## Quick Reference
+
+### Stage Indicators
+- `changes/` - Proposed, not yet built
+- `specs/` - Built and deployed
+- `archive/` - Completed changes
+
+### File Purposes
+- `proposal.md` - Why and what
+- `tasks.md` - Implementation steps
+- `design.md` - Technical decisions
+- `spec.md` - Requirements and behavior
+
+### CLI Essentials
+```bash
+openspec list              # What's in progress?
+openspec show [item]       # View details
+openspec diff [change]     # What's changing?
+openspec validate --strict # Is it correct?
+openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
+```
+
+Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,152 @@
+# Project Context
+
+## Purpose
+Tidigit is an open source library powering productivity tools built at 21n.org to help 21st century digital humans manage their digital lives efficiently. The project includes three main products:
+- **Nucleus** - Digital harmony super app combining all tools below
+- **Memotron** - Memory atlas for personal knowledge management and note-taking
+- **Pointron** - Focus haven for goal tracking and time management
+
+All tools are designed for personal use without collaboration or team features.
+
+## Tech Stack
+
+### Core Technologies
+- **Frontend**: SvelteKit 2.x, Svelte 4.x, TypeScript 5.x
+- **Styling**: TailwindCSS 3.x, tailwindcss-themer
+- **Build System**: Turbo 2.x (monorepo orchestration), Vite 5.x
+- **Package Manager**: npm 10.x
+- **Testing**: Vitest 2.x, Playwright, Storybook 7.x
+
+### Key Libraries
+- **State Management**: Svelte stores, RxDB, SignalDB
+- **Database**: SurrealDB, Dexie (IndexedDB), LocalForage, OPFS
+- **Data Visualization**: D3.js, AntV G6, Carbon Charts
+- **Rich Text**: Monaco Editor, highlight.js
+- **AI/ML**: Hugging Face Transformers, Xenova Transformers
+- **Utilities**: dayjs, moment-timezone, clsx, FlexSearch
+
+### Workspace Structure
+- Monorepo with npm workspaces
+- `apps/*` - Product applications (nucleus, memotron, pointron, timear)
+- `client/*` - Shared client packages (components, elements, stores, utils, types, etc.)
+- `shared/*` - Code shared between client and server (types, utils, dbo)
+- `services/*` - Backend services
+- `extensions/*` - Browser extensions and other extensions
+- `tests/*` - Test files
+
+## Project Conventions
+
+### Code Style
+- **No inline comments** when generating or editing code - let code speak for itself
+- **Formatting**: Prettier with the following rules:
+  - Double quotes (`singleQuote: false`)
+  - Semicolons required (`semi: true`)
+  - Tab width: 2 spaces
+  - No trailing commas (`trailingComma: "none"`)
+  - Svelte sort order: options-scripts-markup-styles
+- **TypeScript**: 
+  - `strict: false` (lenient type checking)
+  - ESNext module resolution with bundler
+  - Module aliases: `@21n/*` for client packages, `@21n/shared-*` for shared packages
+
+### Naming Conventions
+- **Files**: kebab-case for regular files, PascalCase for Svelte components
+- **Components**: PascalCase (e.g., `AccountSettings.svelte`)
+- **Module aliases**: `@21n/actions`, `@21n/components`, `@21n/elements`, `@21n/stores`, `@21n/utils`, `@21n/types`, etc.
+- **Change IDs** (for OpenSpec): kebab-case with verb-led prefixes (`add-`, `update-`, `remove-`, `refactor-`)
+
+### Architecture Patterns
+- **Monorepo Architecture**: Turbo-powered workspace with shared packages
+- **Product Configuration**: Each product has `product.config.ts` defining app menus, settings, resources, and features
+- **Resource System**: Products work with typed resources (nodes, relations, goals, tasks, events, collections, combinations)
+- **Component Hierarchy**:
+  - `elements/` - Basic UI primitives
+  - `components/` - Complex, composed UI components
+  - `products/` - Product-specific implementations
+- **State Management**: Svelte stores with reactive patterns
+- **Database Layer**: 
+  - SurrealDB and SurrealDB WASM for structured data
+  - Dexie/LocalForage for local persistence
+  - OPFS for file storage
+
+### Testing Strategy
+- **Unit Tests**: Vitest for utility functions and business logic
+- **Component Tests**: Storybook for UI component development and testing
+- **E2E Tests**: Playwright for end-to-end testing
+- **Test Commands**:
+  - `npm run test` - Run all tests via Turbo
+  - `npm run test:watch` - Watch mode for individual apps
+  - `npm run typecheck` - TypeScript type checking with svelte-check
+  - `npm run lint` - ESLint checks
+- **Test Files**: `*.test.ts`, `*.test.js` patterns
+
+### Git Workflow
+- **Branching**: Feature branches from main (`feature/your-feature-name`)
+- **Commits**: Conventional commit messages encouraged
+- **Pull Requests**: 
+  - PRs reviewed by automated tools (Sourcery AI, CodeRabbit AI, Typo-app, Cubic AI)
+  - Must address ALL review comments (including from automated reviewers)
+  - Use `gh pr view <number>` to fetch PR details
+- **Pre-commit Hooks**: Managed via lefthook.yml
+- **CI/CD**: GitHub Actions workflows (see `.github/workflows/`)
+
+## Domain Context
+
+### Product Domains
+- **Knowledge Management (Memotron)**: Notes, nodes, relations, collections, tags, markdown editing, PDF annotation, web clipping
+- **Time Management (Pointron)**: Goals, tasks, events, time tracking, focus sessions, calendar integration
+- **Personal Productivity**: Resource management, cross-linking, search, filtering, visualization
+
+### Key Concepts
+- **Resources**: Core data entities (nodes, relations, goals, tasks, events, collections)
+- **DBO (Database Objects)**: Defined in `shared/dbo/` for each product (memotron.dbo.ts, pointron.dbo.ts, global.dbo.ts)
+- **Combinations**: Aggregated views of multiple resource types
+- **Extensions**: Pluggable functionality (browser extensions, web clippers)
+
+### Data Flow
+- Local-first architecture with optional cloud sync
+- Client-side databases (IndexedDB, OPFS)
+- Future: Cloudflare Workers + D1 + R2 for backend
+
+## Important Constraints
+
+### Technical Constraints
+- Browser compatibility required (modern browsers)
+- Offline-first capability essential
+- Performance: Large datasets (>100MB), complex graphs
+- Memory management: Node.js builds use `--max-old-space-size=8192`
+- Self-hosting: Frontend deployable independently from backend
+
+### Licensing
+- **License**: AGPL-3.0
+- All contributions must be AGPL-3.0 compatible
+
+### Development Constraints
+- No inline comments in generated/edited code
+- Must fix ALL PR review issues (human and AI reviewers)
+- Use temporary directories for tooling (e.g., `/tmp/`) not project root
+
+## External Dependencies
+
+### CDN Services
+- Static assets served from `https://cdn.21n.org` (configurable via `VITE_STATIC_URL`)
+
+### Third-party Services
+- **Analytics**: Vercel Analytics, PostHog
+- **Error Tracking**: Sentry (Memotron)
+- **Authentication**: OIDC (oidc-client-ts)
+- **Maps**: MapLibre GL
+
+### Build & Deploy
+- **Platforms**: Vercel (primary), self-hosting supported
+- **Environment Variables**:
+  - `VITE_PRODUCT`: Product name (memotron | pointron | nucleus)
+  - `VITE_STATIC_URL`: Static asset CDN URL
+  - `VITE_BUILD_DATE`: Build date stamp
+  - `NODE_ENV`: Environment (development | production)
+
+### Development Tools
+- **Version Control**: Git, GitHub
+- **CLI Tools**: gh (GitHub CLI) for PR operations
+- **Browser Automation**: Playwright/Puppeteer for scraping/testing
+- **Package Registry**: npm registry


### PR DESCRIPTION
## Summary by Sourcery

Initialize spec-driven development infrastructure by adding OpenSpec and Conduct frameworks, AI agent instructions, and command templates, along with a sample rigorous testing specification.

New Features:
- Add OpenSpec framework with specification scaffolding: openspec/AGENTS.md, project.md, and CLI templates for proposal, apply, and archive workflows
- Introduce Conduct framework with conduct/AGENTS.md, spec.v0.md, track.json, and agent command templates for feature and change management
- Add a Rigorous Testing Initiative spec and Testing Robustness Roadmap plan to standardize testing practices across the project

Documentation:
- Update AGENTS.md, WARP.md, and CLAUDE.md with OpenSpec and Conduct usage instructions
- Add command templates under .claude, .cursor, .factory, .warp, .opencode, and .github directories for conduct-feature, conduct-change, and OpenSpec commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added feature and change management workflows for project development.
  * Added specification-driven development guide and best practices.
  * Added comprehensive testing strategy roadmap with phased implementation plan.
  * Added project architecture and workspace reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->