### PR TITLE
TIDY-449 - design improvements

### DIFF
--- a/client/components/calendar/birdView/Birdview.svelte
+++ b/client/components/calendar/birdView/Birdview.svelte
@@ -24,7 +24,7 @@
 
   let {
     mode = TimeScaleUnit.DAY,
-    birthdate = new Date(1995, 3, 10),
+    birthdate = undefined,
     groupByBirthdate = true,
     yearPhases = []
   }: {

--- a/client/components/calendar/birdView/Roller.svelte
+++ b/client/components/calendar/birdView/Roller.svelte
@@ -76,9 +76,7 @@
     config: RollerConfig;
     items: any[];
     selectedItem?: string | number;
-    handleWheelEvent: (
-      e: WheelEvent | ProgrammedVerticalWheelEvent
-    ) => void;
+    handleWheelEvent: (e: WheelEvent | ProgrammedVerticalWheelEvent) => void;
     container?: HTMLDivElement;
     onMount?: ((scrollToSelectedItem: () => void) => void) | undefined;
   } = $props();
@@ -154,23 +152,30 @@
     return year;
   }
 
-  function resolveYearSuffix(year: number) {
+  function resolveYearDecadeAgePrefix(year: number) {
     if (!isGroupedByBirthdate() || !shouldRenderYearDivider(year))
       return undefined;
-    return getAgeSuffix(year) || undefined;
+    const ageText = getAgeSuffix(year);
+    return ageText ? `${ageText}s` : undefined;
+  }
+
+  function resolveYearPrefix(year: number) {
+    const decadePrefix = resolveYearDecadeAgePrefix(year);
+    if (decadePrefix) return decadePrefix;
+    if (!isGroupedByBirthdate()) return undefined;
+    const y = Number(year);
+    const selectedYear = Number(selectedItem);
+    const matchesHighlight =
+      Number.isFinite(selectedYear) && y === selectedYear;
+    if (!matchesHighlight) return undefined;
+    const ageText = getAgeSuffix(year);
+    return ageText || undefined;
   }
 
   function resolveMonthLabel(year: number, month: string, index: number) {
     let label = month;
     if (index == 0) label += ` ${String(year).slice(-2)}`;
     return label;
-  }
-
-  function resolveMonthSuffix(year: number, index: number) {
-    if (!isGroupedByBirthdate() || index != birthdateParts.monthIndex) {
-      return undefined;
-    }
-    return getAgeSuffix(year) || undefined;
   }
 
   function isBirthday(prefix: string, item: string) {
@@ -211,9 +216,14 @@
   }
 
   function getDayLabel(prefix: string, item: string) {
-    return Number(item) == 1
-      ? `${prefix.slice(getFirstAlphabetPosition(prefix))} ${item}`
-      : item;
+    const n = Number(item);
+    if (n == 1) {
+      return `${prefix.slice(getFirstAlphabetPosition(prefix))} ${item}`;
+    }
+    if (Number.isFinite(n) && n >= 2 && n <= 9 && String(item).length == 1) {
+      return `0${item}`;
+    }
+    return item;
   }
 
   function getDayAdornment(prefix: string, item: string) {
@@ -503,8 +513,7 @@
               {config}
               item={month}
               label={resolveMonthLabel(item, month, index)}
-              suffix={resolveMonthSuffix(item, index)}
-              prefix={item}
+              context={item}
               bind:selectedItem
               {handleClick}
             />
@@ -512,7 +521,7 @@
         {:else}
           <RollerButton
             {config}
-            prefix={config.itemType == Itemtype.YEAR
+            context={config.itemType == Itemtype.YEAR
               ? ""
               : item.slice(0, getLastAlphabetPosition(item) + 1)}
             label={config.itemType == Itemtype.DAY
@@ -523,8 +532,8 @@
               : config.itemType == Itemtype.YEAR
                 ? resolveYearLabel(item)
                 : undefined}
-            suffix={config.itemType == Itemtype.YEAR
-              ? resolveYearSuffix(item)
+            prefix={config.itemType == Itemtype.YEAR
+              ? resolveYearPrefix(item)
               : undefined}
             adornment={config.itemType == Itemtype.DAY
               ? getDayAdornment(

--- a/client/components/calendar/birdView/RollerButton.svelte
+++ b/client/components/calendar/birdView/RollerButton.svelte
@@ -11,7 +11,8 @@
     adornment,
     selectedItem = $bindable(),
     handleClick,
-    prefix = ""
+    prefix,
+    context = ""
   }: {
     config: any;
     item: any;
@@ -21,6 +22,7 @@
     selectedItem?: any;
     handleClick: (value: any) => void;
     prefix?: string;
+    context?: string;
   } = $props();
 
   const currYear = new Date().getFullYear();
@@ -41,7 +43,7 @@
   ];
   const currMonth = monthNames[currMonthIndex];
   const currDate = new Date().getDate();
-  const isSelected = $derived(selectedItem == prefix + item);
+  const isSelected = $derived(selectedItem == context + item);
   const state = $derived.by(() => {
     switch (config.itemType) {
       case Itemtype.YEAR:
@@ -51,25 +53,25 @@
         };
       case Itemtype.MONTH:
         return {
-          isToday: currYear == Number(prefix) && currMonth == item,
+          isToday: currYear == Number(context) && currMonth == item,
           isPast:
-            currYear > Number(prefix) ||
-            (currYear == Number(prefix) &&
+            currYear > Number(context) ||
+            (currYear == Number(context) &&
               currMonthIndex > monthNames.indexOf(item))
         };
       case Itemtype.DAY: {
-        const firstAlphIndex = getFirstAlphabetPosition(prefix);
+        const firstAlphIndex = getFirstAlphabetPosition(context);
         return {
           isToday:
-            currYear == Number(prefix.slice(0, firstAlphIndex)) &&
-            currMonth == prefix.slice(-3) &&
+            currYear == Number(context.slice(0, firstAlphIndex)) &&
+            currMonth == context.slice(-3) &&
             currDate == Number(item),
           isPast:
-            currYear > Number(prefix.slice(0, firstAlphIndex)) ||
-            (currYear == Number(prefix.slice(0, firstAlphIndex)) &&
-              currMonthIndex > monthNames.indexOf(prefix.slice(-3))) ||
-            (currYear == Number(prefix.slice(0, firstAlphIndex)) &&
-              currMonthIndex == monthNames.indexOf(prefix.slice(-3)) &&
+            currYear > Number(context.slice(0, firstAlphIndex)) ||
+            (currYear == Number(context.slice(0, firstAlphIndex)) &&
+              currMonthIndex > monthNames.indexOf(context.slice(-3))) ||
+            (currYear == Number(context.slice(0, firstAlphIndex)) &&
+              currMonthIndex == monthNames.indexOf(context.slice(-3)) &&
               currDate > Number(item))
         };
       }
@@ -90,24 +92,35 @@
   )}
   style="height:{config.itemHeight}px;"
   {...{
-    [`data-${config.itemType}`]: `${prefix}${item}`
+    [`data-${config.itemType}`]: `${context}${item}`
   }}
   onclick={() => {
-    handleClick(prefix + item);
+    handleClick(context + item);
   }}
   onkeydown={(event) => {
     if (event.key === "Enter") {
-      handleClick(prefix + item);
+      handleClick(context + item);
     }
   }}
 >
   <span class="flex w-full items-center justify-center">
     <span class="relative inline-flex items-center justify-center">
-      <span>{label ?? item}</span>
+      {#if prefix}
+        <span
+          class={cn(
+            "absolute right-full mr-1 top-1/2 -translate-y-1/2 rounded-md px-1 py-0.5 text-b5 leading-none tabular-nums",
+            { "bg-aps3 text-aps1": isSelected },
+            { "bg-bgs3 text-fgs3": !isSelected }
+          )}
+        >
+          {prefix}
+        </span>
+      {/if}
+      <span class="tabular-nums">{label ?? item}</span>
       {#if suffix}
         <span
           class={cn(
-            "absolute left-full ml-1 top-1/2 -translate-y-1/2 rounded-full px-1.5 py-0.5 text-b5 leading-none",
+            "absolute left-full ml-1 top-1/2 -translate-y-1/2 rounded-md px-1 py-0.5 text-b5 leading-none tabular-nums",
             { "bg-aps3 text-aps1": isSelected },
             { "bg-bgs3 text-fgs3": !isSelected }
           )}

--- a/client/components/calendar/birdView/RollerPicker.svelte
+++ b/client/components/calendar/birdView/RollerPicker.svelte
@@ -351,12 +351,9 @@
       itemHeight: rollerItemHeight,
       containerHeight: containerHeight
     };
-    if (mode == TimeScaleUnit.PART)
-      onSelectedDateChange?.(selectedDate);
-    else if (mode == TimeScaleUnit.DAY)
-      onSelectedMonthChange?.(selectedMonth);
-    else if (mode == TimeScaleUnit.MONTH)
-      onSelectedYearChange?.(selectedYear);
+    if (mode == TimeScaleUnit.PART) onSelectedDateChange?.(selectedDate);
+    else if (mode == TimeScaleUnit.DAY) onSelectedMonthChange?.(selectedMonth);
+    else if (mode == TimeScaleUnit.MONTH) onSelectedYearChange?.(selectedYear);
 
     onMount?.({
       handleDaysWheelEvent,
@@ -366,7 +363,10 @@
   });
 </script>
 
-<div class="relative flex bg-bgs2" bind:clientHeight={containerHeight}>
+<div
+  class="relative flex bg-bgs1 border-r border-brs2"
+  bind:clientHeight={containerHeight}
+>
   <Roller
     handleWheelEvent={handleYearsWheelEvent}
     items={years}

--- a/client/components/combination/CreateCombination.svelte
+++ b/client/components/combination/CreateCombination.svelte
@@ -16,35 +16,35 @@
   import { CombinationType } from "@21n/components/combination/combination.type";
 
   let label = "";
-  let type: CombinationType = CombinationType.SIDENAV;
+  let type: CombinationType = CombinationType.NOTEBOOK;
   let error: string | undefined = undefined;
   const typeOptions: ISelectItem[] = [
     {
-      label: "Side nav",
+      label: "Notebook",
       icon: "sidebar",
-      value: CombinationType.SIDENAV
+      value: CombinationType.NOTEBOOK
     },
-    {
-      label: "Wall",
-      icon: "widget",
-      value: CombinationType.WALL,
-      isDisabled: true,
-      badge: "planned"
-    },
+    // {
+    //   label: "Wall",
+    //   icon: "widget",
+    //   value: CombinationType.WALL,
+    //   isDisabled: true,
+    //   badge: "planned"
+    // },
     {
       label: "Canvas",
       icon: "canvas",
-      value: CombinationType.WHITEBOARD,
-      isDisabled: true,
-      badge: "planned"
-    },
-    {
-      label: "Mind map",
-      icon: "tree-view",
-      value: CombinationType.MINDMAP,
+      value: CombinationType.CANVAS,
       isDisabled: true,
       badge: "planned"
     }
+    // {
+    //   label: "Mind map",
+    //   icon: "tree-view",
+    //   value: CombinationType.MINDMAP,
+    //   isDisabled: true,
+    //   badge: "planned"
+    // }
   ];
 
   async function onSave() {
@@ -53,7 +53,7 @@
       error = "Name is required";
       return;
     }
-    if (type !== CombinationType.SIDENAV) {
+    if (type !== CombinationType.NOTEBOOK) {
       toasts.error("Only side nav combinations are supported currently");
       return;
     }
@@ -74,14 +74,17 @@
     <div class="flex flex-col gap-6 w-full h-full">
       <TextInput
         label={{
-          label: "Name of the combination",
+          label: "Name of the space",
           orientation: Orientation.Vertical
         }}
-        placeholder="Some combination"
+        placeholder="School, Project X, Work, etc."
         bind:value={label}
       />
       <OptionSelector
-        labelProps={{ label: "Type of combination" }}
+        labelProps={{
+          label: "Layout of the space",
+          orientation: Orientation.Vertical
+        }}
         style={OptionSelectorStyle.TRAIN}
         options={typeOptions}
         bind:selected={type}

--- a/client/components/combination/combination.type.ts
+++ b/client/components/combination/combination.type.ts
@@ -58,13 +58,36 @@ export interface IActiveCombination
 }
 
 export enum CombinationType {
+  /**
+   * @deprecated - use {@link CombinationType.NOTEBOOK} instead.
+   * Side nav is now a view type in notebook.
+   * 
+   * A markdown page can be inserted as a sub side nav (TOC becomes the hierarchy).
+   */
   SIDENAV = "sidenav",
+  /**
+   * @deprecated - use {@link CombinationType.CANVAS} instead.
+   */
   WHITEBOARD = "whiteboard",
+  /**
+   * @deprecated - use {@link CombinationType.CANVAS} instead.
+   * 
+   * A canvas can have option to insert a mind map.
+   * A markdown page can be inserted as a mind map (TOC becomes the hierarchy).
+   */
   MINDMAP = "mindmap",
+  /**
+   * @deprecated - use {@link CombinationType.NOTEBOOK} instead. WALL is now a view type in notebook.
+   * 
+   * Infinitely deep structured layout.
+   * A markdown page can be inserted as sub wall (TOC becomes the hierarchy).
+   */
   WALL = "wall",
   /**
    * @deprecated - use horizontal stack and vertical stack when Calendar scope is activated in Calendar instead.
    * Previous - Pyramid, Funnel views merged into regular timeline view.
    */
-  TIMELINE = "timeline"
+  TIMELINE = "timeline",
+  NOTEBOOK = "notebook",
+  CANVAS = "canvas"
 }

--- a/client/components/commandBar/CommandBar.svelte
+++ b/client/components/commandBar/CommandBar.svelte
@@ -45,7 +45,7 @@
   const defaultPlaceholder = $derived(
     isFullPageContext
       ? "Search for a command"
-      : "Search for a command or scroll to see full list"
+      : "Search anything, run a command or ask Rhombus"
   );
   let placeholder = $state("");
   $effect(() => {
@@ -115,7 +115,8 @@
     placeholder =
       typeof nextSearchAction.searchActionParams?.placeholder === "function"
         ? nextSearchAction.searchActionParams.placeholder(componentParams)
-        : (nextSearchAction.searchActionParams?.placeholder ?? "select an item");
+        : (nextSearchAction.searchActionParams?.placeholder ??
+          "select an item");
   }
   function close() {
     value = "";
@@ -127,7 +128,12 @@
   }
 
   function resolveSearchActionLabel() {
-    return componentParams?.label ?? searchAction?.cmdLabel ?? searchAction?.label ?? "";
+    return (
+      componentParams?.label ??
+      searchAction?.cmdLabel ??
+      searchAction?.label ??
+      ""
+    );
   }
   /**
    * Used in command-only mode.
@@ -156,7 +162,7 @@
 
 <div
   class={cn(
-    "flex flex-col cw:w-full cw:min-w-full w-[40rem] max-w-full overflow-auto",
+    "flex flex-col cw:w-full cw:min-w-full w-[50rem] max-w-full overflow-auto",
     {
       "border border-brs2 rounded-md": isFullPageContext,
       "cw:h-full h-[30rem]":
@@ -229,7 +235,7 @@
           {:else if isFullPageContext && isFocusing}
             Press <b>Esc</b> to close
           {:else}
-            Cmd bar
+            Super bar
           {/if}
         </div>
       </div>
@@ -252,7 +258,7 @@
       <CmdResults
         search={value}
         bind:this={resultsRef}
-        onSearchAction={onSearchAction}
+        {onSearchAction}
         onClose={close}
       />
     {/if}
@@ -268,6 +274,21 @@
       )}
     >
       <span class="inline-flex items-center gap-1">
+        Use <ShortcutText
+          shortcut={{
+            key: ">"
+          }}
+          parentBgIndex={2}
+          isAlwaysShown={true}
+        /> for commands, <ShortcutText
+          shortcut={{
+            key: "`"
+          }}
+          parentBgIndex={2}
+          isAlwaysShown={true}
+        /> for quick note
+      </span>
+      <span class="inline-flex items-center gap-1">
         Press
         <ShortcutText
           shortcut={Action.CLOSE}
@@ -276,11 +297,11 @@
         />
         to close
       </span>
-      <ShortcutText
+      <!-- <ShortcutText
         shortcut={Action.CMD}
         parentBgIndex={2}
         isAlwaysShown={true}
-      />
+      /> -->
     </div>
   {/if}
 </div>

--- a/client/components/resource/ResourcePanelSwitcher.svelte
+++ b/client/components/resource/ResourcePanelSwitcher.svelte
@@ -19,13 +19,13 @@
   import Icon from "@21n/elements/Icon.svelte";
   import { AppSearchParam } from "@21n/types/appStore.type";
 
-interface Props {
-  resourceStore: Readable<IResourcePageWithPanels>;
-  panels: IToggleItem[];
-  isConstrainedWidth?: boolean;
-  accessMode: AccessMode;
-  onAction?: ((detail: IContextMenuItem["value"]) => void) | undefined;
-  contextMenuResolver?:
+  interface Props {
+    resourceStore: Readable<IResourcePageWithPanels>;
+    panels: IToggleItem[];
+    isConstrainedWidth?: boolean;
+    accessMode: AccessMode;
+    onAction?: ((detail: IContextMenuItem["value"]) => void) | undefined;
+    contextMenuResolver?:
       | (() =>
           | {
               group: string;
@@ -47,36 +47,39 @@ interface Props {
     $page.url.searchParams.get(AppSearchParam.MAX) === "true"
   );
 
-function resolveContextMenu() {
-  return contextMenuResolver?.() ?? [];
-}
+  function resolveContextMenu() {
+    return contextMenuResolver?.() ?? [];
+  }
 
-function handleContextMenuAction(event: CustomEvent<any>) {
-  onAction?.(event.detail);
-}
+  function handleContextMenuAction(event: CustomEvent<any>) {
+    onAction?.(event.detail);
+  }
 </script>
 
 <div
-  class={cn("absolute bottom-0 inset-x-0 mx-auto w-fit z-10", {
-    "mb-3": $resourceStore.isInFocusMode,
-    "mb-4": !$resourceStore.isInFocusMode
+  class={cn("fixed bottom-0 inset-x-0 mx-auto w-fit z-10", {
+    // "mb-3": $resourceStore.isInFocusMode,
+    // "mb-4": !$resourceStore.isInFocusMode
   })}
 >
   <div
     class={cn(
-      "flex flex-col border-t border-x border-brs3 shadow-md rounded-md  overflow-hidden"
+      "flex flex-col border-t border-x border-brs3 border-t-bgs1 shadow--md rounded--md  overflow-hidden"
     )}
   >
     <div
       class={cn("flex cw:flex-row-reverse  overflow-hidden", {
         "h-8 bg-bgs3": $resourceStore.isInFocusMode,
-        "h-12 bg-bgs2": !$resourceStore.isInFocusMode,
-        "rounded-md": !$resourceStore.isInEditMode,
-        "rounded-t-md": $resourceStore.isInEditMode
+        "h-[50px] bg-bgs1": !$resourceStore.isInFocusMode,
+        "rounded--md": !$resourceStore.isInEditMode,
+        "rounded-t--md": $resourceStore.isInEditMode
       })}
     >
       {#if $resourceStore.isInFocusMode}
-        <div class="flex h-full" in:slide={{ duration: 300, axis: "x" }}>
+        <div
+          class="flex h-full border-t border-brs2"
+          in:slide={{ duration: 300, axis: "x" }}
+        >
           <BoxButton
             icon="cross"
             label="Close"
@@ -88,7 +91,9 @@ function handleContextMenuAction(event: CustomEvent<any>) {
           />
         </div>
       {:else}
-        <div class="flex cw:border-l border-r border-brs2 text-fgs2 mr-3">
+        <div
+          class="flex cw:border-l border-r border-t border-brs2 text-fgs2 mr-3"
+        >
           <BoxButton
             label="Close"
             icon="cross"
@@ -107,7 +112,7 @@ function handleContextMenuAction(event: CustomEvent<any>) {
           options={panels}
           size={$view.isConstrainedWidth ? Size.sm : Size.md}
           isAccentColor={true}
-          isActiveIndicatorOnTop={true}
+          isActiveIndicatorOnTop={false}
           selected={$resourceStore.panel}
           onSelect={(e) => $resourceStore.switchPanel(e.detail)}
           isIconOnlyMode={$view.isConstrainedWidth}
@@ -130,7 +135,7 @@ function handleContextMenuAction(event: CustomEvent<any>) {
               }}
             />
           {:else}
-            <div class="flex items-center bg--bgs3 h-full">
+            <div class="flex items-center bg--bgs3 border-t border-brs2 h-full">
               <BoxButton
                 icon={isMaximized ? "exitfullscreen" : "fullscreen"}
                 tooltip={isMaximized ? "Minimize" : "Maximize"}
@@ -147,14 +152,14 @@ function handleContextMenuAction(event: CustomEvent<any>) {
                     size={Size.lg}
                     isBoxed={true}
                     parentBgIndex={1}
-                  class="h-full w-10"
-                  id="resourcePanelContextMenu"
-                  icon="more-outline-horizontal"
-                  heading="Actions"
-                  onAction={handleContextMenuAction}
-                />
-              </div>
-            {/if}
+                    class="h-full w-10"
+                    id="resourcePanelContextMenu"
+                    icon="more-outline-horizontal"
+                    heading="Actions"
+                    onAction={handleContextMenuAction}
+                  />
+                </div>
+              {/if}
             </div>
           {/if}
         </div>

--- a/client/layout/layers/UserLayout.svelte
+++ b/client/layout/layers/UserLayout.svelte
@@ -143,9 +143,6 @@
           <LeftNav variant="fixed" />
         {/if}
         <div class="flex flex-col h-full w-full">
-          {#if !$view.isPortrait && !isMaxMode}
-            <TopNav topnav={topnavContent} />
-          {/if}
           <div class="flex w-full flex-grow">
             {#if $context.embed !== Embed.HANDSET && !isHideLeftNavBar && !isMaxMode}
               <LeftNav variant="fixed" isHidePanel={!!pop || !!mainPath} />
@@ -153,7 +150,10 @@
             <div class="min-w-0 flex-grow relative">
               {#if mainPath}
                 <div class="absolute inset-0 w-full h-full bg-bgs1 z-40">
-                  <ComponentResolver path={mainPath} params={{ isInline: true }} />
+                  <ComponentResolver
+                    path={mainPath}
+                    params={{ isInline: true }}
+                  />
                 </div>
               {/if}
               {#if popId}
@@ -180,6 +180,9 @@
               <RightPanel action={rightPanel} />
             {/if}
           </div>
+          {#if !$view.isPortrait && !isMaxMode}
+            <TopNav topnav={topnavContent} />
+          {/if}
           {#if $hTrail.path.length > 0}
             <BottomNav />
           {/if}

--- a/client/layout/leftPanel/LeftNavFixed.svelte
+++ b/client/layout/leftPanel/LeftNavFixed.svelte
@@ -83,8 +83,8 @@
       class={cn(
         "flex flex-col items-center justify-between overflow-auto bg-bgs2",
         {
-          "w-[5.5rem] min-w-[5.5rem] cursor-w-resize": !isHideMenuLabels,
-          "w-[3.5rem] min-w-[3.5rem] cursor-e-resize": isHideMenuLabels
+          "w-[5.5rem] min-w-[5.5rem] !cursor-w-resize": !isHideMenuLabels,
+          "w-[3.5rem] min-w-[3.5rem] !cursor-e-resize": isHideMenuLabels
         },
         (!dev_mixedPanel || !$appStore.currentComponent?.panel) && {
           "rounded-lg border-none": isRounded,

--- a/client/layout/topNav/TopNav.svelte
+++ b/client/layout/topNav/TopNav.svelte
@@ -106,7 +106,7 @@
 <div class="hidden otopl:!block w-full min-h-6 h-6 bg-bgs2"></div>
 <div
   class={cn(
-    "w-full h-11 max-h-11 min-h-11 bg-bgs2 border-b border-brs3 userdata grid",
+    "w-full h-12 max-h-12 min-h-11 bg-bgs2 border-t border-brs3 userdata grid",
     {
       "grid-cols-[auto_1fr]": isFullOverlayMode
     },
@@ -119,7 +119,7 @@
   {#if $context.embed !== Embed.HANDSET}
     <TopNavLeftLogo isRenderProfilePicture={true} />
   {/if}
-  {#if !isFullOverlayMode}
+  <!-- {#if !isFullOverlayMode}
     <div
       class={cn("flex h-full", {
         "border-r border-brs3": isShowBackToSearch
@@ -172,7 +172,7 @@
         </div>
       </div>
     {/if}
-  {/if}
+  {/if} -->
   {#if isRightOverlayMode || isFullOverlayMode}
     <!-- TODO - multiple toasts case -->
     <div
@@ -218,6 +218,10 @@
       {/if}
     </div>
   {:else}
+    <div class="flex items-center justify-start h-full text-b3 text-fgs3 px-3">
+      Toast, player, status, upcoming message, contextual action suggestions
+      area (Default current time)
+    </div>
     <div
       class="flex items-center justify-end h-full"
       in:fly={{ duration: 200, y: 10, easing: quadIn }}
@@ -242,14 +246,13 @@
         text="Syncing..."
       />
       {@render topnav?.()}
-      <TopNavLeftMenuItem action={Action.TODAY} />
-      <TopNavLeftMenuItem action={Action.NAVIGATOR} />
       <TopNavLeftMenuItem action={Action.CMD} />
-      <TopNavLeftMenuItem action={Action.SETTINGS} isLastItem={true} />
+      <TopNavLeftMenuItem action={Action.NAVIGATOR} isLastItem={true} />
+      <!-- <TopNavLeftMenuItem action={Action.SETTINGS} isLastItem={true} /> -->
       {#if isDev}
         <TopNavLeftMenuItem
           action={Action.RHOMBUS}
-          label="Rhom"
+          tooltip="Rhombus on the side"
           isLastItem={true}
         />
       {/if}

--- a/client/products/memotron/capture/TypeSelector.svelte
+++ b/client/products/memotron/capture/TypeSelector.svelte
@@ -41,7 +41,7 @@
       icon: "markdown"
     },
     {
-      value: CaptureMethod.MARKDOWN,
+      value: CaptureMethod.NOTE,
       label: "Note",
       icon: "note-blank"
     },
@@ -57,7 +57,8 @@
       ? [
           {
             icon: "ri:sketching",
-            value: CaptureMethod.SKETCH
+            value: CaptureMethod.SKETCH,
+            label: "Freehand"
           },
           {
             icon: "globe",

--- a/client/products/memotron/overview/MemotronOverviewLayout.svelte
+++ b/client/products/memotron/overview/MemotronOverviewLayout.svelte
@@ -5,14 +5,8 @@
   import { resizeListener } from "@21n/actions/resize.action";
   import PanelSwitcher from "@21n/elements/switcher/PanelSwitcher.svelte";
   import { PanelSwitcherStyle } from "@21n/types/switcher.enum";
-  import {
-    uiState,
-    uiStateDerived
-  } from "@21n/stores/uiState/uiState.store";
-  import {
-    UIState,
-    UIStateScope
-  } from "@21n/stores/uiState/uiState.type";
+  import { uiState, uiStateDerived } from "@21n/stores/uiState/uiState.store";
+  import { UIState, UIStateScope } from "@21n/stores/uiState/uiState.type";
   import { MemotronOverviewPanel } from "@21n/products/memotron/overview/overview.type";
   import { Product } from "@21n/products/product.type";
   import { appStore } from "@21n/stores/app.store";
@@ -82,7 +76,7 @@
         }
       ]}
       style={PanelSwitcherStyle.BAR}
-      title={isNucleusContext ? "Memory" : "Overview"}
+      title={isNucleusContext ? "" : "Overview"}
       isExpandToFullWidth={true}
       size={Size.sm}
       bind:value={selectedPanel}

--- a/client/products/nucleus/base/NucleusBaseLayer.svelte
+++ b/client/products/nucleus/base/NucleusBaseLayer.svelte
@@ -69,16 +69,16 @@
   }
 </script>
 
-<UserBaseLayer onReady={onReady}>
+<UserBaseLayer {onReady}>
   {#snippet topnav()}
     <div class="flex gap-1 items-center h-full">
       <TopNavLeftMenuItem
         action={resourceAction(Resource.node, ResourceActionType.CREATE)}
       />
       <FocusTopNavWidget />
-      {#if isDebug}
+      <!-- {#if isDebug}
         <TopNavLeftMenuItem action={Action.FEED} />
-      {/if}
+      {/if} -->
     </div>
   {/snippet}
   {@render children?.()}

--- a/client/products/nucleus/nucleus.actions.ts
+++ b/client/products/nucleus/nucleus.actions.ts
@@ -8,7 +8,11 @@ import ComingSoonView from "@21n/elements/ComingSoonView.svelte";
 import LibraryPanelContentResolver from "@21n/components/library/LibraryPanelContentResolver.svelte";
 import { Resource } from "@21n/components/flux/resourceStores/resource.enum";
 import NucleusOverviewPanel from "@21n/products/nucleus/overview/NucleusOverviewPanel.svelte";
-import { AccessMode } from "@21n/components/flux/resourceStores/resource.type";
+import {
+  AccessMode,
+  ResourceActionType
+} from "@21n/components/flux/resourceStores/resource.type";
+import { resourceAction } from "@21n/components/flux/resourceStores/resource.utils";
 
 const actionsToFilterInSub = [Action.LIBRARY, Action.OVERVIEW];
 
@@ -35,12 +39,12 @@ export const nucleusActions: IAction[] = [
     label: "Overview",
     icon: "overview",
     component: NucleusOverview,
-    panel: NucleusOverviewPanel,
+    // panel: NucleusOverviewPanel,
     type: ActionType.PAGE
   },
   {
     action: Action.HOME,
-    label: "Rhom",
+    label: "Rhombus",
     icon: "rhombus",
     component: ComingSoonView,
     type: ActionType.PAGE
@@ -55,5 +59,11 @@ export const nucleusActions: IAction[] = [
     liveActionParams: {
       isOpeningBehaviorConfigurable: true
     }
+  },
+  {
+    action: resourceAction(Resource.combination, ResourceActionType.BROWSE),
+    label: "Spaces",
+    icon: "combination",
+    type: ActionType.PAGE
   }
 ];

--- a/client/products/nucleus/overview/NucleusOverview.svelte
+++ b/client/products/nucleus/overview/NucleusOverview.svelte
@@ -1,16 +1,24 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { uiState } from "@21n/stores/uiState/uiState.store";
-  import {
-    UIState,
-    UIStateScope
-  } from "@21n/stores/uiState/uiState.type";
-  import { OverviewPanel } from "@21n/products/product.type";
+  import { UIState, UIStateScope } from "@21n/stores/uiState/uiState.type";
+  import { OverviewPanel, Product } from "@21n/products/product.type";
   import ComingSoonView from "@21n/elements/ComingSoonView.svelte";
   import AnalyticsV2 from "@21n/products/pointron/analytics/AnalyticsV2.svelte";
   import MemotronOverview from "@21n/products/memotron/overview/MemotronOverview.svelte";
+  import BoxSwitcher from "@21n/elements/switcher/BoxSwitcher.svelte";
+  import { resolveProductConfig } from "@21n/products/product.config";
 
-  let selectedPanel: OverviewPanel = resolveSavedState() ?? OverviewPanel.FOCUS;
+  let selectedPanel: OverviewPanel =
+    resolveSavedState() ?? OverviewPanel.DASHBOARD;
+  const items = [
+    ...(resolveProductConfig(Product.NUCLEUS).overviewPanelSwitcherItems ?? []),
+    {
+      label: "Map",
+      value: OverviewPanel.MAP,
+      icon: "ph:map-pin-light"
+    }
+  ];
 
   function resolveSavedState() {
     const savedPanel = uiState.getState(UIState.nucleusOverviewPanel, {
@@ -23,7 +31,7 @@
 
   onMount(() => {
     const uiStateUnsub = uiState.subscribe(() => {
-      selectedPanel = resolveSavedState() ?? OverviewPanel.FOCUS;
+      selectedPanel = resolveSavedState() ?? OverviewPanel.DASHBOARD;
     });
 
     return () => {
@@ -32,10 +40,21 @@
   });
 </script>
 
-{#if selectedPanel === OverviewPanel.FOCUS}
-  <AnalyticsV2 />
-{:else if selectedPanel === OverviewPanel.MEMORY}
-  <MemotronOverview />
-{:else}
-  <ComingSoonView />
-{/if}
+<div class="w-full h-full flex flex-col">
+  <div class="h-12 min-h-12 border-b border-brs3">
+    <BoxSwitcher options={items} bind:selected={selectedPanel} />
+  </div>
+  {#if selectedPanel === OverviewPanel.DASHBOARD}
+    <div class="w-full h-full flex">
+      <div class="w-80 h-full text-fgs3 text-b2 p-3 border-r border-brs3">
+        <!-- TODO -->
+        dashboard sidebar
+      </div>
+      <AnalyticsV2 />
+    </div>
+  {:else if selectedPanel === OverviewPanel.GRAPH || selectedPanel === OverviewPanel.MAP}
+    <MemotronOverview />
+  {:else}
+    <ComingSoonView />
+  {/if}
+</div>

--- a/client/products/pointron/analytics/AnalyticsV2.svelte
+++ b/client/products/pointron/analytics/AnalyticsV2.svelte
@@ -150,7 +150,7 @@
         <div class="flex overflow-hidden w-full">
           <div class="overflow-x-auto w-full">
             <PanelSwitcher
-              title={isNucleusContext ? "Focus" : "Overview"}
+              title={isNucleusContext ? "" : "Overview"}
               items={pages}
               style={PanelSwitcherStyle.BAR}
               isExpandToFullWidth={true}

--- a/client/products/product-nav.config.ts
+++ b/client/products/product-nav.config.ts
@@ -39,8 +39,18 @@ export interface IProductNavConfig {
 const productNavConfig = {
   [Product.NUCLEUS]: {
     appMenu: [Action.CALENDAR, Action.OVERVIEW, Action.LIBRARY] as const,
-    appMenuDev: [Action.HOME, Action.CALENDAR, Action.OVERVIEW, Action.LIBRARY] as const,
-    appMenuPt: [Action.CALENDAR, Action.LIBRARY_PORTRAIT, Action.OVERVIEW] as const,
+    appMenuDev: [
+      Action.HOME,
+      Action.CALENDAR,
+      Action.OVERVIEW,
+      resourceAction(Resource.combination, ResourceActionType.BROWSE),
+      Action.LIBRARY
+    ] as const,
+    appMenuPt: [
+      Action.CALENDAR,
+      Action.LIBRARY_PORTRAIT,
+      Action.OVERVIEW
+    ] as const,
     homePath: Action.CALENDAR,
     homePathPt: Action.LIBRARY_PORTRAIT,
     librarySectionLabel: "Nucleum",
@@ -55,7 +65,12 @@ const productNavConfig = {
     } as Record<string, string>
   },
   [Product.MEMOTRON]: {
-    appMenu: [resourceAction(Resource.node, ResourceActionType.CREATE), Action.CALENDAR, Action.OVERVIEW, Action.LIBRARY] as const,
+    appMenu: [
+      resourceAction(Resource.node, ResourceActionType.CREATE),
+      Action.CALENDAR,
+      Action.OVERVIEW,
+      Action.LIBRARY
+    ] as const,
     appMenuPt: [] as const,
     homePath: Action.CALENDAR,
     homePathPt: Action.MOBILEHOME,
@@ -71,8 +86,18 @@ const productNavConfig = {
     } as Record<string, string>
   },
   [Product.POINTRON]: {
-    appMenu: [PointronAction.FOCUS, Action.CALENDAR, Action.OVERVIEW, Action.LIBRARY] as const,
-    appMenuPt: [Action.OVERVIEW, Action.CALENDAR, PointronAction.FOCUS, Action.LIBRARY_PORTRAIT] as const,
+    appMenu: [
+      PointronAction.FOCUS,
+      Action.CALENDAR,
+      Action.OVERVIEW,
+      Action.LIBRARY
+    ] as const,
+    appMenuPt: [
+      Action.OVERVIEW,
+      Action.CALENDAR,
+      PointronAction.FOCUS,
+      Action.LIBRARY_PORTRAIT
+    ] as const,
     homePath: Action.CALENDAR,
     homePathPt: PointronAction.FOCUS,
     librarySectionLabel: "Focus",

--- a/client/products/product.config.ts
+++ b/client/products/product.config.ts
@@ -7,7 +7,11 @@ import { MemotronAction } from "@21n/products/memotron/memotronAction.enum";
 import { resourceConfig } from "@21n/components/flux/resourceStores/resource.config";
 import type { IResourceTableConfig } from "@21n/components/flux/flux.type";
 import type { ISelectItem } from "@21n/types/select.type";
-import { nextProducts, nextResourceTableMap, nextNucleusOverviewPanelSwitcherItems } from "@21n/next/product.config";
+import {
+  nextProducts,
+  nextResourceTableMap,
+  nextNucleusOverviewPanelSwitcherItems
+} from "@21n/next/product.config";
 
 const isDev = import.meta.env?.DEV || false;
 
@@ -146,7 +150,7 @@ const resourceTableMap: Record<string, Resource[]> = {
     Resource.session,
     Resource.sessionLog
   ],
-  ...nextResourceTableMap,
+  ...nextResourceTableMap
 };
 
 const nucleusNav = getProductNavConfig(Product.NUCLEUS);
@@ -182,8 +186,8 @@ export const products: Record<string, IAppConfigBase> = {
       "ACTIVATE_LINK_BOX"
     ],
     overviewPanelSwitcherItems: [
-      { label: "Focus", value: OverviewPanel.FOCUS, icon: "circle" },
-      { label: "Memory", value: OverviewPanel.MEMORY, icon: "hexagon" },
+      { label: "Dashboard", value: OverviewPanel.DASHBOARD, icon: "overview" },
+      { label: "Graph", value: OverviewPanel.GRAPH, icon: "graph" },
       ...nextNucleusOverviewPanelSwitcherItems
     ],
     e2eCapabilities: productE2EConfigs.nucleus.capabilities,
@@ -354,7 +358,7 @@ export const products: Record<string, IAppConfigBase> = {
       }
     ]
   },
-  ...nextProducts,
+  ...nextProducts
 };
 
 const tableConfigMapper = (resource: Resource) => {
@@ -368,7 +372,9 @@ const tableConfigMapper = (resource: Resource) => {
 
 export const product =
   import.meta.env?.VITE_PRODUCT ||
-  (typeof process !== "undefined" ? process.env?.PLASMO_PUBLIC_PRODUCT : undefined) ||
+  (typeof process !== "undefined"
+    ? process.env?.PLASMO_PUBLIC_PRODUCT
+    : undefined) ||
   Product.NUCLEUS;
 
 export const resolveProductConfig = (productOverride?: Product): IAppConfig => {

--- a/client/products/product.type.ts
+++ b/client/products/product.type.ts
@@ -1,20 +1,35 @@
 import { NextProduct, NextOverviewPanel } from "@21n/next/product.type";
 
-
 enum OverviewPanelBase {
+  /**
+   * @deprecated - use {@link OverviewPanel.DASHBOARD} instead
+   *
+   * Dashboard will host all dashboards from sub apps and their respective custom dashboards created by users.
+   */
   FOCUS = "focus",
+  /**
+   * @deprecated - use {@link OverviewPanel.GRAPH} and {@link OverviewPanel.MAP} instead
+   */
   MEMORY = "memory",
+  /**
+   * current version: regular central graph
+   * v2: Central graph + another view: Horizontal infinite canvas with clusters
+   */
   GRAPH = "graph",
-  MAP = "map"
+  MAP = "map",
+  DASHBOARD = "dashboard"
 }
 
-export const OverviewPanel = { ...OverviewPanelBase, ...NextOverviewPanel } as const;
+export const OverviewPanel = {
+  ...OverviewPanelBase,
+  ...NextOverviewPanel
+} as const;
 export type OverviewPanel = OverviewPanelBase | NextOverviewPanel;
 
 enum ProductBase {
   NUCLEUS = "nucleus",
   POINTRON = "pointron",
-  MEMOTRON = "memotron",
+  MEMOTRON = "memotron"
 }
 
 export const Product = { ...ProductBase, ...NextProduct } as const;

--- a/client/stores/actionMap.ts
+++ b/client/stores/actionMap.ts
@@ -608,14 +608,14 @@ export const globalActions: IAction[] = [
   {
     action: resourceAction(Resource.combination, ResourceActionType.CREATE),
     component: CreateCombination,
-    label: "Create a new combination",
+    label: "Create a new space",
     type: ActionType.MODAL,
     isInactive: false,
     modalParams: {
-      title: "Create a new combination",
+      title: "Create a new space",
       layout: {
-        size: Size.md,
-        orientation: Orientation.Horizontal,
+        size: Size.sm,
+        orientation: Orientation.Vertical,
         isOveriddenFooter: true
       }
     }


### PR DESCRIPTION
## Summary by Sourcery

Refine core UI layouts, navigation, and terminology across Nucleus, Memotron, calendar, and command bar to support new “spaces”/notebook concepts and updated overview panels.

New Features:
- Add Nucleus overview dashboard layout with sidebar and panel switcher, including Graph and Map views and an extra Map tab entry.
- Introduce a new CombinationType NOTEBOOK and CANVAS to represent spaces and canvases, and expose a dedicated Spaces browse action in Nucleus navigation.
- Extend Nucleus dev navigation to include Spaces browsing from the main app menu.

Enhancements:
- Restyle the resource panel switcher container and controls for a fixed bottom layout with updated borders, shadows, and button states.
- Improve calendar birdview roller visuals and semantics, including better day formatting, decade/age prefixes, and compact roller picker styling.
- Update command bar copy, sizing, and footer hints to emphasize broader “Super bar” behavior and keyboard shortcuts.
- Reposition the top navigation to the bottom of the viewport in user layout and tweak its content, labels, and placeholder status area.
- Adjust Memotron and Pointron overview panel switcher titles to align with the new overview terminology.
- Refine left nav fixed panel cursor behavior and combination creation modal size/orientation and copy for “spaces” language.
- Tweak combination creation options and copy to prefer Notebook/CANVAS and de-emphasize deprecated layout types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Design polish for TIDY-449: new Nucleus Overview with a top switcher (Dashboard by default, Graph + Map), a wider bottom Super bar with clearer copy, and Spaces added to nav and creation. Also refines calendar rollers and bottom panel chrome for consistency.

- **New Features**
  - Nucleus Overview: BoxSwitcher at top defaults to Dashboard; Graph and Map available; basic sidebar scaffold added.
  - Super bar: widened to 50rem; placeholder updated to “Search anything, run a command or ask Rhombus”; footer shows tips for “>” commands and “`” quick notes; footer label reads “Super bar”.
  - Spaces: browse action added to Nucleus menu; creation flow uses “space” wording with a smaller, vertical modal.

- **Refactors**
  - Layout chrome: TopNav moved to bottom (taller, border‑top); LeftNav resize cursors fixed; resource panel switcher is now fixed at bottom with updated borders and no top indicator.
  - Calendar roller: decade age shown as a year prefix; days 2–9 zero‑padded; better item context handling; default `birthdate` is now undefined.
  - Combination types: added NOTEBOOK and CANVAS; deprecated SIDENAV/WHITEBOARD/MINDMAP/WALL; default create type is NOTEBOOK; labels and placeholders updated (“space”).
  - Product config and labels: Nucleus overview items are now Dashboard/Graph (Map surfaced in the switcher); dev app menu includes Spaces; wording tweaks (Rhombus, Memotron “Note”/“Freehand”); minor TopNav content simplifications.

<sup>Written for commit e63964fe1e42caa58d2f0106574bea7dc4ba5452. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Spaces" navigation item and a new "Map" overview option.

* **UI Updates**
  * Overview panels renamed/reorganized to "Dashboard", "Graph", and "Map".
  * Renamed "Combinations" to "Spaces" and related create modal/title text.
  * Command bar footer renamed to "Super bar"; placeholder/help text updated.
  * Various layout and header/nav styling adjustments across top/left panels.

* **Improvements**
  * Default creation layout set to "Notebook"; selector labels and placeholders updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->