### PR TITLE
TIDY-437

### DIFF
--- a/apps/e2e-playwright/tests/shared/left-nav-sidebar.spec.ts
+++ b/apps/e2e-playwright/tests/shared/left-nav-sidebar.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { ensureInAppOnHome } from "../utils/helpers";
+
+const runtimeEnv = (
+  globalThis as { process?: { env?: Record<string, string | undefined> } }
+).process?.env;
+
+test.skip(
+  runtimeEnv?.SKIP_E2E === "1",
+  "E2E suite disabled by environment"
+);
+
+/**
+ * All three products (nucleum, pointron, memotron) share the same left-nav strip:
+ * UserBaseLayer → UserLayout → LeftNav variant="fixed" → LeftNavFixed.
+ * Clicking the strip calls handleToggleMenuLabels() and switches between
+ * ~5.5rem (labels visible) and ~3.5rem (icons only) widths.
+ */
+test.describe("shared – left nav sidebar collapse/expand @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/*", (route) => {
+      const reqUrl = route.request().url();
+      if (/accounts\.google\.com/i.test(reqUrl)) {
+        route.abort();
+        return;
+      }
+      route.continue();
+    });
+  });
+
+  test("click left nav strip: collapses then expands back to original width", async ({
+    page
+  }) => {
+    test.setTimeout(60_000);
+    await ensureInAppOnHome(page);
+
+    const toggle = page.getByTestId("leftnav-sidebar-toggle");
+    await expect(toggle).toBeVisible({ timeout: 15_000 });
+
+    const readWidth = async () => {
+      const box = await toggle.boundingBox();
+      return box?.width ?? 0;
+    };
+
+    const w0 = await readWidth();
+    expect(w0).toBeGreaterThan(0);
+
+    // Use evaluate to fire the element's own click handler directly, avoiding
+    // any child controls (e.g. the menu-settings icon) intercepting the event.
+    await toggle.evaluate((el) => (el as HTMLElement).click());
+    await expect
+      .poll(async () => Math.abs((await readWidth()) - w0), { timeout: 8_000 })
+      .toBeGreaterThan(15);
+
+    const w1 = await readWidth();
+
+    await toggle.evaluate((el) => (el as HTMLElement).click());
+    await expect
+      .poll(async () => Math.abs((await readWidth()) - w1), { timeout: 8_000 })
+      .toBeGreaterThan(15);
+
+    const w2 = await readWidth();
+    // Width should return to within 12px of the original after two toggles.
+    expect(Math.abs(w2 - w0)).toBeLessThan(12);
+  });
+});

--- a/client/layout/leftPanel/LeftNavExpandable.svelte
+++ b/client/layout/leftPanel/LeftNavExpandable.svelte
@@ -96,6 +96,8 @@
             <Button
               icon="sidebar-toggle"
               size={Size.lg}
+              testId="leftnav-sidebar-toggle-icon"
+              ariaLabel="Toggle sidebar width"
               on:click={() => {
                 uiState.toggleSidebar();
               }}

--- a/client/layout/leftPanel/LeftNavFixed.svelte
+++ b/client/layout/leftPanel/LeftNavFixed.svelte
@@ -60,6 +60,9 @@
     )}
   >
     <button
+      type="button"
+      data-testid="leftnav-sidebar-toggle"
+      aria-label="Toggle sidebar width"
       class={cn(
         "flex flex-col items-center justify-between overflow-auto bg-bgs2",
         {


### PR DESCRIPTION
## Summary by Sourcery

Add reliable end-to-end coverage for collapsing and expanding the shared left navigation sidebar.

Enhancements:
- Add accessible test IDs and ARIA labels to left nav sidebar toggle controls to support automated testing and improve accessibility.

Tests:
- Add a shared Playwright regression test that verifies the left nav sidebar strip collapses and then returns to its original width across products.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared Playwright test to verify the left nav sidebar collapses/expands on click and returns to its original width across nucleum, pointron, and memotron. Adds toggle `data-testid`s and ARIA labels, and sets the toggle button `type="button"` for reliable selection and behavior, addressing Linear TIDY-437.

<sup>Written for commit 1f5d37657a7b67e0aa4760b5e0cb5d56d2758d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression test suite to verify the left navigation sidebar’s collapse/expand behavior, ensuring width changes and restoration across toggle cycles.

* **Accessibility**
  * Improved sidebar toggle accessibility by adding descriptive aria labels and explicit test hooks to support screen readers and more reliable UI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->