### PR TITLE
pipeline build fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Run unified test suite
         run: npm run test
       - name: Upload coverage to Codecov
@@ -58,7 +58,7 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
         working-directory: apps/e2e-playwright

--- a/.github/workflows/turbo-deploy.yml
+++ b/.github/workflows/turbo-deploy.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           cd ../../
           rm -rf node_modules package-lock.json
-          npm install
+          npm install --legacy-peer-deps
 
       - name: Set dynamic secret names
         run: |
@@ -191,13 +191,13 @@ jobs:
         working-directory: ./deployment
         run: |
           rm -rf node_modules package-lock.json
-          npm install
+          npm install --legacy-peer-deps
 
       - name: Install CDK client dependencies
         working-directory: ./deployment/cdk/client
         run: |
           rm -rf node_modules package-lock.json
-          npm install && npm run build
+          npm install --legacy-peer-deps && npm run build
 
       - name: Set CDK environment variables with fallback
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch npm install commands in deploy and test workflows to use --legacy-peer-deps to avoid peer dependency conflicts during CI runs.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes failing CI builds by using npm install --legacy-peer-deps in test and deploy workflows. Resolves peer dependency conflicts to unblock tests and deployments.

- **Bug Fixes**
  - tests.yml: use --legacy-peer-deps for root and E2E installs.
  - turbo-deploy.yml: use --legacy-peer-deps for root, deployment, and cdk/client installs (build runs after install).

<sup>Written for commit cd43bafa9ec32aaf1fee0bd8a1776279586f4e29. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

