### PR TITLE
TIDY-434

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,9 +62,52 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
         working-directory: apps/e2e-playwright
-      - name: Run smoke tests
-        run: npm run test:smoke
-        working-directory: apps/e2e-playwright
+      - name: Map HTTPS local domains
+        run: |
+          sudo tee -a /etc/hosts >/dev/null <<'EOF'
+          127.0.0.1 local.nucleum.app local.memotron.app local.pointron.app
+          EOF
+      - name: Install Caddy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y caddy
+          # Package often starts systemd caddy → holds :2019 (and :443). Our caddy run needs those.
+          sudo systemctl stop caddy 2>/dev/null || true
+          sudo systemctl disable caddy 2>/dev/null || true
+      - name: Start dev server, create auth session, run smoke tests
+        env:
+          APP_BASE_URL: https://local.nucleum.app
+          APP_BASE_URL_NUCLEUS: https://local.nucleum.app
+          APP_BASE_URL_MEMOTRON: https://local.memotron.app
+          APP_BASE_URL_POINTRON: https://local.pointron.app
+          PRODUCT: nucleum
+          E2E_LOGIN_EMAIL: ${{ secrets.E2E_LOGIN_EMAIL }}
+          E2E_LOGIN_PASSWORD: ${{ secrets.E2E_LOGIN_PASSWORD }}
+        run: |
+          npm run dev --workspace=apps/nucleus -- --port 5173 --host 127.0.0.1 &
+          # Caddy v2: auto_https only accepts off|disable_redirects|disable_certs|ignore_loaded_certs (not "on").
+          # Use printf so the file has no YAML-indent leading spaces (heredoc would break the Caddyfile).
+          printf '%s\n' \
+            'local.nucleum.app, local.memotron.app, local.pointron.app {' \
+            '  tls internal' \
+            '  reverse_proxy 127.0.0.1:5173' \
+            '}' > Caddyfile
+
+          # Port 443 requires root on Linux; non-root caddy exits → trust fails on :2019.
+          CADDYFILE="$PWD/Caddyfile"
+          sudo caddy run --config "$CADDYFILE" --adapter caddyfile &
+          READY=0
+          for i in $(seq 1 30); do curl -sf --connect-timeout 1 http://127.0.0.1:2019/config/ >/dev/null && READY=1 && break; sleep 1; done
+          if [ "$READY" -ne 1 ]; then
+            echo "Caddy admin API did not become ready on 127.0.0.1:2019"
+            exit 1
+          fi
+          sudo caddy trust
+          # Node/wait-on may not pick up the OS trust store (even after `caddy trust`) in CI containers.
+          NODE_TLS_REJECT_UNAUTHORIZED=0 npx wait-on https://local.nucleum.app -t 60000
+          cd apps/e2e-playwright
+          npm run e2e:save-email-auth:nucleum || echo "::warning::Best-effort auth session save failed; continuing with smoke tests."
+          npm run test:smoke
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/apps/e2e-playwright/global-setup.ts
+++ b/apps/e2e-playwright/global-setup.ts
@@ -75,36 +75,48 @@ async function startVite(app: string): Promise<ViteHarness> {
   });
 }
 
