### PR TITLE
TIDY-443

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ artifacts/
 
 .opencode
 .conduct
+
+# Local dev seed files — not for tracking
+**/seed.local.ts

--- a/client/components/calendar/classic/YearViewV2.svelte
+++ b/client/components/calendar/classic/YearViewV2.svelte
@@ -48,13 +48,18 @@
 
   let visibleYears: ReturnType<typeof getYearData>[] = [];
   let visibleYear: number = selectedDate.getFullYear();
-  let lastScrollTop = 0;
   let scrollTimeout: ReturnType<typeof setTimeout> | undefined;
   let containerRef: HTMLDivElement;
   let isExplicitNavigation = false;
-  let virtualScrollTop = 0;
+  let virtualScrollTop = (selectedDate.getFullYear() - BASE_YEAR) * YEAR_HEIGHT;
   let startYearIndex = 0;
   let isMounted = false;
+  // Prevents onScroll from running while a programmatic scroll recalibration
+  // is in progress (avoids stale-YEAR_HEIGHT fallback giving wrong years).
+  let isRecalibrating = false;
+  // The container width at the time YEAR_HEIGHT was last calibrated.  onScroll
+  // skips year updates when the live width differs (layout transition).
+  let calibratedWidth = 0;
 
   let showYearIndicators =
     preferences.resolve(Preference.CALENDAR_TILE_INDICATORS_YEAR) ?? true;
@@ -67,20 +72,9 @@
   onDestroy(unsubscribe);
   onMount(() => {
     updateVisibleYears();
+    calibratedWidth = containerRef?.clientWidth ?? 0;
     requestAnimationFrame(() => {
-      const yearElement = document.querySelector(
-        '[id^="year-"]'
-      ) as HTMLElement;
-      if (yearElement) {
-        const actualHeight = yearElement.offsetHeight;
-        if (actualHeight > 0) {
-          YEAR_HEIGHT = actualHeight;
-          const currentYear = selectedDate.getFullYear();
-          virtualScrollTop = getVirtualPosition(currentYear);
-          updateVisibleYears();
-          containerRef.scrollTop = virtualScrollTop;
-        }
-      }
+      remeasureAndRecalibrate(selectedDate.getFullYear());
     });
 
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -91,10 +85,71 @@
       });
     }, 500);
 
+    // Re-calibrate YEAR_HEIGHT when the container is resized (e.g. side panels
+    // opening/closing narrow the calendar area, making year elements taller).
+    let lastContainerWidth = 0;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const newWidth = Math.round(entry.contentRect.width);
+        if (lastContainerWidth !== 0 && newWidth !== lastContainerWidth) {
+          // Capture the current year+month and block onScroll BEFORE the rAF
+          // so that any scroll events fired by the layout change cannot
+          // corrupt state.
+          const targetYear = visibleYear || selectedDate.getFullYear();
+          const targetMonth = selectedDate.getMonth();
+          isRecalibrating = true;
+          requestAnimationFrame(() => {
+            remeasureAndRecalibrate(targetYear, targetMonth);
+          });
+        }
+        lastContainerWidth = newWidth;
+      }
+    });
+    resizeObserver.observe(containerRef);
+
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
+      resizeObserver.disconnect();
     };
   });
+
+  function remeasureAndRecalibrate(targetYear: number, targetMonth?: number) {
+    const yearElement = containerRef?.querySelector(
+      '[id^="year-"]'
+    ) as HTMLElement | null;
+    if (!yearElement) { isRecalibrating = false; return; }
+    const actualHeight = yearElement.offsetHeight;
+    if (actualHeight <= 0) { isRecalibrating = false; return; }
+
+    YEAR_HEIGHT = actualHeight;
+    virtualScrollTop = getVirtualPosition(targetYear);
+    updateVisibleYears();
+
+    // Flush Svelte DOM updates first, then set scrollTop so the browser
+    // scrolls into already-rendered content.  After the year is in view,
+    // refine to the exact month so the user's position is fully restored.
+    tick().then(() => {
+      if (!containerRef) { isRecalibrating = false; return; }
+      containerRef.scrollTop = virtualScrollTop;
+      requestAnimationFrame(() => {
+        if (targetMonth !== undefined) {
+          const useYearLevel =
+            containerRef?.clientWidth > 1200;
+          const targetId = useYearLevel
+            ? `year-${targetYear}`
+            : `month-${targetYear}-${targetMonth}`;
+          const el = document.getElementById(targetId);
+          if (el) {
+            el.scrollIntoView({ block: useYearLevel ? "start" : "center" });
+          }
+        }
+        requestAnimationFrame(() => {
+          if (containerRef) calibratedWidth = containerRef.clientWidth;
+          isRecalibrating = false;
+        });
+      });
+    });
+  }
 
   function getYearFromIndex(index: number): number {
     return BASE_YEAR + index;
@@ -188,7 +243,15 @@
   }
 
   function onScroll(e: Event) {
-    if (!isMounted) return;
+    if (!isMounted || isRecalibrating) return;
+
+    // If the container width changed since the last calibration, a layout
+    // transition is in progress (e.g. side panel opening/closing).  Year
+    // element positions are stale so skip all year detection until the
+    // ResizeObserver recalibrates.
+    if (calibratedWidth && containerRef &&
+        containerRef.clientWidth !== calibratedWidth) return;
+
     const target = e.target as HTMLElement;
     const { scrollTop } = target;
 
@@ -197,45 +260,39 @@
     }
 
     virtualScrollTop = scrollTop;
