### PR TITLE
test(e2e): expand and harden Memotron overview coverage

### DIFF
--- a/apps/e2e-playwright/README.md
+++ b/apps/e2e-playwright/README.md
@@ -61,6 +61,7 @@ npm run test --workspace=e2e-playwright --
 
 - **Login:** For `cloud` and `cloud-only`, set in `.env`: `E2E_LOGIN_EMAIL` and `E2E_LOGIN_PASSWORD`. Tests can auto-refresh stale auth state when those are present. In CI, set these as secrets.
 - **Base URL:** Set in `.env`: `APP_BASE_URL` (default), or `APP_BASE_URL_NUCLEUM`, `APP_BASE_URL_MEMOTRON`, `APP_BASE_URL_POINTRON` per project (e.g. `https://local.nucleum.app`).
+- **Browser binary:** Tests use the Chrome channel by default. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to run with a specific Chromium-compatible executable in containers or other environments without Google Chrome.
 
 ```bash
 E2E_AUTH_MODE=offline npm run test --workspace=e2e-playwright -- --project pointron tests/focus

--- a/apps/e2e-playwright/global-setup.ts
+++ b/apps/e2e-playwright/global-setup.ts
@@ -178,7 +178,12 @@ async function startVite(app: string): Promise<ViteHarness> {
 
 async function warmUpViteUrl(url: string) {
   const { chromium } = await import("playwright");
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+      : {})
+  });
   try {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const page = await browser.newPage();

--- a/apps/e2e-playwright/playwright.config.ts
+++ b/apps/e2e-playwright/playwright.config.ts
@@ -13,10 +13,18 @@ const defaultBaseURL = process.env.APP_BASE_URL ?? "http://127.0.0.1:4173";
 const authMode = resolveE2EAuthMode();
 const chromeLikeUserAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const configuredExecutablePath =
+  process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
 const chromeLaunchOptions = {
-  args: ["--disable-blink-features=AutomationControlled", "--no-sandbox"]
+  args: ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+  ...(configuredExecutablePath
+    ? { executablePath: configuredExecutablePath }
+    : {})
 };
 const defaultViewport = { width: 1512, height: 982 } as const;
+const browserChannel = configuredExecutablePath
+  ? {}
+  : { channel: "chrome" as const };
 
 function getProjectBaseURL(projectName: string): string {
   if (projectName === Product.NUCLEUM) {
@@ -48,7 +56,7 @@ function getProjectUse(projectName: string) {
     // Local dev uses Caddy `tls internal`; Playwright's bundled Chromium may not honor OS trust store.
     // Keeping this avoids CI/local flakes while still testing app behavior over HTTPS.
     ignoreHTTPSErrors: true,
-    channel: "chrome" as const,
+    ...browserChannel,
     userAgent: chromeLikeUserAgent,
     launchOptions: chromeLaunchOptions,
     baseURL
@@ -98,7 +106,7 @@ export default defineConfig({
     // Local dev uses Caddy `tls internal`; Playwright's bundled Chromium may not honor OS trust store.
     // Keeping this avoids CI/local flakes while still testing app behavior over HTTPS.
     ignoreHTTPSErrors: true,
-    channel: "chrome",
+    ...browserChannel,
     userAgent: chromeLikeUserAgent,
     launchOptions: chromeLaunchOptions
   },

--- a/apps/e2e-playwright/tests/memotron/overview.spec.ts
+++ b/apps/e2e-playwright/tests/memotron/overview.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import { ensureInAppOnHome } from "../utils/helpers";
+
+async function openOverview(page: import("@playwright/test").Page) {
+  await ensureInAppOnHome(page);
+  await page.goto("/overview", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/\/overview(?:\/.*)?$/);
+  await expect(
+    page.getByText("Overview", { exact: true }).first()
+  ).toBeVisible();
+}
+
+async function selectOverviewPanel(
+  page: import("@playwright/test").Page,
+  panel: "Graph" | "Map"
+) {
+  await page.getByText(panel, { exact: true }).first().click();
+}
+
+test.describe("memotron - overview panels", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/*", (route) => {
+      if (/accounts\.google\.com/i.test(route.request().url())) {
+        void route.abort();
+        return;
+      }
+      void route.continue();
+    });
+  });
+
+  test("Graph exposes its empty state and orphan filter", async ({ page }) => {
+    await openOverview(page);
+
+    await expect(
+      page.getByText("Graph", { exact: true }).first()
+    ).toBeVisible();
+    await expect(page.getByText("Map", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("Hide orphans", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Not enough data.", { exact: true })
+    ).toBeVisible();
+  });
+
+  test("Map exposes guidance when captured nodes have no location", async ({
+    page
+  }) => {
+    await openOverview(page);
+    await selectOverviewPanel(page, "Map");
+
+    await expect(
+      page.getByText("No nodes with location data found.", { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Please make sure location permission is enabled while capturing a node.",
+        { exact: true }
+      )
+    ).toBeVisible();
+  });
+
+  test("selected panel persists across an app reload", async ({ page }) => {
+    await openOverview(page);
+    await selectOverviewPanel(page, "Map");
+    await expect(
+      page.getByText("No nodes with location data found.", { exact: true })
+    ).toBeVisible();
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByText("No nodes with location data found.", { exact: true })
+    ).toBeVisible();
+
+    await selectOverviewPanel(page, "Graph");
+    await expect(
+      page.getByText("Not enough data.", { exact: true })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- cover Memotron Overview Graph and Map UI states
- verify the selected overview panel persists across reloads
- allow the Playwright harness and Vite warm-up to use an explicit Chromium executable in container environments
- document the browser executable override

## Verification

- `npx tsc --noEmit -p apps/e2e-playwright/tsconfig.json`
- `npm run test --workspace=e2e-playwright -- --project=memotron tests/memotron/overview.spec.ts --list`
- `git diff --check`

## Live run note

The targeted browser run was attempted against the local Memotron Vite app with system Chromium. Browser startup and global warm-up succeeded after the harness hardening, but the local app rendered a blank shell before the Overview assertions. The test suite's static validation and Playwright discovery pass.




 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/0cd07c2b-2b97-4b45-adec-83384057f99a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=0cd07c2b-2b97-4b45-adec-83384057f99a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-6-astra:medium?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-6-astra:medium?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-6-astra:medium?theme=light&v=12" height="28"></picture></a>&nbsp;&nbsp;<a href="https://linear.app/21n/issue/TIDY-470/playwright-tests-hardening-and-expansion"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/linear?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/linear?theme=light&v=2"><img alt="View on linear" src="https://internal.tembo.io/public/vendor-button/linear?theme=light&v=2" height="28"></picture></a>

## Summary by Sourcery

Expand and harden Memotron Overview end-to-end coverage while improving browser execution support in constrained environments.

New Features:
- Add end-to-end coverage for Memotron Overview Graph and Map states, including panel persistence across reloads.

Enhancements:
- Support configuring a Chromium-compatible executable for Playwright tests and Vite warm-up in containerized environments.

Documentation:
- Document the browser executable override for e2e test environments.

Tests:
- Add Memotron Overview tests covering empty states, map guidance, panel selection, and reload persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright coverage for the Memotron Overview Graph and Map panels and verifies the selected panel persists across reloads. Also hardens the Playwright harness and Vite warm-up so they can use an explicit Chromium executable in container environments via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`, with the override documented in the README.

TIDY-470:
- Covers the Graph empty state and "Hide orphans" filter, plus the Map guidance shown when nodes lack location data.
- Asserts that the selected Overview panel (Graph or Map) is restored after a page reload.
- Keeps the default browser channel as Chrome; the executable override is applied only when the env var is set.

**Bug Fixes**
- Playwright now falls back to a custom Chromium executable instead of failing when Google Chrome is unavailable in the environment.

<sup>Written for commit 421bcff29cba916c0987d59fecad08602afc4c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/21nCo/nucleum/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - End-to-end coverage now verifies the Memotron Overview page, including Graph and Map panels, empty states, guidance, and panel selection after reload.
  - Playwright tests can run with a specified Chromium-compatible executable when Google Chrome is unavailable.

- **Documentation**
  - Added guidance for configuring a custom Chromium executable through the `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->