+const PER_PROJECT_URL_KEYS = [
+  "APP_BASE_URL_NUCLEUM",
+  "APP_BASE_URL_NUCLEUS",
+  "APP_BASE_URL_MEMOTRON",
+  "APP_BASE_URL_POINTRON"
+] as const;
+
+function areAllPerProjectBaseUrlsSet(): boolean {
+  return PER_PROJECT_URL_KEYS.every((key) => Boolean(process.env[key]?.trim()));
+}
+
+function getFirstPerProjectBaseUrl(): string | undefined {
+  return PER_PROJECT_URL_KEYS.map((key) => process.env[key]?.trim()).find((v) => Boolean(v));
+}
+
 export default async function globalSetup(_: FullConfig) {
-  if (process.env.APP_BASE_URL) {
-    const baseURL = process.env.APP_BASE_URL;
-    console.log(`📝 Using APP_BASE_URL (e.g. from .env): ${baseURL}`);
+  const explicitBaseUrl = process.env.APP_BASE_URL?.trim();
+  const perProjectUrl = getFirstPerProjectBaseUrl();
 
-    const authDir = path.join(__dirname, ".auth");
-    const authFiles = ["user.json", "user-memotron.json", "user-pointron.json"];
-    try {
-      const fs = await import("node:fs");
-      const currentOrigin = new URL(baseURL).origin;
-      for (const file of authFiles) {
-        const authPath = path.join(authDir, file);
-        if (fs.existsSync(authPath)) {
-          const raw = fs.readFileSync(authPath, "utf-8");
-          const state = JSON.parse(raw) as { origins?: Array<{ origin: string }> };
-          const savedOrigins = state.origins?.map((o) => o.origin) ?? [];
-          if (savedOrigins.length > 0 && !savedOrigins.includes(currentOrigin)) {
-            console.warn(
-              `\n⚠️  Auth in ${file} was saved for origin(s): ${savedOrigins.join(", ")} but APP_BASE_URL is ${baseURL}.`,
-              `\n   Set APP_BASE_URL_<PROJECT> in .env to match (e.g. APP_BASE_URL_MEMOTRON=${savedOrigins[0]}).\n`
-            );
-          }
-        }
-      }
-    } catch (err) {
-      console.warn("[e2e] Could not check auth origin vs APP_BASE_URL:", err);
-    }
-
+  if (explicitBaseUrl) {
+    console.log(`📝 Using APP_BASE_URL (e.g. from .env): ${explicitBaseUrl}`);
     (globalThis as any).__viteHarness = { close: async () => {} };
-    return baseURL;
+    await warnAuthOriginMismatch(explicitBaseUrl);
+    return explicitBaseUrl;
+  }
+
+  if (perProjectUrl) {
+    console.log(
+      `📝 Using per-project base URLs from .env (e.g. ${perProjectUrl}). No dev server started — ensure app(s) are running at those URLs.`
+    );
+    await warnAuthOriginMismatch(perProjectUrl, {
+      nucleum: process.env.APP_BASE_URL_NUCLEUM?.trim() ?? process.env.APP_BASE_URL_NUCLEUS?.trim(),
+      memotron: process.env.APP_BASE_URL_MEMOTRON?.trim(),
+      pointron: process.env.APP_BASE_URL_POINTRON?.trim()
+    });
+    if (areAllPerProjectBaseUrlsSet()) {
+      (globalThis as any).__viteHarness = { close: async () => {} };
+      return perProjectUrl;
+    }
+    console.log(
+      "📝 Only some per-project base URLs are set; starting local dev server for remaining projects."
+    );
   }
 
   const targetApp = process.env.PLAYWRIGHT_APP ?? "apps/nucleus";
@@ -114,4 +126,37 @@ export default async function globalSetup(_: FullConfig) {
   console.log(`📝 Set APP_BASE_URL to ${harness.url}`);
   (globalThis as any).__viteHarness = harness;
   return harness.url;
+}
+
+async function warnAuthOriginMismatch(
+  baseURL: string,
+  perProjectBaseUrls?: Partial<Record<"nucleum" | "memotron" | "pointron", string | undefined>>
+) {
+  const authDir = path.join(__dirname, ".auth");
+  const authFiles: Array<{ file: string; expectedBaseUrl?: string }> = [
+    { file: "user.json", expectedBaseUrl: perProjectBaseUrls?.nucleum ?? baseURL },
+    { file: "user-memotron.json", expectedBaseUrl: perProjectBaseUrls?.memotron ?? baseURL },
+    { file: "user-pointron.json", expectedBaseUrl: perProjectBaseUrls?.pointron ?? baseURL }
+  ];
+  try {
+    const fs = await import("node:fs");
+    for (const { file, expectedBaseUrl } of authFiles) {
+      if (!expectedBaseUrl) continue;
+      const currentOrigin = new URL(expectedBaseUrl).origin;
+      const authPath = path.join(authDir, file);
+      if (fs.existsSync(authPath)) {
+        const raw = fs.readFileSync(authPath, "utf-8");
+        const state = JSON.parse(raw) as { origins?: Array<{ origin: string }> };
+        const savedOrigins = state.origins?.map((o) => o.origin) ?? [];
+        if (savedOrigins.length > 0 && !savedOrigins.includes(currentOrigin)) {
+          console.warn(
+            `\n⚠️  Auth in ${file} was saved for origin(s): ${savedOrigins.join(", ")} but expected base URL is ${expectedBaseUrl}.`,
+            `\n   Set APP_BASE_URL_<PROJECT> in .env to match (e.g. APP_BASE_URL_MEMOTRON=${savedOrigins[0]}).\n`
+          );
+        }
+      }
+    }
+  } catch (err) {
+    console.warn("[e2e] Could not check auth origin vs APP_BASE_URL:", err);
+  }
 }

--- a/apps/e2e-playwright/package.json
+++ b/apps/e2e-playwright/package.json
@@ -2,6 +2,10 @@
     "e2e:save-auth":"npx tsx scripts/save-google-auth-state.ts",
     "e2e:save-auth:nucleum":"PRODUCT=nucleum APP_BASE_URL=https://local.nucleum.app npx tsx scripts/save-google-auth-state.ts",
     "e2e:save-auth:memotron":"PRODUCT=memotron APP_BASE_URL=https://local.memotron.app npx tsx scripts/save-google-auth-state.ts",
-    "e2e:save-auth:pointron":"PRODUCT=pointron APP_BASE_URL=https://local.pointron.app npx tsx scripts/save-google-auth-state.ts"},"dependencies":{"@21n/products":"*"},"devDependencies":{"@21n/components":"*","@21n/types":"*","@playwright/test":"^1.49.0","@types/node":"^22.0.0","dotenv":"^16.4.5",
+    "e2e:save-auth:pointron":"PRODUCT=pointron APP_BASE_URL=https://local.pointron.app npx tsx scripts/save-google-auth-state.ts",
+    "e2e:save-email-auth":"npx tsx scripts/save-email-auth-state.ts",
+    "e2e:save-email-auth:nucleum":"PRODUCT=nucleum APP_BASE_URL=https://local.nucleum.app npx tsx scripts/save-email-auth-state.ts",
+    "e2e:save-email-auth:memotron":"PRODUCT=memotron APP_BASE_URL=https://local.memotron.app npx tsx scripts/save-email-auth-state.ts",
+    "e2e:save-email-auth:pointron":"PRODUCT=pointron APP_BASE_URL=https://local.pointron.app npx tsx scripts/save-email-auth-state.ts"},"dependencies":{"@21n/products":"*"},"devDependencies":{"@21n/components":"*","@21n/types":"*","@playwright/test":"^1.49.0","@types/node":"^22.0.0","dotenv":"^16.4.5",
     "tsx":"^4.19.0"}
 }

