### PR TITLE
Creation & Browse flows

### DIFF
--- a/apps/e2e-playwright/.env.example
+++ b/apps/e2e-playwright/.env.example
@@ -1,1 +1,1 @@
-APP_BASE_URL=https://local.nucleus.to
+APP_BASE_URL=https://local.nucleum.app

--- a/apps/e2e-playwright/README.md
+++ b/apps/e2e-playwright/README.md
@@ -1,13 +1,13 @@
 # E2E tests (Playwright)
 
-End-to-end tests for Nucleus and its products (Pointron, Memotron).
+End-to-end tests for Nucleum and its products (Pointron, Memotron).
 
 ## Running tests
 
 **By product:**
 
 ```bash
-npx playwright test --project nucleus
+npx playwright test --project nucleum
 npx playwright test --project pointron
 npx playwright test --project memotron
 ```
@@ -28,33 +28,20 @@ npx playwright test
 
 ## Auth and session
 
-Tests can use a saved session so you don’t log in every run.
 
-- **Saved state (per product):** `.auth/user.json` (Nucleus), `.auth/user-memotron.json` (Memotron), `.auth/user-pointron.json` (Pointron). The `.auth/` folder is gitignored.
-- **Base URL:** Set in `.env`: `APP_BASE_URL` (default), or `APP_BASE_URL_NUCLEUS`, `APP_BASE_URL_MEMOTRON`, `APP_BASE_URL_POINTRON` per project (e.g. `https://local.memotron.app`). If a saved auth file exists, the config can auto-adjust the project base URL to match the saved origin.
+- **Login (recommended):** Set in `.env`: `E2E_LOGIN_EMAIL` and `E2E_LOGIN_PASSWORD`. Tests will log in at the start of each run. In CI, set these as secrets.
+- **Base URL:** Set in `.env`: `APP_BASE_URL` (default), or `APP_BASE_URL_NUCLEUM`, `APP_BASE_URL_MEMOTRON`, `APP_BASE_URL_POINTRON` per project (e.g. `https://local.nucleum.app`).
+- **Fallback:** If login env vars are not set, tests use "Continue offline" to reach the app.
 
-**First time or when the session expires (per product):**
-
-| Product   | Command |
-|-----------|---------|
-| Nucleus   | `npm run e2e:save-auth:nucleus` (or set `APP_BASE_URL=https://local.nucleus.to` and run `npm run e2e:save-auth`) |
-| Memotron  | `npm run e2e:save-auth:memotron` |
-| Pointron  | `npm run e2e:save-auth:pointron` |
-
-1. Run the command for the product you want. A browser opens at that product's login page.
-2. Complete Google sign-in once. When you’re back on the app, the script saves the session to that product's auth file.
-3. Run tests: `npx playwright test --project=memotron` (etc.).
-
-If you see a login screen or “Embed token: false” during tests, the session may have expired or the base URL may not match the saved origin. Run the save-auth script again for that product, then re-run the tests.
 
 ## Structure
 
 - **`tests/shared/`** – Overlapping features (run by one or more products):
   - **`navigation.spec.ts`** – Auth and nav (all products)
-  - **`focus/`** – Goals and tasks (Pointron, Nucleus)
-  - **`memory/`** – Capture and nodes (Memotron, Nucleus)
+  - **`focus/`** – Goals and tasks (Pointron, Nucleum)
+  - **`memory/`** – Capture and nodes (Memotron, Nucleum)
   - **`calendar/`**, **`overview/`**, **`collection/`** – Calendar, Overview, Library (all products)
-- **`tests/nucleus/`** – Nucleus-only: app shell (nav), Settings
+- **`tests/nucleum/`** – Nucleum-only: app shell (nav), Settings
 - **`tests/pointron/`**, **`tests/memotron/`** – Product-only specs (app nav, settings per product)
 - **`tests/smoke/`** – Smoke (e.g. home load)
 - **`tests/utils/`** – Shared helpers