-    const isScrollingDown = scrollTop > lastScrollTop;
-    lastScrollTop = scrollTop;
 
-    const currentMonth = selectedDate.getMonth();
-    const currentDay = selectedDate.getDate();
-    const currentYear = selectedDate.getFullYear();
+    const newVisibleYear = getVisibleYearFromDOM();
 
-    const targetYear = isScrollingDown ? currentYear + 1 : currentYear - 1;
-
-    const targetDate = createSafeDate(targetYear, currentMonth, currentDay);
-    const dateButtons = Array.from(
-      containerRef.querySelectorAll("button")
-    ).filter((btn) => {
-      const btnText = btn.textContent?.trim();
-      if (btnText === currentDay.toString()) {
-        const monthContainer = btn.closest('[id^="month-"]');
-        return monthContainer?.id === `month-${targetYear}-${currentMonth}`;
-      }
-      return false;
-    });
-
-    if (dateButtons.length > 0) {
-      const containerRect = containerRef.getBoundingClientRect();
-      const dateButton = dateButtons[0];
-      const buttonRect = dateButton.getBoundingClientRect();
-      const isDateVisible =
-        buttonRect.top >= containerRect.top &&
-        buttonRect.bottom <= containerRect.bottom;
-
-      if (isDateVisible && targetYear !== visibleYear) {
-        visibleYear = targetYear;
-        selectedDate = createSafeDate(targetYear, currentMonth, currentDay);
-        dispatch("yearChange", { year: targetYear });
-      }
+    if (newVisibleYear !== null &&
+      newVisibleYear !== visibleYear &&
+      newVisibleYear >= BASE_YEAR &&
+      newVisibleYear < BASE_YEAR + YEAR_RANGE
+    ) {
+      visibleYear = newVisibleYear;
+      selectedDate = createSafeDate(
+        newVisibleYear,
+        selectedDate.getMonth(),
+        selectedDate.getDate()
+      );
+      dispatch("yearChange", { year: newVisibleYear });
     }
 
     scrollTimeout = setTimeout(() => {
       updateVisibleYears();
     }, 16);
+  }
+
+  function getVisibleYearFromDOM(): number | null {
+    if (!containerRef) return null;
+    const containerRect = containerRef.getBoundingClientRect();
+    const centerY = containerRect.top + containerRef.clientHeight / 2;
+    for (const { year } of visibleYears) {
+      const yearEl = document.getElementById(`year-${year}`);
+      if (!yearEl) continue;
+      const rect = yearEl.getBoundingClientRect();
+      if (rect.top <= centerY && rect.bottom >= centerY) return year;
+    }
+    return null;
   }
 
   export function scrollToToday() {

--- a/client/components/charts/EChart.svelte
+++ b/client/components/charts/EChart.svelte
@@ -1286,8 +1286,12 @@
 
   function buildPieOption(isDonut: boolean): EChartsOption {
     const dataset = Array.isArray(data) ? data : [];
-    const palette = resolvePalette(
-      dataset.map((item: any) => String(item?.group ?? item?.key ?? "Value"))
+    const groups = dataset.map((item: any) =>
+      String(item?.group ?? item?.key ?? "Value")
+    );
+    const palette = resolvePalette(groups);
+    const sliceColors = groups.map((group, index) =>
+      resolveColor(group, index, palette)
     );
     const labelColor = resolveAxisLabelColor();
     const valueData = dataset.map((item: any) => ({
@@ -1311,7 +1315,7 @@
         borderRadius: 6,
         borderColor: normalizeColor(currentColors?.bgs1) ?? "#fff",
         borderWidth: 2,
-        color: ({ dataIndex }) => palette[dataIndex % palette.length]
+        color: ({ dataIndex }) => sliceColors[dataIndex % sliceColors.length]
       },
       label: {
         color: labelColor,

--- a/client/elements/contextMenu/ContextMenuItemBase.svelte
+++ b/client/elements/contextMenu/ContextMenuItemBase.svelte
@@ -37,8 +37,10 @@
   <span
     class={cn("min-w-fit whitespace-nowrap", {
       "text-ars1": isRedAccent
-    })}>{item.label ?? properCase(enumToString(item.value.toString()))}</span
-  >
+    })}>
+    {item.label ??
+      (item.value != null ? properCase(enumToString(item.value.toString())) : "")}
+  </span>
 </span>
 {#if item.secondStepComponent || item.action}
   <Icon icon="chevron-right" size={Size.sm} />

--- a/client/products/nucleus/base/NucleusBaseLayer.svelte
+++ b/client/products/nucleus/base/NucleusBaseLayer.svelte
@@ -44,6 +44,21 @@
   async function onReady() {
     if (isLiteMode) return;
     if (!isDebug) await runFallbacks();
+    if (isDebug) {
+      try {
+        const seed = await import(/* @vite-ignore */ "@21n/products/memotron/base/seed.local");
+        await seed.seedDemoNodes();
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        const isModuleNotFound =
+          msg.includes("Failed to fetch") ||
+          msg.includes("Unknown variable dynamic import") ||
+          msg.includes("Cannot find module");
+        if (!isModuleNotFound) {
+          console.warn("[seed.local]", e);
+        }
+      }
+    }
     // TODO
     $appLoadingState.isLocalLoaded = true;
   }

--- a/client/products/pointron/analytics/page/CardSelector.svelte
+++ b/client/products/pointron/analytics/page/CardSelector.svelte
@@ -85,7 +85,7 @@
       value: AnalyticsCardType.METRICS,
       icon: resolveChartIcon(AnalyticsCardType.METRICS),
       groupId: "other"
-    }
+    },
   ];
   let groups: DropdownGroup[] = [
     {


### PR DESCRIPTION
## Summary by Sourcery

Improve calendar year view scroll calibration and DOM-based visible year detection, refine pie chart color resolution, harden context menu label rendering, add optional local seeding for Nucleus base layer, and tidy minor UI config.

New Features:
- Add optional local demo data seeding for the Nucleus base layer when a local seed module is available.

Bug Fixes:
- Stabilize classic calendar year view scrolling by recalibrating year heights on mount and container resize while preventing stale layout data from corrupting the visible year.
- Determine the visible year in the calendar based on actual DOM element positions instead of scroll direction heuristics to keep selection in sync during layout shifts.
- Ensure pie chart slices always resolve colors via per-slice color resolution rather than indexing directly into the palette when custom color logic is used.
- Prevent context menu items from rendering an unintended label when the item value is null or undefined.

Enhancements:
- Preserve the user’s calendar scroll position across layout-induced resizes by recalculating scroll offsets and scrolling back to the appropriate year or month.
- Simplify analytics card selector options with minor formatting cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the calendar Year view across layout changes and makes pie/donut colors deterministic. Adds optional local seeding for `@21n/products/memotron` to speed up local dev.

- **Bug Fixes**
  - Calendar (Year): Recalibrates on mount and container width changes, suspends scroll handling during recalibration/width transitions, derives the visible year from the view center, and restores scroll to the correct month/year.
  - Charts (Pie/Donut): Uses per-group `resolveColor` so slice and legend colors stay in sync regardless of data order.
  - Context menu: Hides labels when `item.value` is null/undefined.

- **New Features**
  - Local dev seeding: In debug, tries to load `@21n/products/memotron/base/seed.local` and run `seedDemoNodes()`; adds `**/seed.local.ts` to `.gitignore`.

<sup>Written for commit aeea172a9549f84a89293ffc34908a9671552005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter calendar year view: improved initial scroll positioning, automatic recalibration on resize, and more reliable year detection while scrolling.
  * Quietly load optional local demo data in debug mode when available.

* **Bug Fixes**
  * Fixed context menu label rendering for undefined/null values.
  * Improved pie chart slice color assignment for more consistent visuals.

* **Chores**
  * Updated ignore patterns to exclude local seed files and tidied .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->