--- a/apps/e2e-playwright/playwright.config.ts
+++ b/apps/e2e-playwright/playwright.config.ts
@@ -1,27 +1,51 @@
 import { devices, defineConfig } from "@playwright/test";
+import fs from "node:fs";
 import path from "node:path";
 
 import "dotenv/config";
 
 const artifactsDir = path.join(__dirname, "artifacts");
+const authDir = path.join(__dirname, ".auth");
 
 const defaultBaseURL = process.env.APP_BASE_URL ?? "http://127.0.0.1:4173";
 
 function getProjectBaseURL(projectName: string): string {
+  // Project "nucleum" can use APP_BASE_URL_NUCLEUM or APP_BASE_URL_NUCLEUS
+  if (projectName === "nucleum") {
+    return (
+      process.env.APP_BASE_URL_NUCLEUM ??
+      process.env.APP_BASE_URL_NUCLEUS ??
+      process.env.APP_BASE_URL ??
+      defaultBaseURL
+    );
+  }
   const envKey = `APP_BASE_URL_${projectName.toUpperCase()}`;
   return (process.env[envKey] ?? process.env.APP_BASE_URL) ?? defaultBaseURL;
 }
 
+function getAuthFilePath(projectName: string): string {
+  const fileName = projectName === "nucleum" ? "user.json" : `user-${projectName}.json`;
+  return path.join(authDir, fileName);
+}
+
 function getProjectUse(projectName: string) {
   const baseURL = getProjectBaseURL(projectName);
-  return {
+  const authPath = getAuthFilePath(projectName);
+  const use = {
     ...devices["Desktop Chrome"],
     viewport: { width: 1280, height: 720 },
     video: "on" as const,
     trace: "on-first-retry" as const,
     screenshot: "only-on-failure" as const,
+    // Local dev uses Caddy `tls internal`; Playwright's bundled Chromium may not honor OS trust store.
+    // Keeping this avoids CI/local flakes while still testing app behavior over HTTPS.
+    ignoreHTTPSErrors: true,
     baseURL
   };
+  if (fs.existsSync(authPath)) {
+    (use as { storageState?: string }).storageState = authPath;
+  }
+  return use;
 }
 
 export default defineConfig({
@@ -58,7 +82,10 @@ export default defineConfig({
     baseURL: defaultBaseURL,
     trace: "on-first-retry",
     video: "retain-on-failure",
-    screenshot: "only-on-failure"
+    screenshot: "only-on-failure",
+    // Local dev uses Caddy `tls internal`; Playwright's bundled Chromium may not honor OS trust store.
+    // Keeping this avoids CI/local flakes while still testing app behavior over HTTPS.
+    ignoreHTTPSErrors: true
   },
   projects: [
     {

--- a/apps/e2e-playwright/scripts/save-email-auth-state.ts
+++ b/apps/e2e-playwright/scripts/save-email-auth-state.ts
@@ -1,0 +1,280 @@
+/**
+ * One-time save: log in with E2E_LOGIN_EMAIL and E2E_LOGIN_PASSWORD, then save session.
+ * Tests can use the saved session via storageState so they don't log in every time.
+ *
+ * Requires in .env (or env): E2E_LOGIN_EMAIL, E2E_LOGIN_PASSWORD, and APP_BASE_URL (or APP_BASE_URL_<PROJECT>).
+ *
+ * Run:
+ *   Nucleum:  npm run e2e:save-email-auth:nucleum   (or PRODUCT=nucleum APP_BASE_URL=... npm run e2e:save-email-auth)
+ *   Memotron: npm run e2e:save-email-auth:memotron
+ *   Pointron: npm run e2e:save-email-auth:pointron
+ */
+
+import "dotenv/config";
+import { chromium } from "@playwright/test";
+import path from "node:path";
+import fs from "node:fs";
+import net from "node:net";
+
+const authDir = path.join(__dirname, "..", ".auth");
+const product = (process.env.PRODUCT ?? "nucleum").toLowerCase();
+const authFileName = product === "nucleum" ? "user.json" : `user-${product}.json`;
+const authStatePath = path.join(authDir, authFileName);
+
+function getBaseURL(): string {
+  // Match playwright.config.ts precedence: product-specific env first, then APP_BASE_URL, then fallback.
+  const fallback = "http://127.0.0.1:4173";
+  if (product === "nucleum") {
+    return (
+      process.env.APP_BASE_URL_NUCLEUM ??
+      process.env.APP_BASE_URL_NUCLEUS ??
+      process.env.APP_BASE_URL ??
+      fallback
+    );
+  }
+  const envKey = `APP_BASE_URL_${product.toUpperCase()}`;
+  return process.env[envKey] ?? process.env.APP_BASE_URL ?? fallback;
+}
+
+async function main() {
+  const email = process.env.E2E_LOGIN_EMAIL?.trim();
+  const password = process.env.E2E_LOGIN_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error("E2E_LOGIN_EMAIL and E2E_LOGIN_PASSWORD must be set in .env or environment.");
+  }
+
+  const baseURL = getBaseURL();
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true });
+  }
+
+  console.log("Product:", product);
+  console.log("Base URL:", baseURL);
+  console.log("Auth will be saved to:", authStatePath);
+  console.log("Logging in with email/password and saving session...\n");
+
+  const browser = await chromium.launch({
+    headless: process.env.HEADLESS !== "false",
+    channel: "chrome",
+    args: ["--disable-blink-features=AutomationControlled", "--no-sandbox"]
+  });
+
+  const context = await browser.newContext({
+    baseURL,
+    viewport: { width: 1280, height: 720 },
+    // Local dev uses Caddy's `tls internal` certs; Playwright's bundled Chromium may not honor the OS trust store.
+    // Keep this enabled so the auth-save script can run in CI/local HTTPS environments without flaking.
+    ignoreHTTPSErrors: true,
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+  });
+  const page = await context.newPage();
+
+  try {
+    // Start on "/" – app may show "Login/Signup" or "Signup/Login" button first (or redirect to /account/login)
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForTimeout(2_000); // let SPA and auth check settle
+
+    let pathname = new URL(page.url()).pathname;
+
+    // If we're on "/", click Login/Signup (or Signup/Login) to open the login page
+    if (pathname === "/") {
+      const loginSignupBtn = page.getByRole("button", { name: /login|signup/i }).first();
+
+      // Pure UI approach: ensure the button is interactable, click with retries, and only continue once
+      // the login page UI is detected.
+      const hasLoginBtn = await loginSignupBtn
+        .waitFor({ state: "visible", timeout: 20_000 })
+        .then(() => true)
+        .catch(() => false);
+
+      // Only click if the button is present (e.g., if we're not already redirected/logged in).
+      let loginUiReady = false;
+      if (hasLoginBtn) {
+        for (let i = 0; i < 5; i++) {
+          const enabled = await loginSignupBtn.isEnabled().catch(() => false);
+          if (!enabled) await page.waitForTimeout(500);
+
+          await loginSignupBtn.scrollIntoViewIfNeeded().catch(() => null);
+          await loginSignupBtn.click({ timeout: 10_000 }).catch(() => null);
+
+          const navigated = await page
+            .waitForURL(/\/account\/login/, { timeout: 10_000, waitUntil: "domcontentloaded" })
+            .then(() => true)
+            .catch(() => false);
+          if (navigated) break;
+
+          // Sometimes URL change is delayed; alternatively detect the login UI.
+          loginUiReady = await page
+            .getByRole("tab", { name: /^Log in$/i })
+            .first()
+            .waitFor({ state: "visible", timeout: 5_000 })
+            .then(() => true)
+            .catch(() => false);
+          if (loginUiReady) break;
+
+          await page.waitForTimeout(800);
+        }
+      }
+      pathname = new URL(page.url()).pathname;
+      if (pathname !== "/account/login" && loginUiReady) {
+        pathname = "/account/login";
+      }
+    }
+
+    if (pathname !== "/account/login") {
+      throw new Error(
+        `Expected to be on /account/login after clicking Login/Signup; got ${pathname}`
+      );
+    }
+
+    await page.waitForTimeout(1_000); // let login form render
+
+    // Click "Log in" tab (BoxSwitcher option), then fill email and password
+    const logInTab = page
+      .getByRole("tab", { name: /^Log in$/i })
+      .or(page.getByRole("button", { name: /^Log in$/i }))
+      .first();
+    await logInTab.waitFor({ state: "visible", timeout: 15_000 });
+    await logInTab.click({ timeout: 10_000 });
+    await page.waitForTimeout(800);
+
+    const emailInput = page.getByPlaceholder("username@email.com").or(page.getByLabel("Email"));
+    const emailVisible = await emailInput
+      .waitFor({ state: "visible", timeout: 12_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!emailVisible) {
+      throw new Error(
+        "Email input did not appear. Is email/password login enabled for this app?"
+      );
+    }
+    await emailInput.fill(email);
+    await page.waitForTimeout(300);
+
+    // Some builds show an explicit "Enter password" button, others show the password field directly.
+    const enterPasswordBtn = page.getByRole("button", { name: /Enter password/i });
+    const passwordInput = page.locator("#password");
+
+    const haveEnterPassword = await enterPasswordBtn
+      .first()
+      .waitFor({ state: "visible", timeout: 7_500 })
+      .then(() => true)
+      .catch(() => false);
+    if (haveEnterPassword) {
+      await enterPasswordBtn.first().click({ timeout: 10_000 }).catch(() => null);
+      await page.waitForTimeout(500);
+    }
+
+    await passwordInput.waitFor({ state: "visible", timeout: 10_000 });
+    await passwordInput.fill(password);
+    await page.waitForTimeout(300);
+
+    // Wait for the auth API response so the session cookie is applied before we save.
+    const isAccountRelated = (url: string) => {
+      try {
+        const u = new URL(url);
+        return u.pathname.startsWith("/account") || /(^|\.)account\./i.test(u.hostname);
+      } catch {
+        return /account/i.test(url);
+      }
+    };
+    const responsePromise = page
+      .waitForResponse(
+        (res) => isAccountRelated(res.url()),
+        { timeout: 25_000 }
+      )
+      .catch(() => null);
+
+    // Wait for response that sets session cookie. Playwright's response.headers() does NOT expose Set-Cookie,
+    // so use allHeaders() which includes it.
+    const sessionCookiePromise = page
+      .waitForResponse(
+        async (res) => {
+          const h = await res.allHeaders();
+          const setCookie = h["set-cookie"] ?? h["Set-Cookie"];
+          const value = Array.isArray(setCookie) ? setCookie.join(" ") : setCookie;
+          return typeof value === "string" && /session_token|session_data/i.test(value);
+        },
+        { timeout: 25_000 }
+      )
+      .catch(() => null);
+
+    // Avoid clicking the "Log in" tab again; target the form submit button.
+    const submitBtn = page
+      .locator('form button[type="submit"]', { hasText: /^Log in$/i })
+      .first()
+      .or(page.getByRole("button", { name: /^Log in$/i }).last());
+    await submitBtn.click({ timeout: 10_000 });
+
+    await responsePromise;
+    await sessionCookiePromise;
+
+    const leftLogin = await page
+      .waitForURL(
+        (u) => new URL(u).pathname !== "/account/login",
+        {
+        timeout: 40_000,
+        waitUntil: "domcontentloaded"
+        }
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    if (!leftLogin) {
+      throw new Error("Login did not complete (still on login page). Check credentials and app.");
+    }
+
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForLoadState("networkidle").catch(() => null);
+    await page.waitForTimeout(2_000);
+
+    // Same as memotron/pointron: ensure we're on the app origin so session cookies for that origin are in context.
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => null);
+    await page.waitForTimeout(2_000);
+
+    // Wait until the session cookie is actually in the context (Playwright may not expose Set-Cookie in headers).
+    const hostname = new URL(baseURL).hostname;
+    const parentDomain =
+      net.isIP(hostname) !== 0 || hostname === "localhost"
+        ? hostname
+        : hostname.includes(".")
+          ? hostname.split(".").slice(-2).join(".")
+          : hostname; // e.g. local.nucleum.app -> nucleum.app
+    const sessionCookieName = "__Secure-21n.session_token";
+    const deadline = Date.now() + 15_000;
+    let hasSessionCookie = false;
+    while (Date.now() < deadline) {
+      const cookies = await context.cookies();
+      const hasSession = cookies.some(
+        (c) =>
+          (c.name === sessionCookieName || c.name?.includes("session_token")) &&
+          (c.domain === parentDomain || c.domain === `.${parentDomain}`)
+      );
+      if (hasSession) {
+        hasSessionCookie = true;
+        break;
+      }
+      await page.waitForTimeout(500);
+    }
+
+    if (!hasSessionCookie) {
+      throw new Error("Session cookie was not detected; refusing to save unauthenticated storageState.");
+    }
+
+    // Save after login success so session cookie is in context. Do NOT click "Continue offline" — tests will do that.
+    await context.storageState({ path: authStatePath });
+    console.log("Session saved to", authStatePath);
+    console.log("Run tests with: npx playwright test --project=" + product);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/apps/e2e-playwright/tests/utils/helpers.ts
+++ b/apps/e2e-playwright/tests/utils/helpers.ts
@@ -23,65 +23,10 @@ const runtimeEnv = (
 
 
 /**
- * Log in with email/password from env (E2E_LOGIN_EMAIL, E2E_LOGIN_PASSWORD).
- * Navigates to /account/login, selects Log in, fills credentials, submits.
- * Returns true if login was attempted and URL left login page; false if env not set or login failed.
- */
-export async function loginWithEnvCredentials(page: Page): Promise<boolean> {
-  const email = runtimeEnv?.E2E_LOGIN_EMAIL;
-  const password = runtimeEnv?.E2E_LOGIN_PASSWORD;
-  if (!email?.trim() || !password) return false;
-
-  const currentPath = new URL(page.url()).pathname;
-  if (currentPath !== "/account/login") {
-    await page.goto("/account/login", { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("domcontentloaded");
-  }
-
-  // Click the "Log in" tab (Sign up / Log in / Offline).
-  const logInTab = page.getByRole("button", { name: "Log in" }).first();
-  await logInTab.waitFor({ state: "visible", timeout: 10_000 }).catch(() => null);
-  await logInTab.click({ timeout: 5_000 }).catch(() => null);
-  await page.waitForTimeout(500);
-
-  const emailInput = page.getByPlaceholder("username@email.com");
-  // On some self-hosted instances, there is no email/password login at all.
-  // If the email field never appears, treat this as "login not available".
-  const emailVisible = await emailInput
-    .waitFor({ state: "visible", timeout: 8_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!emailVisible) return false;
-  await emailInput.fill(email);
-  await page.waitForTimeout(300);
-
-  const enterPasswordBtn = page.getByRole("button", { name: "Enter password" });
-  await enterPasswordBtn.waitFor({ state: "visible", timeout: 5_000 });
-  await enterPasswordBtn.click();
-  await page.waitForTimeout(500);
-
-  const passwordInput = page.locator("#password");
-  await passwordInput.waitFor({ state: "visible", timeout: 5_000 });
-  await passwordInput.fill(password);
-  await page.waitForTimeout(300);
-
-  const submitBtn = page.getByRole("button", { name: "Log in" }).last();
-  await submitBtn.click({ timeout: 5_000 });
-  // Success = we left /account/login. App may redirect to /signup (where we then click "Continue offline") or to app home.
-  const leftLogin = await page
-    .waitForURL(
-      (u) => new URL(u).pathname !== "/account/login",
-      { timeout: 25_000, waitUntil: "domcontentloaded" }
-    )
-    .then(() => true)
-    .catch(() => false);
-  return leftLogin;
-}
-
-/**
- * Ensure we're in the app (login with env credentials, or dismiss signup with continue offline) and on the home (calendar),
- * with app nav visible. Uses E2E_LOGIN_EMAIL + E2E_LOGIN_PASSWORD from env when set; otherwise continue offline.
- * Waits for any product's nav label (Focus, Capture, Calendar, Overview, Library) so it works for nucleum, pointron, and memotron.
+ * Ensure we're in the app and on the home (calendar), with app nav visible.
+ * Uses saved auth session (storageState): waits for redirect, or if still on post-login screen (e.g. /signup) clicks "Continue offline".
+ * No email/password in tests — run e2e:save-email-auth per project (saves after login success, before "Continue offline").
+ * Waits for any product's nav label (Focus, Capture, Calendar, Overview, Library) for nucleum, pointron, and memotron.
  */
 export async function ensureInAppOnHome(page: Page) {
   const safeGoto = async (url: string) => {
@@ -90,7 +35,6 @@ export async function ensureInAppOnHome(page: Page) {
     } catch (err) {
       const message = (err as Error).message || "";
       if (!/ERR_CONNECTION_REFUSED/i.test(message)) throw err;
-      // Dev server may have restarted between tests – wait briefly and retry once.
       await page.waitForTimeout(1_000);
       await page.goto(url, { waitUntil: "domcontentloaded" });
     }
@@ -99,172 +43,88 @@ export async function ensureInAppOnHome(page: Page) {
   await safeGoto("/");
   await page.waitForLoadState("domcontentloaded");
 
-  const pathname = new URL(page.url()).pathname;
-  const onAuthPage =
-    pathname === "/signup" ||
-    pathname === "/account/login" ||
-    pathname === "/";
-  if (
-    onAuthPage &&
-    runtimeEnv?.E2E_LOGIN_EMAIL?.trim() &&
-    runtimeEnv?.E2E_LOGIN_PASSWORD
-  ) {
-    // When app shows minimal "Embed token: false" + "Login/Signup" view (path "/"), click the button to open the login page.
-    if (pathname === "/") {
-      const loginSignupBtn = page.getByRole("button", {
-        name: /Login\/Signup|Login \/ Signup/i
-      }).first();
-      const visible = await loginSignupBtn
-        .waitFor({ state: "visible", timeout: 8_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (visible) {
-        await loginSignupBtn.click({ timeout: 5_000 });
-        await page
-          .waitForURL(/\/account\/login/, {
-            timeout: 15_000,
-            waitUntil: "domcontentloaded"
-          })
-          .catch(() => null);
-        await page.waitForLoadState("domcontentloaded").catch(() => null);
-      }
-    } else if (pathname !== "/account/login") {
-      await page.goto("/account/login", { waitUntil: "domcontentloaded" });
-      await page.waitForLoadState("domcontentloaded");
-    }
-    const loggedIn = await loginWithEnvCredentials(page);
-    if (loggedIn) {
-      await page.waitForLoadState("domcontentloaded");
-      const afterLoginPath = new URL(page.url()).pathname;
-      // If app redirected to /signup after login, do not navigate away — we will click "Continue offline" there below.
-      if (afterLoginPath !== "/signup" && afterLoginPath !== "/account/login") {
-        await page.goto("/");
-        await page.waitForLoadState("domcontentloaded");
-      }
-    }
-  }
+  // Saved session: wait for app to redirect past auth. If we're already on an auth entry page,
+  // don't burn the full timeout before trying the offline path.
+  const pathAtStart = new URL(page.url()).pathname;
+  const leftAuthPage =
+    pathAtStart !== "/" && pathAtStart !== "/signup" && pathAtStart !== "/account/login"
+      ? true
+      : pathAtStart === "/signup" || pathAtStart === "/account/login"
+        ? false
+        : await page
+            .waitForURL(
+              (u) => {
+                const p = new URL(u).pathname;
+                return p !== "/" && p !== "/signup" && p !== "/account/login";
+              },
+            { timeout: 7_000, waitUntil: "domcontentloaded" }
+            )
+            .then(() => true)
+            .catch(() => false);
 
-  const clickContinueOfflineIfVisible = async () => {
+  const clickContinueOfflineIfVisible = async (): Promise<boolean> => {
     const pathname = new URL(page.url()).pathname;
-    // On /account/login the working "Continue offline" is on /signup; the Offline tab here shows "Continue using offline" (currently no-op in app). Click Offline tab first so that button is visible if the app ever wires it.
     if (pathname === "/") {
-      // Self-hosted welcome screen: primary CTA is a bare "Continue offline" button.
-      const rootContinueOffline = page
-        .getByRole("button", { name: /Continue (using )?offline/i })
-        .first();
+      const btn = page.getByRole("button", { name: /Continue (using )?offline/i }).first();
       try {
-        await rootContinueOffline.waitFor({ state: "visible", timeout: 10_000 });
+        await btn.waitFor({ state: "visible", timeout: 5_000 });
       } catch {
         return false;
       }
-      const beforePathRoot = new URL(page.url()).pathname;
-      await rootContinueOffline.click({ timeout: 5_000, force: true }).catch(() => null);
-      await page.waitForLoadState("domcontentloaded").catch(() => null);
-      // Wait for SPA to leave "/" (navigation may be async)
-      const leftRoot = await page
-        .waitForURL((u) => new URL(u).pathname !== "/", { timeout: 15_000 })
+      const nextUrl = page
+        .waitForURL((u) => new URL(u).pathname !== "/", { timeout: 12_000 })
         .then(() => true)
         .catch(() => false);
-      return leftRoot || new URL(page.url()).pathname !== beforePathRoot;
+      await btn.click({ timeout: 5_000 }).catch(() => null);
+      await page.waitForLoadState("domcontentloaded").catch(() => null);
+      return nextUrl;
     }
     if (pathname === "/account/login") {
       const offlineTab = page.getByRole("button", { name: "Offline" }).first();
       await offlineTab.waitFor({ state: "visible", timeout: 3_000 }).catch(() => null);
-      await offlineTab.click({ timeout: 2_000, force: true }).catch(() => null);
+      await offlineTab.click({ timeout: 2_000 }).catch(() => null);
       await page.waitForTimeout(500);
     }
-    const continueOfflineAny = page.getByRole("button", {
-      name: /Continue (using )?offline/i
-    }).first();
-    const continueOfflineMain = page
-      .getByRole("button", { name: /Continue (using )?offline/i })
-      .filter({ hasText: /Single device|free forever|No signup/i })
-      .first();
-    const waitMs =
-      pathname === "/signup" || pathname === "/account/login" ? 10_000 : 3_000;
-    // On /signup (e.g. self-hosted) the button may be just "Continue offline" without "Single device..." text. Try the unfiltered button first so we click it immediately.
-    let target: ReturnType<typeof page.getByRole>;
-    if (pathname === "/signup") {
-      try {
-        await continueOfflineAny.waitFor({ state: "visible", timeout: waitMs });
-        target = continueOfflineAny;
-      } catch {
-        return false;
-      }
-    } else {
-      try {
-        await continueOfflineMain.waitFor({ state: "visible", timeout: waitMs });
-        target = continueOfflineMain;
-      } catch {
-        try {
-          await continueOfflineAny.waitFor({ state: "visible", timeout: 2_000 });
-          target = continueOfflineAny;
-        } catch {
-          return false;
-        }
-      }
+    const continueOfflineBtn = page.getByRole("button", { name: /Continue (using )?offline/i }).first();
+    try {
+      await continueOfflineBtn.waitFor({ state: "visible", timeout: pathname === "/signup" ? 10_000 : 5_000 });
+    } catch {
+      return false;
     }
-    const beforePath = new URL(page.url()).pathname;
-    await target.click({ timeout: 5_000, force: true }).catch(() => null);
-    await page.waitForLoadState("domcontentloaded").catch(() => null);
-    const progressed = await page
-      .waitForURL(
-        (u) => {
-          const p = new URL(u).pathname;
-          return p !== "/signup" && p !== "/account/login";
-        },
-        { timeout: 8_000, waitUntil: "domcontentloaded" }
-      )
+    const leftAuth = page
+      .waitForURL((u) => new URL(u).pathname !== "/signup" && new URL(u).pathname !== "/account/login", { timeout: 10_000 })
       .then(() => true)
       .catch(() => false);
-    return progressed || new URL(page.url()).pathname !== beforePath;
+    await continueOfflineBtn.click({ timeout: 5_000 }).catch(() => null);
+    await page.waitForLoadState("domcontentloaded").catch(() => null);
+    return leftAuth;
   };
 
-  for (let i = 0; i < 4; i += 1) {
-    const handled = await clickContinueOfflineIfVisible();
-    if (!handled) break;
-  }
-  // If still on login page, the "Continue offline" that works lives on /signup (AccountForm), not on /account/login (Login.svelte's button is no-op). Go there and try again.
-  const pathAfterLoops = new URL(page.url()).pathname;
-  if (
-    pathAfterLoops === "/account/login" ||
-    pathAfterLoops === "/signup" ||
-    pathAfterLoops === "/"
-  ) {
-    await safeGoto("/signup");
-    await page.waitForLoadState("domcontentloaded").catch(() => null);
-    for (let j = 0; j < 3; j += 1) {
+  if (!leftAuthPage) {
+    for (let i = 0; i < 4; i += 1) {
       const handled = await clickContinueOfflineIfVisible();
       if (!handled) break;
       await page.waitForLoadState("domcontentloaded").catch(() => null);
     }
-  }
-  for (let i = 0; i < 3; i += 1) {
-    const handled = await clickContinueOfflineIfVisible();
-    if (!handled) break;
-    await page.waitForLoadState("domcontentloaded").catch(() => null);
+    const pathNow = new URL(page.url()).pathname;
+    if (pathNow === "/" || pathNow === "/signup" || pathNow === "/account/login") {
+      await safeGoto("/signup");
+      await page.waitForLoadState("domcontentloaded").catch(() => null);
+      for (let j = 0; j < 3; j += 1) {
+        const handled = await clickContinueOfflineIfVisible();
+        if (!handled) break;
+        await page.waitForLoadState("domcontentloaded").catch(() => null);
+      }
+    }
   }
 
   const productConfig = resolveProductConfig();
-  await page.goto(`/${productConfig.homePath}`, { waitUntil: "domcontentloaded" });
-  // Wait until we're past signup/login (app may redirect / to /calendar). Use domcontentloaded so SPA client-side nav is enough.
-  await page.waitForURL(
-    (u) => {
-      const p = new URL(u).pathname;
-      return p !== "/signup" && p !== "/account/login";
-    },
-    { timeout: 25_000, waitUntil: "domcontentloaded" }
-  );
-
-  // If we're not already on home, navigate there (relative path = same origin).
   const currentPath = new URL(page.url()).pathname;
   const onHome =
     currentPath === `/${productConfig.homePath}` ||
     currentPath.startsWith(`/${productConfig.homePath}/`);
   if (!onHome) {
-    await page.goto(`/${productConfig.homePath}`, {
-      waitUntil: "domcontentloaded"
-    });
+    await page.goto(`/${productConfig.homePath}`, { waitUntil: "domcontentloaded" });
     await page.waitForURL(
       (u) => {
         const p = new URL(u).pathname;
@@ -273,11 +133,6 @@ export async function ensureInAppOnHome(page: Page) {
       },
       { timeout: 15_000, waitUntil: "domcontentloaded" }
     );
-    for (let i = 0; i < 3; i += 1) {
-      const handled = await clickContinueOfflineIfVisible();
-      if (!handled) break;
-      await page.waitForLoadState("domcontentloaded").catch(() => null);
-    }
   }
 
   const navMarkers = [


### PR DESCRIPTION
## Summary by Sourcery

Switch Playwright e2e tests to use pre-saved email/password auth sessions via storageState instead of logging in during tests, and improve base URL handling for multi-project setups.

New Features:
- Add scripts and tooling to save email/password-based auth state per product for reuse in Playwright tests.
- Load per-project Playwright storageState files automatically so tests start with an authenticated session when available.

Enhancements:
- Simplify in-app navigation helper to rely on saved auth sessions and streamlined offline-continue handling instead of performing login flows at runtime.
- Extend Playwright config and global setup to support per-project base URLs and warn when stored auth origins do not match the configured base URL.

Tests:
- Configure Playwright projects to optionally use saved email auth state files, reducing test flakiness and runtime by avoiding repeated interactive logins.

Chores:
- Add npm scripts to generate and save email/password auth state for each product environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prefer explicit app base URLs and detect per-project base URL variants to avoid starting a dev server.
  * Use filesystem-based Playwright auth state with product-aware storage paths and added scripts to save email-based auth for multiple products.
  * Simplified test helpers to rely on pre-saved authentication sessions.

* **Bug Fixes / Reliability**
  * Log a runtime warning when saved auth origins differ from the current base URL.
  * CI smoke-test workflow updated to start a local TLS proxy, multi-step server setup, and perform a best-effort auth-state save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->