--- a/apps/e2e-playwright/package.json
+++ b/apps/e2e-playwright/package.json
@@ -1,6 +1,6 @@
-{"name":"e2e-playwright","private":true,"scripts":{"test":"playwright test","test:smoke":"playwright test --project=nucleus --grep @smoke","test:regression":"playwright test --grep @regression","test:ci":"playwright test --reporter=line",
+{"name":"e2e-playwright","private":true,"scripts":{"test":"playwright test","test:smoke":"playwright test --project=nucleum --grep @smoke","test:regression":"playwright test --grep @regression","test:ci":"playwright test --reporter=line",
     "e2e:save-auth":"npx tsx scripts/save-google-auth-state.ts",
-    "e2e:save-auth:nucleus":"PRODUCT=nucleus APP_BASE_URL=https://local.nucleus.to npx tsx scripts/save-google-auth-state.ts",
+    "e2e:save-auth:nucleum":"PRODUCT=nucleum APP_BASE_URL=https://local.nucleum.app npx tsx scripts/save-google-auth-state.ts",
     "e2e:save-auth:memotron":"PRODUCT=memotron APP_BASE_URL=https://local.memotron.app npx tsx scripts/save-google-auth-state.ts",
     "e2e:save-auth:pointron":"PRODUCT=pointron APP_BASE_URL=https://local.pointron.app npx tsx scripts/save-google-auth-state.ts"},"dependencies":{"@21n/products":"*"},"devDependencies":{"@21n/components":"*","@21n/types":"*","@playwright/test":"^1.49.0","@types/node":"^22.0.0","dotenv":"^16.4.5",
     "tsx":"^4.19.0"}

--- a/apps/e2e-playwright/playwright.config.ts
+++ b/apps/e2e-playwright/playwright.config.ts
@@ -1,11 +1,9 @@
 import { devices, defineConfig } from "@playwright/test";
 import path from "node:path";
-import fs from "node:fs";
 
 import "dotenv/config";
 
 const artifactsDir = path.join(__dirname, "artifacts");
-const authDir = path.resolve(__dirname, ".auth");
 
 const defaultBaseURL = process.env.APP_BASE_URL ?? "http://127.0.0.1:4173";
 
@@ -14,49 +12,15 @@ function getProjectBaseURL(projectName: string): string {
   return (process.env[envKey] ?? process.env.APP_BASE_URL) ?? defaultBaseURL;
 }
 
-function getAuthPath(projectName: string): string {
-  const file = projectName === "nucleus" ? "user.json" : `user-${projectName}.json`;
-  return path.join(authDir, file);
-}
-
-function resolveBaseURLWithAuth(projectName: string): string {
-  const envKey = `APP_BASE_URL_${projectName.toUpperCase()}`;
-  const explicitEnvURL = process.env[envKey] ?? process.env.APP_BASE_URL;
-  let baseURL = getProjectBaseURL(projectName);
-  const authPath = getAuthPath(projectName);
-  if (!fs.existsSync(authPath)) return baseURL;
-  try {
-    const raw = fs.readFileSync(authPath, "utf-8");
-    const state = JSON.parse(raw) as { origins?: Array<{ origin: string }> };
-    const savedOrigins = state.origins?.map((o) => o.origin) ?? [];
-    const currentOrigin = new URL(baseURL).origin;
-    if (savedOrigins.length > 0 && !savedOrigins.includes(currentOrigin)) {
-      if (!explicitEnvURL) {
-        baseURL = savedOrigins[0];
-      } else {
-        console.warn(
-          `[e2e] ${projectName}: saved auth origins (${savedOrigins.join(", ")}) do not match configured baseURL (${baseURL}). Re-run e2e:save-auth:${projectName} or update ${envKey}.`
-        );
-      }
-    }
-  } catch (err) {
-    console.warn(`[e2e] ${projectName}: could not read auth file ${authPath}:`, err);
-  }
-  return baseURL;
-}
-
 function getProjectUse(projectName: string) {
-  const baseURL = resolveBaseURLWithAuth(projectName);
-  const authPath = getAuthPath(projectName);
-  const useAuth = fs.existsSync(authPath);
+  const baseURL = getProjectBaseURL(projectName);
   return {
     ...devices["Desktop Chrome"],
     viewport: { width: 1280, height: 720 },
     video: "on" as const,
     trace: "on-first-retry" as const,
     screenshot: "only-on-failure" as const,
-    baseURL,
-    ...(useAuth ? { storageState: authPath } : {})
+    baseURL
   };
 }
 
@@ -98,15 +62,15 @@ export default defineConfig({
   },
   projects: [
     {
-      name: "nucleus",
+      name: "nucleum",
       testMatch: [
         "tests/smoke/**/*.spec.ts",
         "tests/shared/**/*.spec.ts",
-        "tests/nucleus/**/*.spec.ts"
+        "tests/nucleum/**/*.spec.ts"
       ],
       retries: 1,
       workers: 1,
-      use: getProjectUse("nucleus")
+      use: getProjectUse("nucleum")
     },
     {
       name: "pointron",

--- a/apps/e2e-playwright/scripts/save-google-auth-state.ts
+++ b/apps/e2e-playwright/scripts/save-google-auth-state.ts
@@ -3,7 +3,7 @@
  * Any next screen (e.g. signup, "Continue offline") is handled in the test only.
  *
  * Run:
- *   Nucleus:  npm run e2e:save-auth:nucleus   (or APP_BASE_URL=https://local.nucleus.to npm run e2e:save-auth)
+ *   Nucleum:  npm run e2e:save-auth:nucleum   (or APP_BASE_URL=https://local.nucleum.app npm run e2e:save-auth)
  *   Memotron: npm run e2e:save-auth:memotron  (or PRODUCT=memotron APP_BASE_URL=https://local.memotron.app npm run e2e:save-auth)
  *   Pointron: npm run e2e:save-auth:pointron   (or PRODUCT=pointron APP_BASE_URL=https://local.pointron.app npm run e2e:save-auth)
  */
@@ -14,8 +14,8 @@ import path from "node:path";
 import fs from "node:fs";
 
 const authDir = path.join(__dirname, "..", ".auth");
-const product = (process.env.PRODUCT ?? "nucleus").toLowerCase();
-const authFileName = product === "nucleus" ? "user.json" : `user-${product}.json`;
+const product = (process.env.PRODUCT ?? "nucleum").toLowerCase();
+const authFileName = product === "nucleum" ? "user.json" : `user-${product}.json`;
 const authStatePath = path.join(authDir, authFileName);
 const baseURL = process.env.APP_BASE_URL ?? "http://127.0.0.1:4173";
 const waitForRedirectBackMs = 120_000;
@@ -25,10 +25,10 @@ const baseHost = new URL(baseURL).host;
 const allowedOrigins = [
   baseOrigin,
   baseOrigin.startsWith("http:") ? `https://${baseHost}` : `http://${baseHost}`,
-  "https://dev.nucleus.to",
-  "http://dev.nucleus.to",
-  "https://local.nucleus.to",
-  "http://local.nucleus.to",
+  "https://dev.nucleum.app",
+  "http://dev.nucleum.app",
+  "https://local.nucleum.app",
+  "http://local.nucleum.app",
   "https://local.memotron.app",
   "http://local.memotron.app",
   "https://dev.memotron.to",

--- a/apps/e2e-playwright/tests/nucleum/app-nav.spec.ts
+++ b/apps/e2e-playwright/tests/nucleum/app-nav.spec.ts
@@ -11,7 +11,8 @@ test.skip(
   "E2E suite disabled by environment"
 );
 
-test.describe("nucleus - app layout and menu @regression", () => {
+test.describe("nucleum – app layout and menu @regression", () => {
+  test.describe.configure({ timeout: 90_000 });
   test.beforeEach(async ({ page }) => {
     await page.route("**/*", (route) => {
       const reqUrl = route.request().url();
@@ -26,7 +27,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Logs via command bar (See Logs), then assert Logs view visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
     await runCommand(page, "See Logs");
     await expect(page.getByText("Logs").first()).toBeVisible({
@@ -37,7 +37,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Logs via UI (Calendar → Activity → Focus), then assert Logs view visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     await page
@@ -87,7 +86,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Overview via command bar (Overview), then assert Overview page visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
     await runCommand(page, "Overview");
 
@@ -104,7 +102,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Overview via UI (click Overview in left nav), then assert Overview page visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     await page
@@ -125,7 +122,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Library via command bar (Library), then assert Library and Goals list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     await runCommand(page, "Library");
@@ -166,7 +162,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Library via command bar (Goals), then assert Goals list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
     await runCommand(page, "Goals");
     await expect(page.getByTestId("search-goals")).toBeVisible({
@@ -177,7 +172,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Library via command bar (Tasks), then assert Tasks list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
     await runCommand(page, "Tasks");
     await expect(
@@ -192,7 +186,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Library via UI (click Library in nav, then Goals), then assert Goals list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     const libraryPath = nucleusProductConfig.pathByNavLabel.Library;
@@ -216,7 +209,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Goals via side nav (pin Goals in menu settings, then click Goals), then assert Goals list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     await page.getByTestId("leftnav-settings").click({ timeout: 5_000 });
@@ -252,7 +244,6 @@ test.describe("nucleus - app layout and menu @regression", () => {
   test("open Library via UI (click Library in nav, then Tasks), then assert Tasks list visible", async ({
     page
   }) => {
-    test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
     const libraryPath = nucleusProductConfig.pathByNavLabel.Library;

--- a/apps/e2e-playwright/tests/nucleum/settings/settings.spec.ts
+++ b/apps/e2e-playwright/tests/nucleum/settings/settings.spec.ts
@@ -10,8 +10,8 @@ test.skip(
   "E2E suite disabled by environment"
 );
 
-/** Nucleus-only settings: footer app version. Open/close/navigate and Mode of interaction are in shared/settings. */
-test.describe("nucleus - settings (product-specific) @regression", () => {
+/** Nucleum-only settings: footer app version. Open/close/navigate and Mode of interaction are in shared/settings. */
+test.describe("nucleum – settings (product-specific) @regression", () => {
   test.beforeEach(async ({ page }) => {
     await page.route("**/*", (route) => {
       const reqUrl = route.request().url();
@@ -31,7 +31,7 @@ test.describe("nucleus - settings (product-specific) @regression", () => {
     await page.waitForTimeout(500);
   }
 
-  test("Settings footer shows app version (Nucleus)", async ({ page }) => {
+  test("Settings footer shows app version (Nucleum)", async ({ page }) => {
     test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
@@ -40,7 +40,7 @@ test.describe("nucleus - settings (product-specific) @regression", () => {
       timeout: 10_000
     });
 
-    await expect(page.getByText(/Nucleus\s+v?[\d.]+/i).first()).toBeVisible({
+    await expect(page.getByText(/Nucleum\s+v?[\d.]+/i).first()).toBeVisible({
       timeout: 5_000
     });
   });

--- a/apps/e2e-playwright/tests/pointron/app-nav.spec.ts
+++ b/apps/e2e-playwright/tests/pointron/app-nav.spec.ts
@@ -82,7 +82,7 @@ test.describe("pointron - app layout and menu @regression", () => {
     await runCommand(page, "Library");
 
     const goalsCard = page
-      .getByRole("button", { name: /^Goals(\s+\d+)?$/i })
+      .getByRole("button", { name: /^(Goals|Objectives)(\s+\d+)?$/i })
       .and(page.locator(":not([aria-disabled='true'])"));
     await goalsCard.first().waitFor({ state: "visible", timeout: 10_000 });
     await goalsCard.first().click({ timeout: 5_000 });
@@ -100,7 +100,9 @@ test.describe("pointron - app layout and menu @regression", () => {
           new RegExp(`^${libraryPath}(\\/.*)?$`).test(new URL(u).pathname),
         { timeout: 15_000 }
       );
-      const goalsBtn = page.getByRole("button", { name: /^Goals(\s+\d+)?$/i }).first();
+      const goalsBtn = page
+        .getByRole("button", { name: /^(Goals|Objectives)(\s+\d+)?$/i })
+        .first();
       await goalsBtn.waitFor({ state: "visible", timeout: 15_000 });
       await goalsBtn.click({ timeout: 5_000 });
       await page.waitForTimeout(600);
@@ -128,9 +130,12 @@ test.describe("pointron - app layout and menu @regression", () => {
       (u) => new RegExp(`^${libraryPath}(\\/.*)?$`).test(new URL(u).pathname),
       { timeout: 10_000 }
     );
-    await page.getByRole("button", { name: /^Goals(\s+\d+)?$/i }).first().click({
-      timeout: 5_000
-    });
+    await page
+      .getByRole("button", { name: /^(Goals|Objectives)(\s+\d+)?$/i })
+      .first()
+      .click({
+        timeout: 5_000
+      });
     await expect(page.getByTestId("search-goals")).toBeVisible({
       timeout: 10_000
     });

--- a/apps/e2e-playwright/tests/shared/collection/collection.spec.ts
+++ b/apps/e2e-playwright/tests/shared/collection/collection.spec.ts
@@ -1,5 +1,10 @@
-import { test } from "@playwright/test";
-import { ensureInAppOnHome } from "../../utils/helpers";
+import { test, expect } from "@playwright/test";
+import {
+  ensureInAppOnHome,
+  runCommand,
+  openLibraryAndTab,
+  LibraryTab
+} from "../../utils/helpers";
 
 const runtimeEnv = (
   globalThis as { process?: { env?: Record<string, string | undefined> } }
@@ -19,8 +24,78 @@ test.describe("collection - all workflows @regression", () => {
     });
   });
 
+  test("create collection via command bar, then verify in Library", async ({
+    page
+  }) => {
+    test.setTimeout(120_000);
+    await ensureInAppOnHome(page);
+
+    const collectionName = `E2E collection cmd ${Date.now()}`;
+    await runCommand(page, "Create a new collection");
+    const titleInput = page.getByPlaceholder("Name of the collection");
+    await titleInput.waitFor({ state: "visible", timeout: 15_000 });
+    await titleInput.fill(collectionName);
+    await page.waitForLoadState("domcontentloaded").catch(() => null);
+    const modal = page.locator("#collection_create");
+    const saveBtn = modal.getByRole("button", { name: /Save.*Enter/i });
+    await saveBtn.click({ timeout: 5_000 });
+    await titleInput.waitFor({ state: "hidden", timeout: 10_000 }).catch(() => null);
+
+    await openLibraryAndTab(page, LibraryTab.Collections);
+    await expect(
+      page.getByText(collectionName, { exact: true }).first()
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("create collection via UI (Library -> Collections -> New collection), then verify in Library", async ({
+    page
+  }) => {
+    test.setTimeout(120_000);
+    await ensureInAppOnHome(page);
+
+    const collectionName = `E2E collection UI ${Date.now()}`;
+    await openLibraryAndTab(page, LibraryTab.Collections);
+
+    const newCollectionBtn = page
+      .getByRole("button", { name: /New collection|Create a new collection/i })
+      .first();
+    await newCollectionBtn.click({ timeout: 10_000 });
+
+    const titleInput = page.getByPlaceholder("Name of the collection");
+    await titleInput.waitFor({ state: "visible", timeout: 15_000 });
+    await titleInput.fill(collectionName);
+    await page.waitForLoadState("domcontentloaded").catch(() => null);
+    const modal = page.locator("#collection_create");
+    const saveBtn = modal.getByRole("button", { name: /Save.*Enter/i });
+    await saveBtn.click({ timeout: 5_000 });
+    await titleInput.waitFor({ state: "hidden", timeout: 10_000 }).catch(() => null);
+
+    await expect(
+      page.getByText(collectionName, { exact: true }).first()
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test.describe("browse from library", () => {
+    test("open Library → Collections and see collections list", async ({
+      page
+    }) => {
+      test.setTimeout(120_000);
+      await ensureInAppOnHome(page);
+      await openLibraryAndTab(page, LibraryTab.Collections);
+      const recordsContainer = page.locator("#records-container");
+      await expect(recordsContainer).toBeVisible({ timeout: 15_000 });
+    });
+  });
+
+  test.describe("browse from pinned resource browser", () => {
+    test.skip("browse collections from pinned", async ({ page }) => {
+      await ensureInAppOnHome(page);
+      // No dedicated "pinned collections" list in app; collections can be pinned to app menu (product-specific). N/A.
+    });
+  });
+
   test.skip("collection workflows", async ({ page }) => {
     await ensureInAppOnHome(page);
-    // TODO: collection create, browse, edit, etc.
+    // TODO: collection browse, edit, etc.
   });
 });

--- a/apps/e2e-playwright/tests/shared/focus/goal/browse.spec.ts
+++ b/apps/e2e-playwright/tests/shared/focus/goal/browse.spec.ts
@@ -28,7 +28,7 @@ test.describe("goal - browse flows @regression", () => {
 
   test.describe("from library", () => {
     test("open Library → Goals and see goal in list", async ({ page }, testInfo) => {
-      test.setTimeout(60_000);
+      test.setTimeout(120_000);
       await ensureInAppOnHome(page);
       const productConfig = getProductConfig(testInfo.project.name);
       const libraryPath = productConfig.pathByNavLabel.Library;
@@ -42,11 +42,28 @@ test.describe("goal - browse flows @regression", () => {
       await page.keyboard.press("Escape");
       await page.keyboard.press("Escape");
 
-      await page.getByRole("button", { name: /^Library$/i }).click({ timeout: 5_000 });
-      await page.waitForURL((u) => new RegExp(`^${libraryPath}(\\/.*)?$`).test(new URL(u).pathname), { timeout: 10_000 });
-      await page.getByRole("button", { name: /^Goals(\s+\d+)?$/i }).first().click({ timeout: 5_000 });
+      const libraryBtn = page.getByRole("button", { name: /^Library$/i }).first();
+      await libraryBtn.waitFor({ state: "visible", timeout: 10_000 });
+      await libraryBtn.click({ timeout: 5_000 });
+      // Wait for Library panel to appear – search box label differs by tab:
+      // "Search collections" for Collections, "Search goals" for Goals/Objectives.
+      await expect(
+        page
+          .getByRole("textbox", { name: /Search (collections|goals)/ })
+          .first()
+      ).toBeVisible({ timeout: 15_000 });
+      await page
+        .getByRole("button", { name: /^(Goals|Objectives)(\s+\d+)?$/i })
+        .first()
+        .click({ timeout: 5_000 });
       await page.waitForTimeout(1_500);
-      await expect(page.getByText(goalName, { exact: true }).first()).toBeVisible({ timeout: 15_000 });
+      // In Pointron, the goal row text includes status (e.g. "Not started"),
+      // so we match on a button containing the goalName rather than exact text.
+      const goalRow = page
+        .getByRole("button")
+        .filter({ hasText: goalName })
+        .first();
+      await expect(goalRow).toBeVisible({ timeout: 15_000 });
     });
   });
 
@@ -105,18 +122,18 @@ test.describe("goal - browse flows @regression", () => {
 
       const goalName = `E2E pin UI ${Date.now()}`;
 
-      const productConfig = getProductConfig(testInfo.project.name);
-      const libraryPath = productConfig.pathByNavLabel.Library;
+      const libraryBtn = page.getByRole("button", { name: /^Library$/i }).first();
+      await libraryBtn.waitFor({ state: "visible", timeout: 10_000 });
+      await libraryBtn.click({ timeout: 5_000 });
+      await expect(
+        page.getByRole("textbox", { name: /Search (collections|goals)/ }).first()
+      ).toBeVisible({ timeout: 15_000 });
       await page
-        .getByRole("button", { name: /^Library$/i })
-        .click({ timeout: 5_000 });
-      await page.waitForURL(
-        (u) => new RegExp(`^${libraryPath}(\\/.*)?$`).test(new URL(u).pathname),
-        { timeout: 10_000 }
-      );
-      await page.getByRole("button", { name: /^Goals(\s+\d+)?$/i }).first().click({
-        timeout: 5_000
-      });
+        .getByRole("button", { name: /^(Goals|Objectives)(\s+\d+)?$/i })
+        .first()
+        .click({
+          timeout: 5_000
+        });
       await page.waitForTimeout(500);
 
       const newGoalBtn = page.getByRole("button", { name: /New goal/i }).first();

--- a/apps/e2e-playwright/tests/shared/focus/goal/context-menu.spec.ts
+++ b/apps/e2e-playwright/tests/shared/focus/goal/context-menu.spec.ts
@@ -285,7 +285,7 @@ test.describe("goal – context menu (all actions) @regression", () => {
         await page.waitForTimeout(500);
       }
 
-      // Pointron has Quick Focus panel (quick-focus-search); Nucleus does not.
+      // Pointron has Quick Focus panel (quick-focus-search); Nucleum does not.
       // Navigate to Focus view via nav button so Quick Start panel with quick-focus-search is visible.
       const isPointron = testInfo.project.name === "pointron";
       if (isPointron) {
@@ -306,7 +306,7 @@ test.describe("goal – context menu (all actions) @regression", () => {
         await dismissAnyModals(page);
         await navigateToLibraryGoals(page);
       } else {
-        // Nucleus: just verify pin state by unpinning via context menu
+        // Nucleum: just verify pin state by unpinning via context menu
         await navigateToLibraryGoals(page);
       }
 

--- a/apps/e2e-playwright/tests/shared/focus/task/browse.spec.ts
+++ b/apps/e2e-playwright/tests/shared/focus/task/browse.spec.ts
@@ -1,5 +1,10 @@
-import { test } from "@playwright/test";
-import { ensureInAppOnHome } from "../../../utils/helpers";
+import { test, expect } from "@playwright/test";
+import {
+  ensureInAppOnHome,
+  runCommand,
+  openLibraryAndTab,
+  LibraryTab
+} from "../../../utils/helpers";
 
 const runtimeEnv = (
   globalThis as { process?: { env?: Record<string, string | undefined> } }
@@ -20,16 +25,33 @@ test.describe("task - browse flows @regression", () => {
   });
 
   test.describe("from library", () => {
-    test.skip("open Library → Tasks and see task in list", async ({ page }) => {
+    test("open Library → Tasks and see task in list", async ({ page }) => {
+      test.setTimeout(120_000);
       await ensureInAppOnHome(page);
-      // TODO: create task, open Library → Tasks, assert task visible
+
+      const taskName = `E2E browse task ${Date.now()}`;
+      await runCommand(page, "Create a new task");
+      const taskNameInput = page.getByTestId("task-name-input");
+      await taskNameInput.waitFor({ state: "visible", timeout: 15_000 });
+      await taskNameInput.fill(taskName);
+      await page.keyboard.press("Enter");
+      await taskNameInput
+        .waitFor({ state: "hidden", timeout: 5_000 })
+        .catch(() => null);
+      await page.keyboard.press("Escape").catch(() => null);
+      await page.waitForTimeout(500);
+
+      await openLibraryAndTab(page, LibraryTab.Tasks);
+      await expect(
+        page.getByRole("button", { name: taskName }).first()
+      ).toBeVisible({ timeout: 15_000 });
     });
   });
 
   test.describe("from pinned resource browser", () => {
     test.skip("pin task and see in pinned list", async ({ page }) => {
       await ensureInAppOnHome(page);
-      // TODO: pin task to quick focus (if supported), assert in pinned list
+      // App supports "Pin a goal to quick focus" only; tasks are not pinnable to a quick-focus list. N/A.
     });
   });
 });

--- a/apps/e2e-playwright/tests/shared/memory/node/browse.spec.ts
+++ b/apps/e2e-playwright/tests/shared/memory/node/browse.spec.ts
@@ -1,5 +1,9 @@
-import { test } from "@playwright/test";
-import { ensureInAppOnHome } from "../../../utils/helpers";
+import { test, expect } from "@playwright/test";
+import {
+  ensureInAppOnHome,
+  openLibraryAndTab,
+  LibraryTab
+} from "../../../utils/helpers";
 
 const runtimeEnv = (
   globalThis as { process?: { env?: Record<string, string | undefined> } }
@@ -19,13 +23,20 @@ test.describe("node - browse flows (from library, from pinned) @regression", () 
     });
   });
 
-  test.skip("browse nodes from library", async ({ page }) => {
-    await ensureInAppOnHome(page);
-    // TODO
+  test.describe("from library", () => {
+    test("open Library → Nodes and see nodes list", async ({ page }) => {
+      test.setTimeout(120_000);
+      await ensureInAppOnHome(page);
+      await openLibraryAndTab(page, LibraryTab.Nodes);
+      const recordsContainer = page.locator("#records-container");
+      await expect(recordsContainer).toBeVisible({ timeout: 15_000 });
+    });
   });
 
-  test.skip("browse nodes from pinned resource browser", async ({ page }) => {
-    await ensureInAppOnHome(page);
-    // TODO
+  test.describe("from pinned resource browser", () => {
+    test.skip("browse nodes from pinned resource browser", async ({ page }) => {
+      await ensureInAppOnHome(page);
+      // Pinned resource browser (app menu) shows pinned library sections; no dedicated "pinned nodes" list like Quick Focus for goals. N/A or product-specific.
+    });
   });
 });

--- a/apps/e2e-playwright/tests/shared/memory/node/creation.spec.ts
+++ b/apps/e2e-playwright/tests/shared/memory/node/creation.spec.ts
@@ -1,5 +1,10 @@
-import { test } from "@playwright/test";
-import { ensureInAppOnHome } from "../../../utils/helpers";
+import { test, expect } from "@playwright/test";
+import {
+  ensureInAppOnHome,
+  runCommand,
+  openLibraryAndTab,
+  LibraryTab
+} from "../../../utils/helpers";
 
 const runtimeEnv = (
   globalThis as { process?: { env?: Record<string, string | undefined> } }
@@ -19,11 +24,91 @@ test.describe("node - creation flows @regression", () => {
     });
   });
 
-  test.skip("create node via command bar", async ({ page }) => {
+  test("create node via command bar", async ({ page }) => {
+    test.setTimeout(60_000);
     await ensureInAppOnHome(page);
+
+    const nodeText = `E2E node cmd ${Date.now()}`;
+    await runCommand(page, "Capture");
+
+    const editor = page
+      .getByTestId("capture-editor")
+      .getByPlaceholder("Start typing to capture...")
+      .or(
+        page
+          .getByTestId("capture-editor")
+          .getByRole("textbox", { name: /Markdown editor|Start typing/i })
+      )
+      .first();
+    const markdownBtn = page.getByRole("button", { name: /^Markdown$/i }).first();
+    const editorVisible = await editor.isVisible().catch(() => false);
+    if (!editorVisible) {
+      await markdownBtn.click({ timeout: 5_000 });
+      await page.waitForTimeout(800);
+    }
+    await editor.waitFor({ state: "visible", timeout: 8_000 });
+    await editor.click();
+    await page.keyboard.type(nodeText, { delay: 50 });
+    await page.waitForTimeout(300);
+
+    const saveBtn = page
+      .getByTestId("capture-save-button")
+      .or(page.getByRole("button", { name: /^Save$/i }));
+    await saveBtn.first().click({ timeout: 5_000 });
+    await page.waitForTimeout(1_500);
+    const closeBtn = page.getByRole("button", { name: "Close" });
+    await closeBtn.click({ timeout: 5_000 });
+    await page.waitForTimeout(800);
+
+    await openLibraryAndTab(page, LibraryTab.Nodes);
+    await expect(
+      page.getByText(nodeText, { exact: false }).first()
+    ).toBeVisible({ timeout: 15_000 });
   });
 
-  test.skip("create node via UI", async ({ page }) => {
+  test("create node via UI", async ({ page }) => {
+    test.setTimeout(60_000);
     await ensureInAppOnHome(page);
+
+    const nodeText = `E2E node UI ${Date.now()}`;
+    await page
+      .getByRole("button", { name: /^Capture$/i })
+      .first()
+      .click({ timeout: 5_000 });
+
+    await page.waitForTimeout(1_000);
+    const editor = page
+      .getByTestId("capture-editor")
+      .getByPlaceholder("Start typing to capture...")
+      .or(
+        page
+          .getByTestId("capture-editor")
+          .getByRole("textbox", { name: /Markdown editor|Start typing/i })
+      )
+      .first();
+    const markdownBtn = page.getByRole("button", { name: /^Markdown$/i }).first();
+    const editorVisible = await editor.isVisible().catch(() => false);
+    if (!editorVisible) {
+      await markdownBtn.click({ timeout: 5_000 });
+      await page.waitForTimeout(800);
+    }
+    await editor.waitFor({ state: "visible", timeout: 8_000 });
+    await editor.click();
+    await page.keyboard.type(nodeText, { delay: 50 });
+    await page.waitForTimeout(300);
+
+    const saveBtn = page
+      .getByTestId("capture-save-button")
+      .or(page.getByRole("button", { name: /^Save$/i }));
+    await saveBtn.first().click({ timeout: 5_000 });
+    await page.waitForTimeout(1_500);
+    const closeBtn = page.getByRole("button", { name: "Close" });
+    await closeBtn.click({ timeout: 5_000 });
+    await page.waitForTimeout(800);
+
+    await openLibraryAndTab(page, LibraryTab.Nodes);
+    await expect(
+      page.getByText(nodeText, { exact: false }).first()
+    ).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/apps/e2e-playwright/tests/shared/settings/settings.spec.ts
+++ b/apps/e2e-playwright/tests/shared/settings/settings.spec.ts
@@ -58,7 +58,8 @@ test.describe("settings - open, close, navigate (shared) @regression", () => {
     test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
-    if (testInfo.project.name === "nucleus") {
+    if (testInfo.project.name === "nucleum") {
+      // Nucleum: profile/logo button (top-left)
       await page.getByTestId("topnav-account-settings").waitFor({ state: "visible", timeout: 10_000 });
       await page.getByTestId("topnav-account-settings").click({ timeout: 5_000 });
     } else {
@@ -109,7 +110,7 @@ test.describe("settings - open, close, navigate (shared) @regression", () => {
   test("navigate to Focus and assert Focus settings panel visible (Pointron, Nucleus)", async ({
     page
   }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
@@ -131,7 +132,7 @@ test.describe("settings - open, close, navigate (shared) @regression", () => {
   test("navigate to Node settings and assert panel visible (Memotron, Nucleus)", async ({
     page
   }, testInfo) => {
-    test.skip(testInfo.project.name === "pointron", "Node settings only in Memotron and Nucleus");
+    test.skip(testInfo.project.name === "pointron", "Node settings only in Memotron and Nucleum");
     test.setTimeout(45_000);
     await ensureInAppOnHome(page);
 
@@ -153,7 +154,7 @@ test.describe("settings - open, close, navigate (shared) @regression", () => {
   test("Node settings: hide/show text highlight colors in Bookmarks after PDF highlight (Memotron, Nucleus)", async ({
     page
   }, testInfo) => {
-    test.skip(testInfo.project.name === "pointron", "Node settings only in Memotron and Nucleus");
+    test.skip(testInfo.project.name === "pointron", "Node settings only in Memotron and Nucleum");
     test.setTimeout(120_000);
     await ensureInAppOnHome(page);
 
@@ -1047,8 +1048,8 @@ test.describe("settings - Accessibility (shared) @regression", () => {
     page
   }, testInfo) => {
     test.skip(
-      testInfo.project.name === "nucleus" || testInfo.project.name === "pointron",
-      "Known bug: sizing visually stays the same on Nucleus and Pointron"
+      testInfo.project.name === "nucleum" || testInfo.project.name === "pointron",
+      "Known bug: sizing visually stays the same on Nucleum and Pointron"
     );
     test.setTimeout(60_000);
     await ensureInAppOnHome(page);
@@ -1126,7 +1127,7 @@ test.describe("settings - Focus (Pointron, Nucleus) @regression", () => {
   test("Focus: navigate and assert panel and controls visible", async ({
     page
   }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(45_000);
     await ensureInAppOnHome(page);
     await openFocus(page);
@@ -1145,7 +1146,7 @@ test.describe("settings - Focus (Pointron, Nucleus) @regression", () => {
   });
 
   test("Focus: quick durations persist after add", async ({ page }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(60_000);
     await ensureInAppOnHome(page);
     await openFocus(page);
@@ -1177,7 +1178,7 @@ test.describe("settings - Focus (Pointron, Nucleus) @regression", () => {
   });
 
   test("Focus: default break reminder value persists", async ({ page }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(60_000);
     await ensureInAppOnHome(page);
     await openFocus(page);
@@ -1207,7 +1208,7 @@ test.describe("settings - Focus (Pointron, Nucleus) @regression", () => {
   });
 
   test("Focus: PiP toggle state persists", async ({ page }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(60_000);
     await ensureInAppOnHome(page);
     await openFocus(page);
@@ -1241,7 +1242,7 @@ test.describe("settings - Focus (Pointron, Nucleus) @regression", () => {
   test("Focus: set 2min quick duration, 1min break reminder, PiP on → create goal → start focus → verify PiP → add manual log (last 2 min) → start focus → verify break reminder after 1 min", async ({
     page
   }, testInfo) => {
-    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleus");
+    test.skip(testInfo.project.name === "memotron", "Focus panel only in Pointron and Nucleum");
     test.setTimeout(240_000);
     await ensureInAppOnHome(page);
 

--- a/apps/e2e-playwright/tests/utils/helpers.ts
+++ b/apps/e2e-playwright/tests/utils/helpers.ts
@@ -17,30 +17,191 @@ function resolveProductConfig() {
   }
 }
 
+const runtimeEnv = (
+  globalThis as { process?: { env?: Record<string, string | undefined> } }
+).process?.env;
+
+
+/**
+ * Log in with email/password from env (E2E_LOGIN_EMAIL, E2E_LOGIN_PASSWORD).
+ * Navigates to /account/login, selects Log in, fills credentials, submits.
+ * Returns true if login was attempted and URL left login page; false if env not set or login failed.
+ */
+export async function loginWithEnvCredentials(page: Page): Promise<boolean> {
+  const email = runtimeEnv?.E2E_LOGIN_EMAIL;
+  const password = runtimeEnv?.E2E_LOGIN_PASSWORD;
+  if (!email?.trim() || !password) return false;
+
+  const currentPath = new URL(page.url()).pathname;
+  if (currentPath !== "/account/login") {
+    await page.goto("/account/login", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("domcontentloaded");
+  }
+
+  // Click the "Log in" tab (Sign up / Log in / Offline).
+  const logInTab = page.getByRole("button", { name: "Log in" }).first();
+  await logInTab.waitFor({ state: "visible", timeout: 10_000 }).catch(() => null);
+  await logInTab.click({ timeout: 5_000 }).catch(() => null);
+  await page.waitForTimeout(500);
+
+  const emailInput = page.getByPlaceholder("username@email.com");
+  // On some self-hosted instances, there is no email/password login at all.
+  // If the email field never appears, treat this as "login not available".
+  const emailVisible = await emailInput
+    .waitFor({ state: "visible", timeout: 8_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!emailVisible) return false;
+  await emailInput.fill(email);
+  await page.waitForTimeout(300);
+
+  const enterPasswordBtn = page.getByRole("button", { name: "Enter password" });
+  await enterPasswordBtn.waitFor({ state: "visible", timeout: 5_000 });
+  await enterPasswordBtn.click();
+  await page.waitForTimeout(500);
+
+  const passwordInput = page.locator("#password");
+  await passwordInput.waitFor({ state: "visible", timeout: 5_000 });
+  await passwordInput.fill(password);
+  await page.waitForTimeout(300);
+
+  const submitBtn = page.getByRole("button", { name: "Log in" }).last();
+  await submitBtn.click({ timeout: 5_000 });
+  // Success = we left /account/login. App may redirect to /signup (where we then click "Continue offline") or to app home.
+  const leftLogin = await page
+    .waitForURL(
+      (u) => new URL(u).pathname !== "/account/login",
+      { timeout: 25_000, waitUntil: "domcontentloaded" }
+    )
+    .then(() => true)
+    .catch(() => false);
+  return leftLogin;
+}
+
+/**
+ * Ensure we're in the app (login with env credentials, or dismiss signup with continue offline) and on the home (calendar),
+ * with app nav visible. Uses E2E_LOGIN_EMAIL + E2E_LOGIN_PASSWORD from env when set; otherwise continue offline.
+ * Waits for any product's nav label (Focus, Capture, Calendar, Overview, Library) so it works for nucleum, pointron, and memotron.
+ */
 export async function ensureInAppOnHome(page: Page) {
-  await page.goto("/");
+  const safeGoto = async (url: string) => {
+    try {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+    } catch (err) {
+      const message = (err as Error).message || "";
+      if (!/ERR_CONNECTION_REFUSED/i.test(message)) throw err;
+      // Dev server may have restarted between tests – wait briefly and retry once.
+      await page.waitForTimeout(1_000);
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+    }
+  };
+
+  await safeGoto("/");
   await page.waitForLoadState("domcontentloaded");
 
+  const pathname = new URL(page.url()).pathname;
+  const onAuthPage =
+    pathname === "/signup" ||
+    pathname === "/account/login" ||
+    pathname === "/";
+  if (
+    onAuthPage &&
+    runtimeEnv?.E2E_LOGIN_EMAIL?.trim() &&
+    runtimeEnv?.E2E_LOGIN_PASSWORD
+  ) {
+    // When app shows minimal "Embed token: false" + "Login/Signup" view (path "/"), click the button to open the login page.
+    if (pathname === "/") {
+      const loginSignupBtn = page.getByRole("button", {
+        name: /Login\/Signup|Login \/ Signup/i
+      }).first();
+      const visible = await loginSignupBtn
+        .waitFor({ state: "visible", timeout: 8_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (visible) {
+        await loginSignupBtn.click({ timeout: 5_000 });
+        await page
+          .waitForURL(/\/account\/login/, {
+            timeout: 15_000,
+            waitUntil: "domcontentloaded"
+          })
+          .catch(() => null);
+        await page.waitForLoadState("domcontentloaded").catch(() => null);
+      }
+    } else if (pathname !== "/account/login") {
+      await page.goto("/account/login", { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("domcontentloaded");
+    }
+    const loggedIn = await loginWithEnvCredentials(page);
+    if (loggedIn) {
+      await page.waitForLoadState("domcontentloaded");
+      const afterLoginPath = new URL(page.url()).pathname;
+      // If app redirected to /signup after login, do not navigate away — we will click "Continue offline" there below.
+      if (afterLoginPath !== "/signup" && afterLoginPath !== "/account/login") {
+        await page.goto("/");
+        await page.waitForLoadState("domcontentloaded");
+      }
+    }
+  }
+
   const clickContinueOfflineIfVisible = async () => {
+    const pathname = new URL(page.url()).pathname;
+    // On /account/login the working "Continue offline" is on /signup; the Offline tab here shows "Continue using offline" (currently no-op in app). Click Offline tab first so that button is visible if the app ever wires it.
+    if (pathname === "/") {
+      // Self-hosted welcome screen: primary CTA is a bare "Continue offline" button.
+      const rootContinueOffline = page
+        .getByRole("button", { name: /Continue (using )?offline/i })
+        .first();
+      try {
+        await rootContinueOffline.waitFor({ state: "visible", timeout: 10_000 });
+      } catch {
+        return false;
+      }
+      const beforePathRoot = new URL(page.url()).pathname;
+      await rootContinueOffline.click({ timeout: 5_000, force: true }).catch(() => null);
+      await page.waitForLoadState("domcontentloaded").catch(() => null);
+      // Wait for SPA to leave "/" (navigation may be async)
+      const leftRoot = await page
+        .waitForURL((u) => new URL(u).pathname !== "/", { timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false);
+      return leftRoot || new URL(page.url()).pathname !== beforePathRoot;
+    }
+    if (pathname === "/account/login") {
+      const offlineTab = page.getByRole("button", { name: "Offline" }).first();
+      await offlineTab.waitFor({ state: "visible", timeout: 3_000 }).catch(() => null);
+      await offlineTab.click({ timeout: 2_000, force: true }).catch(() => null);
+      await page.waitForTimeout(500);
+    }
+    const continueOfflineAny = page.getByRole("button", {
+      name: /Continue (using )?offline/i
+    }).first();
     const continueOfflineMain = page
       .getByRole("button", { name: /Continue (using )?offline/i })
       .filter({ hasText: /Single device|free forever|No signup/i })
       .first();
-    const continueOfflineAny = page.getByRole("button", {
-      name: /Continue (using )?offline/i
-    }).first();
-    const pathname = new URL(page.url()).pathname;
     const waitMs =
       pathname === "/signup" || pathname === "/account/login" ? 10_000 : 3_000;
-    let target = continueOfflineMain;
-    try {
-      await continueOfflineMain.waitFor({ state: "visible", timeout: waitMs });
-    } catch {
+    // On /signup (e.g. self-hosted) the button may be just "Continue offline" without "Single device..." text. Try the unfiltered button first so we click it immediately.
+    let target: ReturnType<typeof page.getByRole>;
+    if (pathname === "/signup") {
       try {
-        await continueOfflineAny.waitFor({ state: "visible", timeout: 2_000 });
+        await continueOfflineAny.waitFor({ state: "visible", timeout: waitMs });
         target = continueOfflineAny;
       } catch {
         return false;
+      }
+    } else {
+      try {
+        await continueOfflineMain.waitFor({ state: "visible", timeout: waitMs });
+        target = continueOfflineMain;
+      } catch {
+        try {
+          await continueOfflineAny.waitFor({ state: "visible", timeout: 2_000 });
+          target = continueOfflineAny;
+        } catch {
+          return false;
+        }
       }
     }
     const beforePath = new URL(page.url()).pathname;
@@ -52,7 +213,7 @@ export async function ensureInAppOnHome(page: Page) {
           const p = new URL(u).pathname;
           return p !== "/signup" && p !== "/account/login";
         },
-        { timeout: 8_000 }
+        { timeout: 8_000, waitUntil: "domcontentloaded" }
       )
       .then(() => true)
       .catch(() => false);
@@ -63,6 +224,21 @@ export async function ensureInAppOnHome(page: Page) {
     const handled = await clickContinueOfflineIfVisible();
     if (!handled) break;
   }
+  // If still on login page, the "Continue offline" that works lives on /signup (AccountForm), not on /account/login (Login.svelte's button is no-op). Go there and try again.
+  const pathAfterLoops = new URL(page.url()).pathname;
+  if (
+    pathAfterLoops === "/account/login" ||
+    pathAfterLoops === "/signup" ||
+    pathAfterLoops === "/"
+  ) {
+    await safeGoto("/signup");
+    await page.waitForLoadState("domcontentloaded").catch(() => null);
+    for (let j = 0; j < 3; j += 1) {
+      const handled = await clickContinueOfflineIfVisible();
+      if (!handled) break;
+      await page.waitForLoadState("domcontentloaded").catch(() => null);
+    }
+  }
   for (let i = 0; i < 3; i += 1) {
     const handled = await clickContinueOfflineIfVisible();
     if (!handled) break;
@@ -70,22 +246,38 @@ export async function ensureInAppOnHome(page: Page) {
   }
 
   const productConfig = resolveProductConfig();
-  await page.goto(productConfig.homePath, { waitUntil: "domcontentloaded" });
-  await page
-    .waitForURL(
+  await page.goto(`/${productConfig.homePath}`, { waitUntil: "domcontentloaded" });
+  // Wait until we're past signup/login (app may redirect / to /calendar). Use domcontentloaded so SPA client-side nav is enough.
+  await page.waitForURL(
+    (u) => {
+      const p = new URL(u).pathname;
+      return p !== "/signup" && p !== "/account/login";
+    },
+    { timeout: 25_000, waitUntil: "domcontentloaded" }
+  );
+
+  // If we're not already on home, navigate there (relative path = same origin).
+  const currentPath = new URL(page.url()).pathname;
+  const onHome =
+    currentPath === `/${productConfig.homePath}` ||
+    currentPath.startsWith(`/${productConfig.homePath}/`);
+  if (!onHome) {
+    await page.goto(`/${productConfig.homePath}`, {
+      waitUntil: "domcontentloaded"
+    });
+    await page.waitForURL(
       (u) => {
         const p = new URL(u).pathname;
         const home = `/${productConfig.homePath}`;
         return p === home || p.startsWith(`${home}/`);
       },
-      { timeout: 10_000 }
-    )
-    .catch(() => null);
-
-  for (let i = 0; i < 3; i += 1) {
-    const handled = await clickContinueOfflineIfVisible();
-    if (!handled) break;
-    await page.waitForLoadState("domcontentloaded").catch(() => null);
+      { timeout: 15_000, waitUntil: "domcontentloaded" }
+    );
+    for (let i = 0; i < 3; i += 1) {
+      const handled = await clickContinueOfflineIfVisible();
+      if (!handled) break;
+      await page.waitForLoadState("domcontentloaded").catch(() => null);
+    }
   }
 
   const navMarkers = [
@@ -154,7 +346,7 @@ export async function openLibraryAndTab(
   await page.getByRole("button", { name: /^Library$/i }).click({ timeout: 5_000 });
   await page.waitForURL(
     (u) => /^\/library(\/.*)?$/.test(new URL(u).pathname),
-    { timeout: 10_000 }
+    { timeout: 10_000, waitUntil: "domcontentloaded" }
   );
   const tabButton = page.getByRole("button", { name: tabName }).first();
   await tabButton.waitFor({ state: "visible", timeout: 10_000 });

--- a/client/components/account/auth.ts
+++ b/client/components/account/auth.ts
@@ -67,7 +67,13 @@ async function performCheckUsingSessionAPI() {
   }
 }
 
-export function performSessionCheck(): Promise<boolean | undefined> {
-  //TODO: Implement offline user case
-  return performCheckUsingSessionAPI();
+export async function performSessionCheck(): Promise<boolean | undefined> {
+  if (typeof window === "undefined") return false;
+  const offlineSessionId = await clientStorage.get(
+    ClientStorageKey.OFFLINE_SESSION_ID
+  );
+  if (offlineSessionId) return true;
+  const cloudSession = await performCheckUsingSessionAPI();
+  if (cloudSession) return true;
+  return cloudSession;
 }


### PR DESCRIPTION
## Summary by Sourcery

Strengthen Playwright E2E flows by adding authenticated/unauthenticated entry handling, implementing creation and browse scenarios for nodes, tasks, and collections, and standardizing the Nucleum product naming and configuration across tests and docs.

New Features:
- Add automated login via environment-provided credentials with fallback to offline mode for E2E tests.
- Introduce E2E scenarios for creating nodes and collections via both command bar and UI and verifying presence in Library views.
- Add E2E browse flows for tasks, nodes, and collections from Library tabs.

Enhancements:
- Improve navigation helpers to reliably reach app home across signup/login flows and across products using shared nav labels.
- Extend Playwright config and product-specific specs to use the updated Nucleum naming and base URLs instead of Nucleus.
- Enhance session checking to treat offline sessions as valid application sessions.

Build:
- Adjust Playwright project configuration and scripts to use Nucleum naming and remove storage-state based auth in favor of runtime login.

Documentation:
- Update E2E README to describe the new login-via-env workflow, adjust product naming to Nucleum, and clarify test structure.

Tests:
- Unskip and expand regression tests around creation and browsing of tasks, nodes, and collections, including new assertions on Library views and product-specific behavior notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands E2E coverage for Nucleum by automating creation and browsing of collections, nodes, and tasks, and hardens auth entry with env-based login and offline fallback. Completes the Nucleus → Nucleum rename across tests and tooling, addressing TIDY-433.

- **New Features**
  - Creation flows: collections (command bar, UI), nodes (command bar, UI), tasks (command bar) with verification in Library tabs.
  - Browse flows: Library → Collections/Nodes assert list container; Library → Tasks verifies created task; Goals waits for search, supports “Goals”/“Objectives”, and non-exact row text.
  - Auth helpers: `loginWithEnvCredentials` using `E2E_LOGIN_EMAIL`/`E2E_LOGIN_PASSWORD`; more resilient `ensureInAppOnHome` across `/`, `/account/login`, `/signup` with automatic offline fallback; `openLibraryAndTab`, `runCommand`.

- **Refactors**
  - Rename Nucleus → Nucleum across tests, paths, config, and docs; `.env.example` base URL is `https://local.nucleum.app`; README now recommends env login with offline fallback.
  - Playwright: default project `nucleum`; remove storage-state auth and origin checks; add `e2e:save-auth:nucleum`; update allowed origins in save-auth script to `*.nucleum.app`.
  - Client auth: `performSessionCheck` treats `ClientStorageKey.OFFLINE_SESSION_ID` as a valid session.

<sup>Written for commit 2fc4128d2674d99c5a28dc768a50cce62863a7f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Product Rebranding**
  * Renamed product references from Nucleus to Nucleum across docs, configs, test paths, and default local base URL.

* **Authentication Updates**
  * Tests now prefer explicit login via environment credentials; CI secrets guidance added.
  * Session check enhanced to detect offline sessions before cloud check.

* **Testing & Quality**
  * Expanded and re-enabled many E2E tests (collections, tasks, nodes, settings, library flows); increased timeouts and moved to UI-driven interactions.
  * Test scripts and project identifiers updated for the rebrand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->